### PR TITLE
Migrations for controls stats

### DIFF
--- a/backend/src/main/resources/db/migration/internal/V0.59__Update_ports_table.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.59__Update_ports_table.sql
@@ -1,0 +1,4 @@
+ALTER TABLE public.ports
+    DROP COLUMN stationary_vessels_h3_res9,
+    ADD COLUMN facade VARCHAR(100),
+    ADD COLUMN fao_areas VARCHAR(100)[];

--- a/backend/src/main/resources/db/migration/internal/V0.60__Update_controls_table.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.60__Update_controls_table.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.controls
+    DROP COLUMN fao_area,
+    ADD COLUMN fao_areas VARCHAR(100)[];

--- a/backend/src/main/resources/db/migration/layers/V0.58__Create_facade_areas_table.sql
+++ b/backend/src/main/resources/db/migration/layers/V0.58__Create_facade_areas_table.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS public.facade_areas;
+
+CREATE TABLE public.facade_areas
+(
+    facade text,
+    geometry public.geometry(MultiPolygon,4326)
+);
+
+CREATE INDEX facade_areas_geometry_geom_idx ON public.facade_areas USING gist (geometry);


### PR DESCRIPTION
Add FAO areas and façade to `ports` and `controls` tables.