### PR TITLE
Fix track vessel id

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/VesselIdentifier.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/VesselIdentifier.kt
@@ -1,0 +1,8 @@
+package fr.gouv.cnsp.monitorfish.domain.entities
+
+enum class VesselIdentifier {
+    INTERNAL_REFERENCE_NUMBER,
+    IRCS,
+    EXTERNAL_REFERENCE_NUMBER,
+    UNDEFINED
+}

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/last_position/LastPosition.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/last_position/LastPosition.kt
@@ -45,4 +45,5 @@ data class LastPosition(
         val totalWeightOnboard: Double? = null,
         val lastControlDateTime: ZonedDateTime? = null,
         val lastControlInfraction: Boolean? = null,
-        val postControlComment: String? = null)
+        val postControlComment: String? = null,
+        val vesselIdentifier: String? = null)

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/repositories/PositionRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/repositories/PositionRepository.kt
@@ -6,10 +6,19 @@ import java.time.ZonedDateTime
 interface PositionRepository {
     fun findAll(): List<Position>
     fun findAllByMmsi(mmsi: String): List<Position>
-    fun findVesselLastPositions(internalReferenceNumber: String,
-                                externalReferenceNumber: String,
-                                ircs: String,
-                                from: ZonedDateTime,
-                                to: ZonedDateTime): List<Position>
+    fun findVesselLastPositionsByIrcs(ircs: String,
+                                      from: ZonedDateTime,
+                                      to: ZonedDateTime): List<Position>
+    fun findVesselLastPositionsByInternalReferenceNumber(internalReferenceNumber: String,
+                                                         from: ZonedDateTime,
+                                                         to: ZonedDateTime): List<Position>
+    fun findVesselLastPositionsByExternalReferenceNumber(externalReferenceNumber: String,
+                                                         from: ZonedDateTime,
+                                                         to: ZonedDateTime): List<Position>
+    fun findVesselLastPositionsWithoutSpecifiedIdentifier(internalReferenceNumber: String,
+                                                          externalReferenceNumber: String,
+                                                          ircs: String,
+                                                          from: ZonedDateTime,
+                                                          to: ZonedDateTime): List<Position>
     fun save(position: Position)
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/BffController.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/BffController.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api
 
+import fr.gouv.cnsp.monitorfish.domain.entities.VesselIdentifier
 import fr.gouv.cnsp.monitorfish.domain.entities.VesselTrackDepth
 import fr.gouv.cnsp.monitorfish.domain.use_cases.*
 import fr.gouv.cnsp.monitorfish.infrastructure.api.outputs.*
@@ -63,6 +64,9 @@ class BffController(
                   @ApiParam("Vessel track depth")
                   @RequestParam(name = "trackDepth")
                   trackDepth: VesselTrackDepth,
+                  @ApiParam("Vessel positions identifier")
+                  @RequestParam(name = "vesselIdentifier")
+                  vesselIdentifier: VesselIdentifier,
                   @ApiParam("from date")
                   @RequestParam(name = "afterDateTime", required = false)
                   @DateTimeFormat(pattern = zoneDateTimePattern)
@@ -79,6 +83,7 @@ class BffController(
                     externalReferenceNumber,
                     IRCS,
                     trackDepth,
+                    vesselIdentifier,
                     afterDateTime,
                     beforeDateTime)
 

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/ControllersExceptionHandler.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/ControllersExceptionHandler.kt
@@ -3,11 +3,13 @@ package fr.gouv.cnsp.monitorfish.infrastructure.api
 import fr.gouv.cnsp.monitorfish.domain.exceptions.NAFMessageParsingException
 import fr.gouv.cnsp.monitorfish.domain.exceptions.NoERSLastDepartureDateFound
 import fr.gouv.cnsp.monitorfish.infrastructure.api.outputs.ApiError
+import fr.gouv.cnsp.monitorfish.infrastructure.api.outputs.MissingParameterApiError
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.core.Ordered.HIGHEST_PRECEDENCE
 import org.springframework.core.annotation.Order
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -30,4 +32,12 @@ class ControllersExceptionHandler {
         logger.error(e.message, e.cause)
         return ApiError(e)
     }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MissingServletRequestParameterException::class)
+    fun handleNoParameter(e: MissingServletRequestParameterException): MissingParameterApiError {
+        logger.error(e.message, e.cause)
+        return MissingParameterApiError("Parameter \"${e.parameterName}\" is missing.")
+    }
+
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/outputs/LastPositionDataOutput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/outputs/LastPositionDataOutput.kt
@@ -36,7 +36,8 @@ data class LastPositionDataOutput(
         val totalWeightOnboard: Double? = null,
         val lastControlDateTime: ZonedDateTime? = null,
         val lastControlInfraction: Boolean? = null,
-        val postControlComment: String? = null) {
+        val postControlComment: String? = null,
+        val vesselIdentifier: String? = null) {
     companion object {
         fun fromLastPosition(position: LastPosition): LastPositionDataOutput {
             return LastPositionDataOutput(
@@ -69,7 +70,8 @@ data class LastPositionDataOutput(
                     totalWeightOnboard = position.totalWeightOnboard,
                     lastControlDateTime = position.lastControlDateTime,
                     lastControlInfraction = position.lastControlInfraction,
-                    postControlComment = position.postControlComment)
+                    postControlComment = position.postControlComment,
+                    vesselIdentifier = position.vesselIdentifier)
         }
     }
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/outputs/MissingParameterApiError.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/outputs/MissingParameterApiError.kt
@@ -1,0 +1,3 @@
+package fr.gouv.cnsp.monitorfish.infrastructure.api.outputs
+
+data class MissingParameterApiError(val error: String)

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/LastPositionEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/LastPositionEntity.kt
@@ -90,7 +90,9 @@ data class LastPositionEntity(
         @Column(name = "last_control_infraction")
         val lastControlInfraction: Boolean? = null,
         @Column(name = "post_control_comments")
-        val postControlComment: String? = null) : Serializable {
+        val postControlComment: String? = null,
+        @Column(name = "vessel_identifier")
+        val vesselIdentifier: String? = null) : Serializable {
 
     fun toLastPosition(mapper: ObjectMapper) = LastPosition(
             internalReferenceNumber = internalReferenceNumber,
@@ -122,5 +124,6 @@ data class LastPositionEntity(
             totalWeightOnboard = totalWeightOnboard,
             lastControlDateTime = lastControlDateTime,
             lastControlInfraction = lastControlInfraction,
-            postControlComment = postControlComment)
+            postControlComment = postControlComment,
+            vesselIdentifier = vesselIdentifier)
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaVesselRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaVesselRepository.kt
@@ -23,19 +23,19 @@ class JpaVesselRepository(private val dbVesselRepository: DBVesselRepository) : 
             }
         }
 
-        if (externalReferenceNumber.isNotEmpty()) {
-            try {
-                return dbVesselRepository.findByExternalReferenceNumberIgnoreCaseContaining(externalReferenceNumber).toVessel()
-            } catch (e: EmptyResultDataAccessException) {
-                logger.warn("No vessel found for external marking $externalReferenceNumber", e)
-            }
-        }
-
         if (ircs.isNotEmpty()) {
             try {
                 return dbVesselRepository.findByIrcs(ircs).toVessel()
             } catch (e: EmptyResultDataAccessException) {
                 logger.warn("No vessel found for IRCS $externalReferenceNumber", e)
+            }
+        }
+
+        if (externalReferenceNumber.isNotEmpty()) {
+            try {
+                return dbVesselRepository.findByExternalReferenceNumberIgnoreCaseContaining(externalReferenceNumber).toVessel()
+            } catch (e: EmptyResultDataAccessException) {
+                logger.warn("No vessel found for external marking $externalReferenceNumber", e)
             }
         }
 

--- a/backend/src/main/resources/db/migration/internal/V0.38__Update_last_positions_table.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.38__Update_last_positions_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.last_positions
+    ADD COLUMN vessel_identifier VARCHAR(30);

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaLastPositionRepositoryITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaLastPositionRepositoryITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.database.repositories
 
+import fr.gouv.cnsp.monitorfish.domain.entities.VesselIdentifier
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -46,6 +47,7 @@ class JpaLastPositionRepositoryITests : AbstractDBTests() {
         assertThat(position?.lastControlDateTime).isNotNull
         assertThat(position?.lastControlInfraction).isTrue
         assertThat(position?.postControlComment).isEqualTo("Tout va bien")
+        assertThat(position?.vesselIdentifier).isEqualTo(VesselIdentifier.INTERNAL_REFERENCE_NUMBER.toString())
     }
 
 }

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaPositionRepositoryITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaPositionRepositoryITests.kt
@@ -2,7 +2,6 @@ package fr.gouv.cnsp.monitorfish.infrastructure.database.repositories
 
 import fr.gouv.cnsp.monitorfish.domain.entities.Position
 import fr.gouv.cnsp.monitorfish.domain.entities.PositionType
