### PR TITLE
Add automatic app updater script

### DIFF
--- a/infra/remote/README.md
+++ b/infra/remote/README.md
@@ -1,0 +1,13 @@
+## Environment variables 
+
+The env variables are set in the file `$HOME/.monitorfish`.
+
+i.e for the integration environment:
+```
+export MONITORFISH_VERSION="v1.0.3"
+export MONITORFISH_LOGS_GID="1004"
+export MONITORFISH_LOGS_FOLDER="/opt/monitorfish"
+export MONITORFISH_GIT_FOLDER="/home/mf/monitorfish
+```
+
+> Be sure to add in the `$HOME/.bashrc` or `$HOME/.bash_profile`: `source $HOME/.monitorfish` to add the variables to the shell

--- a/infra/remote/update_app_image/README.md
+++ b/infra/remote/update_app_image/README.md
@@ -1,0 +1,29 @@
+# Update app image
+
+A bash script checks for new bugfixes images (i.e v1.0.X) every minutes.
+The script will run only if the `cron.lock` file contain "End of update".
+
+> The following environment variables need to be set:
+>```
+> export MONITORFISH_VERSION="vX.X.X" # To be changed
+> export MONITORFISH_LOGS_FOLDER="/opt/monitorfish" # To be changed
+> export MONITORFISH_GIT_FOLDER="/home/mf/monitorfish # To be changed
+> ```
+
+To install it:
+- Make the `update_app_image.sh` script executable: 
+```
+chmod +x $MONITORFISH_GIT_FOLDER/infra/remote/update_app_image/update_app_image.sh
+```
+- Create the `$MONITORFISH_LOGS_FOLDER/cron.log` file with:
+```
+touch $MONITORFISH_LOGS_FOLDER/cron.log
+```
+- Create the `$MONITORFISH_LOGS_FOLDER/cron.lock` file with:
+```
+echo "End of update" > $MONITORFISH_LOGS_FOLDER/cron.lock
+```
+- Finally, add this line to the crontab file (with `crontab -e`):
+```
+* * * * * bash -l -c 'source $HOME/.monitorfish; $MONITORFISH_GIT_FOLDER/infra/remote/update_app_image/update_app_image.sh > $MONITORFISH_LOGS_FOLDER/cron.log 2>&1'
+```

--- a/infra/remote/update_app_image/update_app_image.sh
+++ b/infra/remote/update_app_image/update_app_image.sh
@@ -27,6 +27,7 @@ else
     echo "MONITORFISH_VERSION=$MONITORFISH_VERSION"
 fi
 
+
 echo "" > $MONITORFISH_LOGS_FOLDER/cron.lock
 
 # Increment bugfixes version number
@@ -49,10 +50,11 @@ if [ $exit_code -ne 0 ]; then
     exit 0
 fi
 
-export MONITORFISH_VERSION=$MONITORFISH_VERSION_INCREMENT
-
 echo "Restarting app with version: $MONITORFISH_VERSION_INCREMENT"
 
 cd $MONITORFISH_GIT_FOLDER && make restart-remote-app-dev
+
+echo "Replacing current app version ($MONITORFISH_VERSION) to $MONITORFISH_VERSION_INCREMENT in $HOME/.monitorfish"
+sed -i "s/$MONITORFISH_VERSION/$MONITORFISH_VERSION_INCREMENT/" $HOME/.monitorfish
 
 echo $exit_message > $MONITORFISH_LOGS_FOLDER/cron.lock

--- a/infra/remote/update_app_image/update_app_image.sh
+++ b/infra/remote/update_app_image/update_app_image.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -e
+
+source $HOME/.monitorfish
+
+echo `date`
+echo "Checking if the update process is already running..."
+exit_code=0
+/bin/grep -Fxq "End of update" $MONITORFISH_LOGS_FOLDER/cron.lock || exit_code=$?
+
+# Check if script is already running
+if [ $exit_code -ne 0 ]; then
+    echo "Update already in progress."
+    exit 0
+fi
+
+echo "OK. No update in progress."
+exit_message="End of update"
+
+if test -z "$MONITORFISH_VERSION"
+then
+    echo "MONITORFISH_VERSION env variable is not set"
+    echo $exit_message > $MONITORFISH_LOGS_FOLDER/cron.lock
+    exit 1
+else
+    echo "MONITORFISH_VERSION=$MONITORFISH_VERSION"
+fi
+
+echo "" > $MONITORFISH_LOGS_FOLDER/cron.lock
+
+# Increment bugfixes version number
+if [[ $MONITORFISH_VERSION =~ (v[0-9]+\.[0-9]+\.)([0-9]+)$ ]]; then
+    prefix=${BASH_REMATCH[1]}
+    number=$(( 10#${BASH_REMATCH[2]} + 1 ))
+    new=${prefix}${number}
+    MONITORFISH_VERSION_INCREMENT=$new
+fi
+
+echo "Trying to fetch version: $MONITORFISH_VERSION_INCREMENT"
+
+# Pull new docker image
+exit_code=0
+docker pull ghcr.io/mtes-mct/monitorfish/monitorfish-app:$MONITORFISH_VERSION_INCREMENT || exit_code=$?
+
+# Check if image exists
+if [ $exit_code -ne 0 ]; then
+    echo $exit_message > $MONITORFISH_LOGS_FOLDER/cron.lock
+    exit 0
+fi
+
+export MONITORFISH_VERSION=$MONITORFISH_VERSION_INCREMENT
+
+echo "Restarting app with version: $MONITORFISH_VERSION_INCREMENT"
+
+cd $MONITORFISH_GIT_FOLDER && make restart-remote-app-dev
+
+echo $exit_message > $MONITORFISH_LOGS_FOLDER/cron.lock


### PR DESCRIPTION
Ajoute un script cron de MAJ de l'application (seulement l'app, pas prefect) pour faire des bugfixes en PROD en crééant une nouvelle image qui incrémente le numéro de patch de la version.
Par exemple, de `v1.0.2` à v1.0.3