### PR TITLE
Add id in last position

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/LastPositionEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/LastPositionEntity.kt
@@ -18,7 +18,6 @@ import java.time.ZonedDateTime
 import javax.persistence.*
 
 @Entity
-@IdClass(LastPositionEntity.ReferenceCompositeKey::class)
 @TypeDefs(
         TypeDef(name = "duration",
                 typeClass = PostgreSQLIntervalType::class,
@@ -27,16 +26,17 @@ import javax.persistence.*
         TypeDef(name = "string-array",
                 typeClass = ListArrayType::class)
 )
-@Table(name = "last_positions", uniqueConstraints = [UniqueConstraint(columnNames = ["cfr", "external_immatriculation"])])
+@Table(name = "last_positions")
 data class LastPositionEntity(
         @Id
+        @Column(name = "id")
+        val id: Int,
         @Column(name = "cfr")
         val internalReferenceNumber: String? = null,
         @Column(name = "mmsi")
         val mmsi: String? = null,
         @Column(name = "ircs")
         val ircs: String? = null,
-        @Id
         @Column(name = "external_immatriculation")
         val externalReferenceNumber: String? = null,
         @Column(name = "vessel_name")
@@ -85,8 +85,6 @@ data class LastPositionEntity(
         val speciesOnboard: String? = null,
         @Column(name = "total_weight_onboard")
         val totalWeightOnboard: Double? = null) : Serializable {
-
-    data class ReferenceCompositeKey(val internalReferenceNumber: String? = null, val externalReferenceNumber: String? = null) : Serializable
 
     fun toLastPosition(mapper: ObjectMapper) = LastPosition(
             internalReferenceNumber = internalReferenceNumber,

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/interfaces/DBLastPositionRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/interfaces/DBLastPositionRepository.kt
@@ -6,9 +6,6 @@ import org.springframework.data.repository.CrudRepository
 import java.time.ZonedDateTime
 
 @DynamicUpdate
-interface DBLastPositionRepository : CrudRepository<LastPositionEntity, LastPositionEntity.ReferenceCompositeKey> {
+interface DBLastPositionRepository : CrudRepository<LastPositionEntity, Int> {
     fun findAllByDateTimeGreaterThanEqual(dateTime: ZonedDateTime) : List<LastPositionEntity>
-    fun findByInternalReferenceNumberEquals(internalReferenceNumber: String): LastPositionEntity
-    fun findByExternalReferenceNumberEquals(externalReferenceNumber: String): LastPositionEntity
-    fun findByIrcsEquals(ircs: String): LastPositionEntity
 }

--- a/backend/src/main/resources/db/migration/internal/V0.34__Update_last_position_table.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.34__Update_last_position_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.last_positions
+    ADD COLUMN id integer NOT NULL;

--- a/datascience/src/pipeline/flows/last_positions.py
+++ b/datascience/src/pipeline/flows/last_positions.py
@@ -35,6 +35,8 @@ def merge(last_positions, current_segments):
         ["NaT", np.nan], [None, None]
     )
 
+    last_positions = last_positions.reset_index().rename(columns={"index": "id"})
+
     return last_positions
 
 

--- a/datascience/src/pipeline/queries/monitorfish/last_positions.sql
+++ b/datascience/src/pipeline/queries/monitorfish/last_positions.sql
@@ -13,19 +13,20 @@ WITH last_54_hours_positions AS (
         course,
         date_time,
         ROW_NUMBER() OVER (
-            PARTITION BY internal_reference_number, external_reference_number 
-            ORDER BY id DESC) AS rk
+            PARTITION BY internal_reference_number, external_reference_number, ircs
+            ORDER BY date_time DESC) AS rk
     FROM positions
     WHERE date_time > CURRENT_TIMESTAMP - INTERVAL '2 days 6 hours'
     AND (internal_reference_number IS NOT NULL OR 
-         external_reference_number IS NOT NULL)
+         external_reference_number IS NOT NULL OR
+         ircs IS NOT NULL)
 ),
 
 last_two_positions AS (
     SELECT 
         id,
-        COALESCE(internal_reference_number, '') AS internal_reference_number,
-        COALESCE(external_reference_number, '') AS external_reference_number,
+        internal_reference_number,
+        external_reference_number,
         mmsi,
         ircs,
         vessel_name,
@@ -50,11 +51,13 @@ emission_periods AS (
     SELECT
         internal_reference_number,
         external_reference_number,
+        ircs,
         (MAX(date_time) - MIN(date_time)) / NULLIF(COUNT(id) - 1, 0) AS emission_period
     FROM last_two_positions
     GROUP BY 
         internal_reference_number,
-        external_reference_number
+        external_reference_number,
+        ircs
 ),
 
 vessels_ AS (


### PR DESCRIPTION
* Add ircs as one of the possible identifiers (along with cfr and external immat) when extracting last positions from `positions` table
* Use the newly added `id` field (generated by python flow)  as key in last_positions table