-import fr.gouv.cnsp.monitorfish.domain.entities.VesselTrackDepth
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -66,7 +65,7 @@ class JpaPositionRepositoryITests : AbstractDBTests() {
         jpaPositionRepository.save(secondPosition)
         jpaPositionRepository.save(thirdPosition)
         jpaPositionRepository.save(fourthPosition)
-        val lastPositions = jpaPositionRepository.findVesselLastPositions(
+        val lastPositions = jpaPositionRepository.findVesselLastPositionsWithoutSpecifiedIdentifier(
                 "FR224226850",
                 "",
                 "",
@@ -93,7 +92,7 @@ class JpaPositionRepositoryITests : AbstractDBTests() {
         jpaPositionRepository.save(secondPosition)
         jpaPositionRepository.save(thirdPosition)
         jpaPositionRepository.save(fourthPosition)
-        val lastPositions = jpaPositionRepository.findVesselLastPositions(
+        val lastPositions = jpaPositionRepository.findVesselLastPositionsWithoutSpecifiedIdentifier(
                 "FR224226850",
                 "",
                 "",
@@ -120,7 +119,7 @@ class JpaPositionRepositoryITests : AbstractDBTests() {
         jpaPositionRepository.save(secondPosition)
         jpaPositionRepository.save(thirdPosition)
         jpaPositionRepository.save(fourthPosition)
-        val lastPositions = jpaPositionRepository.findVesselLastPositions(
+        val lastPositions = jpaPositionRepository.findVesselLastPositionsWithoutSpecifiedIdentifier(
                 "",
                 "NOT_NULL",
                 "",
@@ -146,7 +145,7 @@ class JpaPositionRepositoryITests : AbstractDBTests() {
         jpaPositionRepository.save(secondPosition)
         jpaPositionRepository.save(thirdPosition)
         jpaPositionRepository.save(fourthPosition)
-        val lastPositions = jpaPositionRepository.findVesselLastPositions(
+        val lastPositions = jpaPositionRepository.findVesselLastPositionsWithoutSpecifiedIdentifier(
                 "",
                 "",
                 "NOT_NULL",

--- a/datascience/src/pipeline/flows/last_positions.py
+++ b/datascience/src/pipeline/flows/last_positions.py
@@ -40,9 +40,9 @@ def merge(last_positions, current_segments, last_controls):
     last_positions = pd.merge(last_positions, current_segments, on="cfr", how="left")
 
     vessel_identifier_labels = {
-        "cfr": "internalReferenceNumber",
-        "ircs": "ircs",
-        "external_immatriculation": "externalReferenceNumber",
+        "cfr": "INTERNAL_REFERENCE_NUMBER",
+        "ircs": "IRCS",
+        "external_immatriculation": "EXTERNAL_REFERENCE_NUMBER",
     }
 
     last_positions["vessel_identifier"] = get_first_non_null_column_name(

--- a/datascience/src/pipeline/processing.py
+++ b/datascience/src/pipeline/processing.py
@@ -94,6 +94,39 @@ def combine_overlapping_columns(df: pd.DataFrame, ordered_cols_list: List) -> pd
     return res
 
 
+def get_first_non_null_column_name(
+    df: pd.DataFrame, result_labels: Union[None, dict] = None
+) -> pd.Series:
+    """Returns a Series with the same index as the input DataFrame, whose values are
+    the name of the first column (or the corresponding label, if provided) with a
+    non-null value in each row, from left to right.
+
+    Rows with all null values return None.
+
+    Args:
+        df (pd.DataFrame): input pandas DataFrame
+        result_labels (dict): if provided, must be a mapping of column names to the
+        corresponding labels in the result.
+
+    Returns:
+        pd.Series: Series containing the name of the first column with a non-null value
+        in each row of the DataFrame, from left to right
+    """
+
+    non_null_rows = df.dropna(how="all")
+    first_non_null_values_idx = np.argmax(non_null_rows.notnull().values, axis=1)
+
+    res_values = np.choose(first_non_null_values_idx, list(df))
+
+    res = pd.Series(index=df.index, data=[None] * len(df))
+    res[non_null_rows.index] = res_values
+
+    if result_labels is not None:
+        res = res.map(lambda s: result_labels.get(s))
+
+    return res
+
+
 def df_to_dict_series(df: pd.DataFrame, result_colname: str = "json_col"):
     """Converts a pandas DataFrame into a Series with the same index as the input
     DataFrame and whose values are dictionnaries like :

--- a/datascience/src/pipeline/queries/monitorfish/last_positions.sql
+++ b/datascience/src/pipeline/queries/monitorfish/last_positions.sql
@@ -85,4 +85,4 @@ ON (
     AND pos.external_reference_number = per.external_reference_number)
 LEFT JOIN vessels
 ON pos.internal_reference_number = vessels.cfr
-WHERE pos.flag_state != 'GBR' OR pos.latitude < 46.2294 OR pos.latitude > 46.2305 
+WHERE pos.flag_state != 'GB' OR pos.latitude < 46.2294 OR pos.latitude > 46.2305 

--- a/datascience/src/pipeline/queries/ocan/flotteurs.sql
+++ b/datascience/src/pipeline/queries/ocan/flotteurs.sql
@@ -14,6 +14,7 @@ LEFT JOIN COMMUN.C_CODE_PAYS cp
 ON f.idc_pays_flotteur = cp.idc_pays
 LEFT JOIN COMMUN.C_CODE_QUARTIER cq
 ON f.idc_quartier_immat = cq.idc_quartier
-WHERE f.indicatif_radio IS NOT NULL
-OR f.num_cfr IS NOT NULL
-OR f.num_immat_etranger IS NOT NULL
+WHERE f.idc_situation IN (2, 4, 5, 7, 9, 10)
+AND (f.indicatif_radio IS NOT NULL
+    OR f.num_cfr IS NOT NULL
+    OR f.num_immat_etranger IS NOT NULL)

--- a/frontend/src/api/fetch.js
+++ b/frontend/src/api/fetch.js
@@ -58,11 +58,12 @@ export function getVesselFromAPI (identity, vesselTrackDepthObject) {
   const internalReferenceNumber = identity.internalReferenceNumber || ''
   const externalReferenceNumber = identity.externalReferenceNumber || ''
   const ircs = identity.ircs || ''
+  const vesselIdentifier = identity.vesselIdentifier || 'UNDEFINED'
   const trackDepth = vesselTrackDepthObject.trackDepth ? vesselTrackDepthObject.trackDepth : ''
   const afterDateTime = vesselTrackDepthObject.afterDateTime ? vesselTrackDepthObject.afterDateTime.toISOString() : ''
   const beforeDateTime = vesselTrackDepthObject.beforeDateTime ? vesselTrackDepthObject.beforeDateTime.toISOString() : ''
 
-  return fetch(`/bff/v1/vessels/find?internalReferenceNumber=${internalReferenceNumber}&externalReferenceNumber=${externalReferenceNumber}&IRCS=${ircs}&trackDepth=${trackDepth}&afterDateTime=${afterDateTime}&beforeDateTime=${beforeDateTime}`)
+  return fetch(`/bff/v1/vessels/find?internalReferenceNumber=${internalReferenceNumber}&externalReferenceNumber=${externalReferenceNumber}&IRCS=${ircs}&vesselIdentifier=${vesselIdentifier}&trackDepth=${trackDepth}&afterDateTime=${afterDateTime}&beforeDateTime=${beforeDateTime}`)
     .then(response => {
       if (response.status === OK) {
         return response.json().then(vessel => {

--- a/frontend/src/domain/entities/vessel.js
+++ b/frontend/src/domain/entities/vessel.js
@@ -58,8 +58,8 @@ export class Vessel {
       totalWeightOnboard: vessel.totalWeightOnboard,
       lastControlDateTime: vessel.lastControlDateTime,
       lastControlInfraction: vessel.lastControlInfraction,
-      postControlComment: vessel.postControlComment
-
+      postControlComment: vessel.postControlComment,
+      vesselIdentifier: vessel.vesselIdentifier
     })
 
     this.feature.setId(`${Layers.VESSELS.code}:${options.id}`)
@@ -255,7 +255,8 @@ export const getVesselIdentityFromFeature = feature => {
     vesselName: feature.getProperties().vesselName,
     flagState: feature.getProperties().flagState,
     mmsi: feature.getProperties().mmsi,
-    ircs: feature.getProperties().ircs
+    ircs: feature.getProperties().ircs,
+    vesselIdentifier: feature.getProperties().vesselIdentifier
   }
 }
 
@@ -266,7 +267,8 @@ export const getVesselIdentityFromVessel = vessel => {
     vesselName: vessel.vesselName,
     flagState: vessel.flagState,
     mmsi: vessel.mmsi,
-    ircs: vessel.ircs
+    ircs: vessel.ircs,
+    vesselIdentifier: vessel.vesselIdentifier
   }
 }
 


### PR DESCRIPTION
* Add `vessel_identifier` column to `last_positions` table in last_positions flow to indicate which identifier to use for track retrieval
* Fix flag_state filter on GB vessels with incorrect VMS positions
* Filter non professional vessels in navpro extract