### PR TITLE
Remove OL layers objects from redux

### DIFF
--- a/frontend/src/domain/entities/layers.js
+++ b/frontend/src/domain/entities/layers.js
@@ -1,3 +1,15 @@
+/**
+ *
+ * @param {Object} layer
+ * @param { String } layer.type
+ * @param { String } layer.topic
+ * @param { String } layer.zone
+ * @returns String
+ */
+export const getLayerNameNormalized = (layer) => {
+  return [layer.type, layer.topic, layer.zone].filter(Boolean).join(':')
+}
+
 export const layersGroups = {
   TWELVE_FORTY_ONE: {
     code: 'twelve_forty_one',

--- a/frontend/src/domain/shared_slices/Layer.js
+++ b/frontend/src/domain/shared_slices/Layer.js
@@ -49,13 +49,19 @@ const reducers = {
       zone,
       namespace
     } = action.payload
+
     if (type !== Layers.VESSELS.code) {
-      const SeachedLayerName = getLayerNameNormalized({ type, topic, zone })
+      const searchedLayerName = getLayerNameNormalized({ type, topic, zone })
       const found = !!state.showedLayers
-        .find(layer => getLayerNameNormalized(layer) === SeachedLayerName)
+        .find(layer => getLayerNameNormalized(layer) === searchedLayerName)
 
       if (!found) {
-        state.showedLayers = state.showedLayers.concat(action.payload)
+        state.showedLayers = state.showedLayers.concat({
+          type,
+          topic,
+          zone,
+          namespace
+        })
         window.localStorage.setItem(`${namespace}${layersShowedOnMapLocalStorageKey}`, JSON.stringify(state.showedLayers))
       }
     }
@@ -81,16 +87,16 @@ const reducers = {
       if (zone && topic) {
         state.showedLayers = state.showedLayers
           .filter(layer => !(layer.topic === topic && layer.zone === zone))
-          // LayerName is not used anymore, but may be still store in LocalStorage
+          // LayerName is not used anymore, but may be still stored in LocalStorage (see l. 17)
           .filter(layer => !(layer.layerName === topic && layer.zone === zone))
       } else if (topic) {
         state.showedLayers = state.showedLayers
           .filter(layer => !(layer.topic === topic))
-          // LayerName is not used anymore, but may be still store in LocalStorage
+          // LayerName is not used anymore, but may be still stored in LocalStorage (see l. 17)
           .filter(layer => !(layer.layerName === topic))
       }
     } else {
-      state.showedLayers = state.showedLayers.filter(layer => layer.type !== type)
+      state.showedLayers = state.showedLayers.filter(layer => !(layer.type === type && layer.zone === zone))
     }
     window.localStorage.setItem(`${namespace}${layersShowedOnMapLocalStorageKey}`, JSON.stringify(state.showedLayers))
   },

--- a/frontend/src/domain/shared_slices/Layer.js
+++ b/frontend/src/domain/shared_slices/Layer.js
@@ -1,12 +1,10 @@
-import Layers from '../entities/layers'
+import Layers, { getLayerNameNormalized } from '../entities/layers'
 import { createGenericSlice, getLocalStorageState } from '../../utils'
 
 const layersShowedOnMapLocalStorageKey = 'layersShowedOnMap'
 
 const initialState = {
-  layers: [],
   lastShowedFeatures: [],
-  layersAndAreas: [],
   layersToFeatures: [],
   administrativeZonesGeometryCache: [],
   layersSidebarOpenedLayer: ''
@@ -40,39 +38,6 @@ const reducers = {
     state.administrativeZonesGeometryCache = state.administrativeZonesGeometryCache.concat(action.payload)
   },
   /**
-   * Add a new layer
-   * @param {Object=} state
-   * @param {{payload: any | null}} action - The OpenLayers VectorLayer object to add
-   */
-  addLayer (state, action) {
-    state.layers = state.layers.concat(action.payload)
-  },
-  /**
-   * Remove a layer
-   * @param {Object=} state
-   * @param {{payload: any | null}} action - The OpenLayers VectorLayer object to remove
-   */
-  removeLayer (state, action) {
-    state.layers = state.layers.filter(layer => layer.name !== action.payload.name)
-  },
-  /**
-   * Remove layers
-   * @param {Object=} state
-   * @param {{payload: any[] | null}} action - The OpenLayers VectorLayer objects to remove
-   */
-  removeLayers (state, action) {
-    state.layers = state.layers.filter(layer => !action.payload
-      .some(layerToRemove => layerToRemove.name === layer.name))
-  },
-  /**
-   * Set initial layers
-   * @param {Object=} state
-   * @param {{payload: any[] | null}} action - The OpenLayers VectorLayer objects
-   */
-  setLayers (state, action) {
-    state.layers = action.payload
-  },
-  /**
    * Show a Regulatory or Administrative layer
    * @param {Object=} state
    * @param {{payload: AdministrativeOrRegulatoryLayer | null}} action - The layer to show
@@ -85,23 +50,9 @@ const reducers = {
       namespace
     } = action.payload
     if (type !== Layers.VESSELS.code) {
-      let found = false
-      if (type === Layers.REGULATORY.code) {
-        found = state.showedLayers
-          .filter(layer => layer.type === Layers.REGULATORY.code)
-          .some(layer => (
-            layer.topic === topic &&
-            layer.zone === zone
-          ))
-      } else if (zone) {
-        found = state.showedLayers
-          .some(layer => (
-            layer.type === type &&
-            layer.layer === zone
-          ))
-      } else {
-        found = state.showedLayers.some(layer => layer.type === type)
-      }
+      const SeachedLayerName = getLayerNameNormalized({ type, topic, zone })
+      const found = !!state.showedLayers
+        .find(layer => getLayerNameNormalized(layer) === SeachedLayerName)
 
       if (!found) {
         state.showedLayers = state.showedLayers.concat(action.payload)
@@ -142,27 +93,6 @@ const reducers = {
       state.showedLayers = state.showedLayers.filter(layer => layer.type !== type)
     }
     window.localStorage.setItem(`${namespace}${layersShowedOnMapLocalStorageKey}`, JSON.stringify(state.showedLayers))
-  },
-  /**
-   * Add a new layer with an area to show layers in a sort order (the biggest are under the smallest)
-   * @param {Object=} state
-   * @param {{payload: LayerAndArea | null}} action - The layer and area
-   */
-  pushLayerAndArea (state, action) {
-    state.layersAndAreas = state.layersAndAreas.filter(layerAndArea => {
-      return layerAndArea.name !== action.payload.name
-    })
-    state.layersAndAreas = state.layersAndAreas.concat(action.payload)
-  },
-  /**
-   * Remove a layer with an area
-   * @param {Object=} state
-   * @param {{payload: LayerAndArea | null}} action - The layer and area
-   */
-  removeLayerAndArea (state, action) {
-    state.layersAndAreas = state.layersAndAreas.filter(layerAndArea => {
-      return layerAndArea.name !== action.payload
-    })
   },
   /**
    * Store layer to feature and simplified feature - To show simplified features if the zoom is low

--- a/frontend/src/domain/types/layer.js
+++ b/frontend/src/domain/types/layer.js
@@ -2,7 +2,7 @@
  * @typedef AdministrativeOrRegulatoryLayer
  * @property {string} type
  * @property {string | null} topic
- * @property {RegulatoryZone | null} zone
+ * @property {string | null} zone
  * @property {string} namespace
  */
 

--- a/frontend/src/domain/use_cases/hideLayer.js
+++ b/frontend/src/domain/use_cases/hideLayer.js
@@ -21,10 +21,10 @@ const hideLayer = layerToHide => (dispatch, getState) => {
 
   const { showedLayers } = getState().layer
   if (type && showedLayers) {
-    const layername = getLayerNameNormalized({ type, topic, zone })
+    const layerName = getLayerNameNormalized({ type, topic, zone })
 
     const layersToRemove = showedLayers.filter(layer_ => {
-      return getLayerNameNormalized(layer_) === layername
+      return getLayerNameNormalized(layer_) === layerName
     })
 
     if (layersToRemove) {

--- a/frontend/src/domain/use_cases/hideLayer.js
+++ b/frontend/src/domain/use_cases/hideLayer.js
@@ -1,5 +1,6 @@
 import layer from '../shared_slices/Layer'
 import { batch } from 'react-redux'
+import { getLayerNameNormalized } from '../entities/layers'
 
 /**
  * hide a Regulatory or Administrative layer
@@ -14,23 +15,22 @@ const hideLayer = layerToHide => (dispatch, getState) => {
   } = layerToHide
 
   const {
-    removeLayerAndArea,
     removeShowedLayer,
     removeLayerToFeatures
   } = layer[namespace].actions
 
   const { showedLayers } = getState().layer
   if (type && showedLayers) {
-    const layername = [type, topic, zone].filter(Boolean).join(':')
+    const layername = getLayerNameNormalized({ type, topic, zone })
+
     const layersToRemove = showedLayers.filter(layer_ => {
-      return [layer_.type, layer_.topic, layer_.zone].filter(Boolean).join(':') === layername
+      return getLayerNameNormalized(layer_) === layername
     })
 
     if (layersToRemove) {
       batch(() => {
         dispatch(removeShowedLayer(layerToHide))
         layersToRemove.forEach(layer => {
-          dispatch(removeLayerAndArea(layer.type))
           dispatch(removeLayerToFeatures(layer.type))
         })
       })

--- a/frontend/src/domain/use_cases/hideLayer.js
+++ b/frontend/src/domain/use_cases/hideLayer.js
@@ -14,46 +14,24 @@ const hideLayer = layerToHide => (dispatch, getState) => {
   } = layerToHide
 
   const {
-    removeLayer,
     removeLayerAndArea,
-    removeLayers,
     removeShowedLayer,
     removeLayerToFeatures
   } = layer[namespace].actions
 
-  if (type) {
-    let layerToRemove, layersToRemove
+  const { showedLayers } = getState().layer
+  if (type && showedLayers) {
+    const layername = [type, topic, zone].filter(Boolean).join(':')
+    const layersToRemove = showedLayers.filter(layer_ => {
+      return [layer_.type, layer_.topic, layer_.zone].filter(Boolean).join(':') === layername
+    })
 
-    if (topic && zone) {
-      layerToRemove = getState().layer.layers.find(layer => {
-        return layer.name === `${type}:${topic}:${zone}`
-      })
-    } else if (topic) {
-      layersToRemove = getState().layer.layers.filter(layer => {
-        return layer.name.includes(`${type}:${topic}`)
-      })
-    } else if (zone) {
-      layersToRemove = getState().layer.layers.filter(layer => {
-        return layer.name.includes(`${type}:${zone}`)
-      })
-    } else {
-      layerToRemove = getState().layer.layers.find(layer => layer.name === type)
-    }
-
-    if (layerToRemove) {
+    if (layersToRemove) {
       batch(() => {
-        dispatch(removeLayer(layerToRemove))
-        dispatch(removeShowedLayer(layerToHide))
-        dispatch(removeLayerAndArea(layerToRemove.name))
-        dispatch(removeLayerToFeatures(layerToRemove.name))
-      })
-    } else if (layersToRemove) {
-      batch(() => {
-        dispatch(removeLayers(layersToRemove))
         dispatch(removeShowedLayer(layerToHide))
         layersToRemove.forEach(layer => {
-          dispatch(removeLayerAndArea(layer.name))
-          dispatch(removeLayerToFeatures(layer.name))
+          dispatch(removeLayerAndArea(layer.type))
+          dispatch(removeLayerToFeatures(layer.type))
         })
       })
     }

--- a/frontend/src/domain/use_cases/showAdministrativeLayer.js
+++ b/frontend/src/domain/use_cases/showAdministrativeLayer.js
@@ -28,24 +28,21 @@ const setIrretrievableFeaturesEvent = error => {
 const showAdministrativeLayer = layerToShow => (dispatch, getState) => {
   currentNamespace = layerToShow.namespace
   const {
-    addLayer,
     addShowedLayer
   } = layer[currentNamespace].actions
 
   batch(() => {
-    dispatch(addLayer(getVectorLayer(layerToShow.type, layerToShow.zone, getState().global.inBackofficeMode)))
     dispatch(addShowedLayer(layerToShow))
   })
 }
 
-const getVectorLayer = (type, zone, inBackofficeMode) => {
+export const getVectorLayer = (type, zone, inBackofficeMode) => {
   let name
   if (zone) {
     name = `${type}:${zone}`
   } else {
     name = type
   }
-
   const layer = new VectorImageLayer({
     source: getAdministrativeVectorSource(type, zone, inBackofficeMode),
     className: 'administrative',

--- a/frontend/src/domain/use_cases/showAdministrativeLayer.js
+++ b/frontend/src/domain/use_cases/showAdministrativeLayer.js
@@ -26,7 +26,7 @@ const setIrretrievableFeaturesEvent = error => {
  * @param {string} layerToShow.zone
  * @returns
  */
-const showAdministrativeLayer = layerToShow => (dispatch, getState) => {
+const showAdministrativeLayer = layerToShow => dispatch => {
   currentNamespace = layerToShow.namespace
   const {
     addShowedLayer

--- a/frontend/src/domain/use_cases/showAdministrativeLayer.js
+++ b/frontend/src/domain/use_cases/showAdministrativeLayer.js
@@ -1,12 +1,13 @@
-import layer from '../shared_slices/Layer'
-import { getAdministrativeAndRegulatoryLayersStyle } from '../../layers/styles/administrativeAndRegulatoryLayers.style'
+import { batch } from 'react-redux'
 import VectorSource from 'ol/source/Vector'
 import GeoJSON from 'ol/format/GeoJSON'
-import { OPENLAYERS_PROJECTION, WSG84_PROJECTION } from '../entities/map'
-import { all, bbox as bboxStrategy } from 'ol/loadingstrategy'
-import { getAdministrativeZoneFromAPI } from '../../api/fetch'
-import { batch } from 'react-redux'
 import VectorImageLayer from 'ol/layer/VectorImage'
+import { all, bbox as bboxStrategy } from 'ol/loadingstrategy'
+
+import layer from '../shared_slices/Layer'
+import { getAdministrativeZoneFromAPI } from '../../api/fetch'
+import { getAdministrativeAndRegulatoryLayersStyle } from '../../layers/styles/administrativeAndRegulatoryLayers.style'
+import { OPENLAYERS_PROJECTION, WSG84_PROJECTION } from '../entities/map'
 
 const IRRETRIEVABLE_FEATURES_EVENT = 'IRRETRIEVABLE_FEATURES'
 

--- a/frontend/src/domain/use_cases/showAdministrativeLayer.js
+++ b/frontend/src/domain/use_cases/showAdministrativeLayer.js
@@ -18,7 +18,13 @@ const setIrretrievableFeaturesEvent = error => {
     error: error
   }
 }
-
+/**
+ *
+ * @param {Object} layerToShow
+ * @param {string} layerToShow.type
+ * @param {string} layerToShow.zone
+ * @returns
+ */
 const showAdministrativeLayer = layerToShow => (dispatch, getState) => {
   currentNamespace = layerToShow.namespace
   const {

--- a/frontend/src/domain/use_cases/showRegulationToEdit.js
+++ b/frontend/src/domain/use_cases/showRegulationToEdit.js
@@ -37,7 +37,7 @@ const showRegulationToEdit = regulatoryZone => async (dispatch, getState) => {
       if (!regulatoryZoneMetadata.id) {
         regulatoryZoneMetadata.id = feature.id.split('.')[1]
       }
-      console.log(regulatoryZoneMetadata)
+
       dispatch(setRegulatoryZoneMetadata(regulatoryZoneMetadata))
     }).catch(error => {
       console.error(error)

--- a/frontend/src/domain/use_cases/showRegulatoryLayer.js
+++ b/frontend/src/domain/use_cases/showRegulatoryLayer.js
@@ -29,7 +29,7 @@ const setIrretrievableFeaturesEvent = error => {
  * Show a Regulatory or Administrative layer
  * @param layerToShow {AdministrativeOrRegulatoryLayer} - The layer to show
  */
-const showRegulatoryLayer = layerToShow => (dispatch) => {
+const showRegulatoryLayer = layerToShow => dispatch => {
   currentNamespace = layerToShow.namespace
   const {
     addShowedLayer
@@ -48,7 +48,6 @@ export const getVectorLayer = (dispatch, getState) => (layerToShow) => {
   const { gears } = getState().gear
   const gearCategory = getGearCategory(layerToShow.gears, gears)
   const hash = getHash(`${layerToShow.topic}:${layerToShow.zone}`)
-  // TODO: switch to LayersType.REGULATORY ?
   const name = `${Layers.REGULATORY.code}:${layerToShow.topic}:${layerToShow.zone}`
 
   const layer = new VectorImageLayer({
@@ -64,7 +63,6 @@ export const getVectorLayer = (dispatch, getState) => (layerToShow) => {
 }
 
 const getRegulatoryVectorSource = (dispatch, getState) => regulatoryZoneProperties => {
-  // TODO: switch to LayersType.REGULATORY ?
   const zoneName = `${Layers.REGULATORY.code}:${regulatoryZoneProperties.topic}:${regulatoryZoneProperties.zone}`
 
   const {
@@ -84,7 +82,7 @@ const getRegulatoryVectorSource = (dispatch, getState) => regulatoryZoneProperti
         const features = getState().regulatory.simplifiedGeometries ? simplifiedRegulatoryZone : regulatoryZone
         vectorSource.addFeatures(vectorSource.getFormat().readFeatures(features))
         const center = getCenter(vectorSource.getExtent())
-        const centerHasValidCoordinates = center && center.length && !Number.isNaN(center[0]) && !Number.isNaN(center[1])
+        const centerHasValidCoordinates = center?.length && !Number.isNaN(center[0]) && !Number.isNaN(center[1])
         batch(() => {
           dispatch(pushLayerToFeatures({
             name: zoneName,

--- a/frontend/src/features/backoffice/LawType.js
+++ b/frontend/src/features/backoffice/LawType.js
@@ -68,7 +68,7 @@ const LawType = props => {
   return (<LawTypeContainer data-cy='law-type'>
     <LawTypeName onClick={openLawTypeList}>
       <LawTypeText>{lawType}</LawTypeText>
-      <ChevronIcon isOpen={isOpen}/>
+      <ChevronIcon $isOpen={isOpen}/>
     </LawTypeName>
     {isOpen && <RegulatoryZoneLayerList isOpen={isOpen}>
       {displayRegulatoryTopics(regZoneByLawType[lawType])}
@@ -122,7 +122,7 @@ const RegulatoryZoneLayerList = styled.ul`
 `
 
 const ChevronIcon = styled(ChevronIconSVG)`
-  transform: ${props => props.isOpen ? 'rotate(0deg)' : 'rotate(180deg)'};
+  transform: ${props => props.$isOpen ? 'rotate(0deg)' : 'rotate(180deg)'};
   width: 17px;
   float: right;
   margin-right: 10px;

--- a/frontend/src/features/commonComponents/MapPropertyTrigger.js
+++ b/frontend/src/features/commonComponents/MapPropertyTrigger.js
@@ -26,8 +26,6 @@ const MapPropertyTrigger = ({ booleanProperty, updateBooleanProperty, text, Icon
           transition: 'all 0.2s',
           cursor: 'pointer'
         }}
-        isSelected={value}
-        onClick={update}
       />
       <ShowLabelText
         data-cy={'map-property-trigger'}

--- a/frontend/src/features/commonStyles/icons/ChevronIcon.style.js
+++ b/frontend/src/features/commonStyles/icons/ChevronIcon.style.js
@@ -6,7 +6,7 @@ export const ChevronIcon = styled(ChevronIconSVG)`
   float: right;
   margin-right: 10px;
   margin-top: 9px;
-  transform: ${props => !props.isOpen ? 'rotate(180deg)' : 'rotate(0deg)'};
+  transform: ${props => !props.$isOpen ? 'rotate(180deg)' : 'rotate(0deg)'};
   transition: all 0.5s
   cursor: pointer;
 `

--- a/frontend/src/features/interest_points/InterestPoint.js
+++ b/frontend/src/features/interest_points/InterestPoint.js
@@ -79,7 +79,7 @@ const InterestPoint = () => {
         onMouseEnter={() => dispatch(expandRightMenu())}
         title={'Créer un point d\'intérêt'}
         onClick={openOrCloseInterestPoint}>
-        <InterestPointIcon rightMenuIsOpen={rightMenuIsOpen} selectedVessel={selectedVessel}/>
+        <InterestPointIcon $rightMenuIsOpen={rightMenuIsOpen} $selectedVessel={selectedVessel}/>
       </InterestPointWrapper>
       <SaveInterestPoint
         healthcheckTextWarning={healthcheckTextWarning}
@@ -118,7 +118,7 @@ const InterestPointWrapper = styled(MapButtonStyle)`
 
 const InterestPointIcon = styled(InterestPointSVG)`
   width: 40px;
-  opacity: ${props => props.selectedVessel && !props.rightMenuIsOpen ? '0' : '1'};
+  opacity: ${props => props.$selectedVessel && !props.$rightMenuIsOpen ? '0' : '1'};
   transition: all 0.2s;
 `
 

--- a/frontend/src/features/layers/administrative/AdministrativeLayerGroup.js
+++ b/frontend/src/features/layers/administrative/AdministrativeLayerGroup.js
@@ -22,7 +22,7 @@ const AdministrativeLayerGroup = props => {
               {props.layers[0].group.name.replace(/[_]/g, ' ')}
             </Text>
             <Chevron
-              isOpen={isOpen}
+              $isOpen={isOpen}
               onClick={() => setIsOpen(!isOpen)}
             />
           </Zone>

--- a/frontend/src/features/layers/administrative/AdministrativeLayers.js
+++ b/frontend/src/features/layers/administrative/AdministrativeLayers.js
@@ -84,7 +84,7 @@ const AdministrativeLayers = props => {
         showZones={showZones}
         data-cy={'administrative-zones-open'}
       >
-        Zones administratives <ChevronIcon isOpen={showZones}/>
+        Zones administratives <ChevronIcon $isOpen={showZones}/>
       </SectionTitle>
       <NamespaceContext.Consumer>
         {namespace => (

--- a/frontend/src/features/layers/base/BaseLayers.js
+++ b/frontend/src/features/layers/base/BaseLayers.js
@@ -35,7 +35,7 @@ const BaseLayers = ({ namespace }) => {
   return (
     <>
       <SectionTitle onClick={() => onSectionTitleClicked()} showBaseLayers={showBaseLayers}>
-        Fonds de carte <ChevronIcon isOpen={showBaseLayers}/>
+        Fonds de carte <ChevronIcon $isOpen={showBaseLayers}/>
       </SectionTitle>
       <BaseLayersList showBaseLayers={showBaseLayers} baseLayersLength={baseLayersKeys.length}>
         {

--- a/frontend/src/features/layers/regulatory/RegulatoryLayerZone.js
+++ b/frontend/src/features/layers/regulatory/RegulatoryLayerZone.js
@@ -93,7 +93,11 @@ const RegulatoryLayerZone = props => {
 
   useEffect(() => {
     if (showRegulatoryZone && isReadyToShowRegulatoryLayers) {
-      dispatch(showRegulatoryLayer({ type: LayersEnum.REGULATORY.code, ...regulatoryZone, namespace }))
+      dispatch(showRegulatoryLayer({
+        type: LayersEnum.REGULATORY.code,
+        ...regulatoryZone,
+        namespace
+      }))
     } else {
       dispatch(hideLayer({
         type: LayersEnum.REGULATORY.code,

--- a/frontend/src/features/layers/regulatory/RegulatoryLayerZone.js
+++ b/frontend/src/features/layers/regulatory/RegulatoryLayerZone.js
@@ -4,20 +4,23 @@ import {
   useRouteMatch,
   useHistory
 } from 'react-router-dom'
+import { useDispatch, useSelector } from 'react-redux'
+
 import { COLORS } from '../../../constants/constants'
 import LayersEnum from '../../../domain/entities/layers'
+
 import showRegulatoryZoneMetadata from '../../../domain/use_cases/showRegulatoryZoneMetadata'
 import showRegulationToEdit from '../../../domain/use_cases/showRegulationToEdit'
-import { useDispatch, useSelector } from 'react-redux'
 import closeRegulatoryZoneMetadata from '../../../domain/use_cases/closeRegulatoryZoneMetadata'
 import zoomInLayer from '../../../domain/use_cases/zoomInLayer'
 import hideLayer from '../../../domain/use_cases/hideLayer'
-import { CloseIcon } from '../../commonStyles/icons/CloseIcon.style'
 import showRegulatoryLayer from '../../../domain/use_cases/showRegulatoryLayer'
+
+import { CloseIcon } from '../../commonStyles/icons/CloseIcon.style'
 import { ShowIcon } from '../../commonStyles/icons/ShowIcon.style'
 import { HideIcon } from '../../commonStyles/icons/HideIcon.style'
-import { ReactComponent as EditSVG } from '../../icons/Bouton_edition.svg'
 import { REGPaperDarkIcon, REGPaperIcon } from '../../commonStyles/icons/REGPaperIcon.style'
+import { ReactComponent as EditSVG } from '../../icons/Bouton_edition.svg'
 
 export function showOrHideMetadataIcon (regulatoryZoneMetadata, regulatoryZone, setMetadataIsShown) {
   if (regulatoryZoneMetadata && regulatoryZone &&
@@ -90,7 +93,7 @@ const RegulatoryLayerZone = props => {
 
   useEffect(() => {
     if (showRegulatoryZone && isReadyToShowRegulatoryLayers) {
-      dispatch(showRegulatoryLayer({ ...regulatoryZone, namespace }))
+      dispatch(showRegulatoryLayer({ type: LayersEnum.REGULATORY.code, ...regulatoryZone, namespace }))
     } else {
       dispatch(hideLayer({
         type: LayersEnum.REGULATORY.code,

--- a/frontend/src/features/layers/regulatory/RegulatoryLayers.js
+++ b/frontend/src/features/layers/regulatory/RegulatoryLayers.js
@@ -82,7 +82,7 @@ const RegulatoryLayers = props => {
         regulatoryLayersAddedToMySelection={regulatoryLayersAddedToMySelection}
         showRegulatoryLayers={showRegulatoryLayers}
       >
-        Mes zones réglementaires <ChevronIcon isOpen={showRegulatoryLayers}/>
+        Mes zones réglementaires <ChevronIcon $isOpen={showRegulatoryLayers}/>
       </RegulatoryLayersTitle>
       <RegulatoryLayersList
         topicLength={Object.keys(selectedRegulatoryLayers).length}

--- a/frontend/src/features/measurements/Measurement.js
+++ b/frontend/src/features/measurements/Measurement.js
@@ -69,7 +69,7 @@ const Measurement = () => {
       case MeasurementTypes.CIRCLE_RANGE:
         return <CircleRangeIcon/>
       default:
-        return <MeasurementIcon rightMenuIsOpen={rightMenuIsOpen} selectedVessel={selectedVessel}/>
+        return <MeasurementIcon $rightMenuIsOpen={rightMenuIsOpen} $selectedVessel={selectedVessel}/>
     }
   }
 
@@ -209,7 +209,7 @@ const MeasurementWrapper = styled(MapButtonStyle)`
 
 const MeasurementIcon = styled(MeasurementSVG)`
   width: 40px;
-  opacity: ${props => props.selectedVessel && !props.rightMenuIsOpen ? '0' : '1'};
+  opacity: ${props => props.$selectedVessel && !props.$rightMenuIsOpen ? '0' : '1'};
   transition: all 0.2s;
 `
 

--- a/frontend/src/features/vessel_filters/Filter.js
+++ b/frontend/src/features/vessel_filters/Filter.js
@@ -18,7 +18,7 @@ const Filter = ({ filter, index, isLastItem, removeFilter, showFilter, hideFilte
           data-cy={'vessel-filter'}
           title={filter.name.replace(/[_]/g, ' ')}
           onClick={() => setIsOpen(!isOpen)}>
-          <ChevronIcon isOpen={isOpen}/>
+          <ChevronIcon $isOpen={isOpen}/>
           <FilterIcon fill={filter.color}/>
           {filter.name
             ? filter.name.replace(/[_]/g, ' ')
@@ -118,7 +118,7 @@ const ChevronIcon = styled(ChevronIconSVG)`
   margin-right: 8px;
   margin-top: 5px;
   
-  animation: ${props => props.isOpen ? 'chevron-layer-opening' : 'chevron-layer-closing'} 0.5s ease forwards;
+  animation: ${props => props.$isOpen ? 'chevron-layer-opening' : 'chevron-layer-closing'} 0.5s ease forwards;
 
   @keyframes chevron-layer-opening {
     0%   { transform: rotate(180deg); }

--- a/frontend/src/features/vessel_filters/VesselFilters.js
+++ b/frontend/src/features/vessel_filters/VesselFilters.js
@@ -84,8 +84,8 @@ const VesselFilters = () => {
           title={'Mes filtres'}
           onClick={() => setVesselFilterBoxIsOpen(!vesselFilterBoxIsOpen)}>
           <FilterIcon
-            rightMenuIsOpen={rightMenuIsOpen}
-            selectedVessel={selectedVessel}/>
+            $rightMenuIsOpen={rightMenuIsOpen}
+            $selectedVessel={selectedVessel}/>
         </VesselFilterIcon>
         <VesselFilterBox
           healthcheckTextWarning={healthcheckTextWarning}
@@ -239,7 +239,7 @@ const FilterIcon = styled(FilterSVG)`
   height: 23px;
   margin-right: 3px;
   margin-top: 2px;
-  opacity: ${props => props.selectedVessel && !props.rightMenuIsOpen ? '0' : '1'};
+  opacity: ${props => props.$selectedVessel && !props.$rightMenuIsOpen ? '0' : '1'};
   transition: all 0.2s;
 `
 

--- a/frontend/src/features/vessel_search/VesselsSearch.js
+++ b/frontend/src/features/vessel_search/VesselsSearch.js
@@ -163,8 +163,8 @@ const VesselsSearch = () => {
         isOpen={selectedVessel}
         selectedVessel={selectedVessel}>
         <SearchIcon
-          rightMenuIsOpen={rightMenuIsOpen}
-          selectedVessel={selectedVessel}/>
+          $rightMenuIsOpen={rightMenuIsOpen}
+          $selectedVessel={selectedVessel}/>
       </SearchButton>
     </>)
 }
@@ -259,7 +259,7 @@ const SearchIcon = styled(SearchIconSVG)`
   width: 24px;
   height: 24x;
   margin-top: 4px;
-  opacity: ${props => props.selectedVessel && !props.rightMenuIsOpen ? '0' : '1'};
+  opacity: ${props => props.$selectedVessel && !props.$rightMenuIsOpen ? '0' : '1'};
   transition: all 0.2s;
 `
 

--- a/frontend/src/features/vessel_sidebar/controls/YearControls.js
+++ b/frontend/src/features/vessel_sidebar/controls/YearControls.js
@@ -31,7 +31,7 @@ const YearControls = props => {
       <YearTitle isEmpty={yearControls.length === 0} isLastItem={props.isLastItem} isOpen={isOpen}>
         <Text isEmpty={yearControls.length === 0} isOpen={isOpen} title={props.year} onClick={() => setIsOpen(!isOpen)}>
           {
-            yearControls.length ? <ChevronIcon isOpen={isOpen}/> : null
+            yearControls.length ? <ChevronIcon $isOpen={isOpen}/> : null
           }
           <Year>{props.year}</Year>
           <YearResume data-cy={'vessel-controls-year'}>
@@ -131,7 +131,7 @@ const ChevronIcon = styled(ChevronIconSVG)`
   margin-top: 9px;
   float: right;
   
-  animation: ${props => props.isOpen ? 'chevron-layer-opening' : 'chevron-layer-closing'} 0.5s ease forwards;
+  animation: ${props => props.$isOpen ? 'chevron-layer-opening' : 'chevron-layer-closing'} 0.5s ease forwards;
 
   @keyframes chevron-layer-opening {
     0%   { transform: rotate(180deg); }

--- a/frontend/src/features/vessel_sidebar/fishing_activities/ers_messages/ERSMessageSpecies.js
+++ b/frontend/src/features/vessel_sidebar/fishing_activities/ers_messages/ERSMessageSpecies.js
@@ -32,7 +32,7 @@ const ERSMessageSpecies = props => {
             <InlineKey>Poids total (estimé) </InlineKey>
             <Kg>{props.species.weight ? props.species.weight : <NoValue>-</NoValue>} kg</Kg>
           </Weight>
-          <ChevronIcon isOpen={isOpen} name={props.species.species}/>
+          <ChevronIcon $isOpen={isOpen} name={props.species.species}/>
         </Title>
         <Content isOpen={isOpen} name={props.species.species}
                  length={props.species.properties ? props.species.properties.length : 1}>
@@ -244,7 +244,7 @@ const ChevronIcon = styled(ChevronIconSVG)`
   margin-right: 10px;
   margin-top: 2px;
   
-  animation: ${props => props.isOpen ? `chevron-${props.name}-zones-opening` : `chevron-${props.name}-zones-closing`} 0.2s ease forwards;
+  animation: ${props => props.$isOpen ? `chevron-${props.name}-zones-opening` : `chevron-${props.name}-zones-closing`} 0.2s ease forwards;
 
   ${props => `
       @keyframes chevron-${props.name}-zones-opening {

--- a/frontend/src/features/vessel_sidebar/fishing_activities/ers_messages_resumes/ERSMessageResumeHeader.js
+++ b/frontend/src/features/vessel_sidebar/fishing_activities/ers_messages_resumes/ERSMessageResumeHeader.js
@@ -25,7 +25,7 @@ const ERSMessageResumeHeader = props => {
           isOpen={props.isOpen}
         >
           {
-            props.hasNoMessage || props.noContent ? null : <ChevronIcon isOpen={props.isOpen} name={props.messageType}/>
+            props.hasNoMessage || props.noContent ? null : <ChevronIcon $isOpen={props.isOpen} name={props.messageType}/>
           }
           <ERSMessageName
             isNotAcknowledged={props.isNotAcknowledged}
@@ -139,7 +139,7 @@ const ChevronIcon = styled(ChevronIconSVG)`
   margin-right: 10px;
   margin-top: 12px;
   
-  animation: ${props => props.isOpen ? `chevron-${props.name}-resume-opening` : `chevron-${props.name}-resume-closing`} 0.2s ease forwards;
+  animation: ${props => props.$isOpen ? `chevron-${props.name}-resume-opening` : `chevron-${props.name}-resume-closing`} 0.2s ease forwards;
 
   ${props => `
       @keyframes chevron-${props.name}-resume-opening {

--- a/frontend/src/features/vessel_sidebar/fishing_activities/ers_messages_resumes/SpeciesAndWeightChart.js
+++ b/frontend/src/features/vessel_sidebar/fishing_activities/ers_messages_resumes/SpeciesAndWeightChart.js
@@ -87,7 +87,7 @@ const SpeciesAndWeightChart = ({
                 </WeightText>
                 {
                   speciesPresentationAndWeightArray
-                    ? <ChevronIcon isOpen={speciesAndWeight.species === speciesPresentationOpened}/>
+                    ? <ChevronIcon $isOpen={speciesAndWeight.species === speciesPresentationOpened}/>
                     : null
                 }
               </Weight>
@@ -229,7 +229,7 @@ const ChevronIcon = styled(ChevronIconSVG)`
   float: right;
   margin-right: 10px;
   margin-top: 0;
-  transform: ${props => !props.isOpen ? 'rotate(180deg)' : 'rotate(0deg)'};
+  transform: ${props => !props.$isOpen ? 'rotate(180deg)' : 'rotate(0deg)'};
   transition: all 0.5;
   text-align: right;
   margin-left: auto;

--- a/frontend/src/features/vessel_sidebar/risk_factor/RiskFactorResume.js
+++ b/frontend/src/features/vessel_sidebar/risk_factor/RiskFactorResume.js
@@ -68,7 +68,7 @@ const RiskFactorResume = () => {
                   <SubRiskTitle>
                     Impact sur la ressource
                   </SubRiskTitle>
-                  <Chevron isOpen={impactRiskFactorIsOpen}/>
+                  <Chevron $isOpen={impactRiskFactorIsOpen}/>
                 </SubRiskHeader>
                 <RiskFactorImpact/>
                 <RiskFactorCursor
@@ -91,7 +91,7 @@ const RiskFactorResume = () => {
                   <SubRiskTitle>
                     Probabilité d&apos;infraction
                   </SubRiskTitle>
-                  <Chevron isOpen={probabilityRiskFactorIsOpen}/>
+                  <Chevron $isOpen={probabilityRiskFactorIsOpen}/>
                 </SubRiskHeader>
                 <RiskFactorInfractions/>
                 <RiskFactorCursor
@@ -114,7 +114,7 @@ const RiskFactorResume = () => {
                   <SubRiskTitle>
                     Priorité de contrôle
                   </SubRiskTitle>
-                  <Chevron isOpen={detectabilityRiskFactorIsOpen}/>
+                  <Chevron $isOpen={detectabilityRiskFactorIsOpen}/>
                 </SubRiskHeader>
                 <RiskFactorControl/>
                 <RiskFactorCursor

--- a/frontend/src/features/vessel_visibility/VesselVisibility.js
+++ b/frontend/src/features/vessel_visibility/VesselVisibility.js
@@ -82,8 +82,8 @@ const VesselVisibility = () => {
         title={'Affichage des dernières positions'}
         onClick={() => setVesselVisibilityBoxIsOpen(!vesselVisibilityBoxIsOpen)}>
         <Vessel
-          rightMenuIsOpen={rightMenuIsOpen}
-          selectedVessel={selectedVessel}/>
+          $rightMenuIsOpen={rightMenuIsOpen}
+          $selectedVessel={selectedVessel}/>
       </VesselVisibilityIcon>
       <VesselVisibilityBox
         healthcheckTextWarning={healthcheckTextWarning}
@@ -233,7 +233,7 @@ const VesselVisibilityIcon = styled(MapButtonStyle)`
 const Vessel = styled(VesselSVG)`
   width: 25px;
   height: 25px;
-  opacity: ${props => props.selectedVessel && !props.rightMenuIsOpen ? '0' : '1'};
+  opacity: ${props => props.$selectedVessel && !props.$rightMenuIsOpen ? '0' : '1'};
   transition: all 0.2s;
 `
 

--- a/frontend/src/layers/AdministrativeLayers.js
+++ b/frontend/src/layers/AdministrativeLayers.js
@@ -1,48 +1,52 @@
 import { useEffect } from 'react'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
+import layer from '../domain/shared_slices/Layer'
 import Layers, { layersType } from '../domain/entities/layers'
 
-const AdministrativeLayers = ({ map }) => {
-  const layer = useSelector(state => state.layer)
+const AdministrativeLayers = ({ map, namespace = 'homepage' }) => {
+  const { removeLayer } = layer[namespace].actions
+  const stateLayer = useSelector(state => state.layer)
+  const { showedLayers, layers } = stateLayer
+  const dispatch = useDispatch()
   const administrativeLayers = Object.keys(Layers)
     .map(topic => Layers[topic])
     .filter(layer => layer.type === layersType.ADMINISTRATIVE)
 
   useEffect(() => {
-    addOrRemoveAdministrativeLayers()
-  }, [layer.layers])
-
-  function addOrRemoveAdministrativeLayers () {
-    if (map && layer.layers) {
+    if (map && layers && layers.length) {
       addAdministrativeLayersToMap()
+    }
+  }, [layers])
+
+  useEffect(() => {
+    if (map && showedLayers) {
       removeAdministrativeLayersToMap()
     }
-  }
+  }, [showedLayers])
 
   function addAdministrativeLayersToMap () {
-    if (layer.layers.length) {
-      const layersToInsert = layer.layers
-        .filter(layer => !map.getLayers().getArray().some(layer_ => layer === layer_))
-        .filter(showedLayer => administrativeLayers
-          .some(administrativeLayer => showedLayer.name?.includes(administrativeLayer.code)))
+    const layersToInsert = layers
+      .filter(layer => !map.getLayers().getArray().some(layer_ => layer === layer_))
+      .filter(layer => administrativeLayers
+        .some(administrativeLayer => layer.name?.includes(administrativeLayer.code)))
 
-      layersToInsert.forEach(layerToInsert => {
-        if (!layerToInsert) {
-          return
-        }
+    layersToInsert.forEach(layerToInsert => {
+      if (!layerToInsert) {
+        return
+      }
 
-        map.getLayers().push(layerToInsert)
-      })
-    }
+      map.getLayers().push(layerToInsert)
+      dispatch(removeLayer(layerToInsert))
+    })
   }
 
   function removeAdministrativeLayersToMap () {
-    const layers = layer.layers.length ? layer.layers : []
+    const _showedLayers = showedLayers?.length ? showedLayers : []
 
     const layersToRemove = map.getLayers().getArray()
-      .filter(showedLayer => !layers.some(layer_ => showedLayer === layer_))
-      .filter(showedLayer => administrativeLayers
-        .some(administrativeLayer => showedLayer.name?.includes(administrativeLayer.code)))
+      .filter(OLLayer => !_showedLayers.some(layer_ => OLLayer.name === layer_.type)) // les couches dans OL qui ne sont plus dans le state showedLayers
+      .filter(OLLayer => administrativeLayers
+        .some(administrativeLayer => OLLayer.name?.includes(administrativeLayer.code))) // les couches de type administrativeLayer
 
     layersToRemove.forEach(layerToRemove => {
       map.getLayers().remove(layerToRemove)

--- a/frontend/src/layers/RegulatoryLayers.js
+++ b/frontend/src/layers/RegulatoryLayers.js
@@ -1,18 +1,19 @@
 import { useEffect, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
-import LayersEnum from '../domain/entities/layers'
+import { useDispatch, useSelector, useStore } from 'react-redux'
+import LayersEnum, { getLayerNameNormalized } from '../domain/entities/layers'
 import { showSimplifiedGeometries, showWholeGeometries } from '../domain/shared_slices/Regulatory'
+import { getVectorLayer } from '../domain/use_cases/showRegulatoryLayer'
 
 export const metadataIsShowedPropertyName = 'metadataIsShowed'
-const simplifiedFeaturesZoom = 9.5
+const SIMPLIFIED_FEATURE_ZOOM_LEVEL = 9.5
 
 const RegulatoryLayers = ({ map, mapMovingAndZoomEvent }) => {
   const throttleDuration = 500 // ms
   const dispatch = useDispatch()
+  const { getState } = useStore()
 
   const {
-    layers,
-    layersAndAreas,
+    showedLayers,
     lastShowedFeatures,
     layersToFeatures
   } = useSelector(state => state.layer)
@@ -27,11 +28,14 @@ const RegulatoryLayers = ({ map, mapMovingAndZoomEvent }) => {
 
   useEffect(() => {
     sortRegulatoryLayersFromAreas()
-  }, [layers, map, layersAndAreas])
+  }, [map, layersToFeatures])
 
   useEffect(() => {
-    addOrRemoveRegulatoryLayersToMap()
-  }, [layers])
+    if (map && showedLayers) {
+      addRegulatoryLayersToMap()
+      removeRegulatoryLayersToMap()
+    }
+  }, [showedLayers])
 
   useEffect(() => {
     addOrRemoveMetadataIsShowedPropertyToShowedRegulatoryLayers()
@@ -50,15 +54,7 @@ const RegulatoryLayers = ({ map, mapMovingAndZoomEvent }) => {
   }, [map, mapMovingAndZoomEvent, layersToFeatures])
 
   function getShowSimplifiedFeatures (currentZoom) {
-    let showSimplifiedFeatures = true
-
-    if (currentZoom < simplifiedFeaturesZoom) {
-      showSimplifiedFeatures = true
-    } else if (currentZoom >= simplifiedFeaturesZoom) {
-      showSimplifiedFeatures = false
-    }
-
-    return showSimplifiedFeatures
+    return currentZoom < SIMPLIFIED_FEATURE_ZOOM_LEVEL
   }
 
   function featuresAreAlreadyDrawWithTheSameTolerance (showSimplifiedFeatures, simplifiedGeometries) {
@@ -101,13 +97,6 @@ const RegulatoryLayers = ({ map, mapMovingAndZoomEvent }) => {
     }
   }
 
-  function addOrRemoveRegulatoryLayersToMap () {
-    if (map && layers) {
-      addRegulatoryLayersToMap()
-      removeRegulatoryLayersToMap()
-    }
-  }
-
   function addOrRemoveMetadataIsShowedPropertyToShowedRegulatoryLayers () {
     if (map) {
       const regulatoryLayers = map.getLayers().getArray().filter(layer => layer?.name?.includes(LayersEnum.REGULATORY.code))
@@ -144,45 +133,43 @@ const RegulatoryLayers = ({ map, mapMovingAndZoomEvent }) => {
   }
 
   function sortRegulatoryLayersFromAreas () {
-    if (map && layers.length && layersAndAreas.length > 1) {
-      const sortedLayersToArea = [...layersAndAreas].sort((a, b) => a.area - b.area).reverse()
+    const sortedLayersToArea = [...layersToFeatures].sort((a, b) => a.area - b.area).reverse()
 
-      sortedLayersToArea.forEach((layerAndArea, index) => {
-        index = index + 1
-        const layer = map.getLayers().getArray().find(layer => layer?.name === layerAndArea.name)
+    sortedLayersToArea.forEach((layerAndArea, index) => {
+      index = index + 1
+      const layer = map.getLayers().getArray().find(layer => layer?.name === layerAndArea.name)
 
-        if (layer) {
-          layer.setZIndex(index)
-        }
-      })
-    }
+      if (layer) {
+        layer.setZIndex(index)
+      }
+    })
   }
 
   function addRegulatoryLayersToMap () {
-    if (layers.length) {
-      const layersToInsert = layers
-        .filter(layer => {
-          return !map.getLayers().getArray().some(layer_ => layer === layer_)
-        })
-        .filter(layer => layer?.name?.includes(LayersEnum.REGULATORY.code))
-
+    if (showedLayers.length) {
+      const layersToInsert = showedLayers
+        .filter(layer => !map.getLayers()?.getArray().some(layer_ => {
+          return getLayerNameNormalized({ ...layer, type: LayersEnum.REGULATORY.code }) === layer_.name
+        })) // Les couches dans showedLayers qui ne sont pas dans OL
+        .filter(layer => layer.type === LayersEnum.REGULATORY.code) // Les couches de type regulatoryLayer
       layersToInsert.forEach(layerToInsert => {
         if (!layerToInsert) {
           return
         }
-
-        map.getLayers().push(layerToInsert)
+        const getVectorLayerClosure = getVectorLayer(dispatch, getState)
+        const vectorLayer = getVectorLayerClosure(layerToInsert)
+        map.getLayers().push(vectorLayer)
       })
     }
   }
 
   function removeRegulatoryLayersToMap () {
-    const layersOrEmptyArray = layers.length ? layers : []
-    const layersToRemove = map.getLayers().getArray()
-      .filter(showedLayer => !layersOrEmptyArray.some(layer_ => showedLayer === layer_))
-      .filter(layer => layer?.name?.includes(LayersEnum.REGULATORY.code))
+    const _showedLayers = showedLayers.length ? showedLayers : []
+    const layersToRemove = map?.getLayers()?.getArray()
+      .filter(OLLayer => !_showedLayers.some(layer_ => OLLayer.name === getLayerNameNormalized(layer_)))
+      .filter(OLLayer => OLLayer?.name?.includes(LayersEnum.REGULATORY.code))
 
-    layersToRemove.forEach(layerToRemove => {
+    layersToRemove?.forEach(layerToRemove => {
       map.getLayers().remove(layerToRemove)
     })
   }

--- a/frontend/src/layers/RegulatoryLayers.js
+++ b/frontend/src/layers/RegulatoryLayers.js
@@ -148,10 +148,9 @@ const RegulatoryLayers = ({ map, mapMovingAndZoomEvent }) => {
   function addRegulatoryLayersToMap () {
     if (showedLayers.length) {
       const layersToInsert = showedLayers
-        .filter(layer => !map.getLayers()?.getArray().some(layer_ => {
-          return getLayerNameNormalized({ ...layer, type: LayersEnum.REGULATORY.code }) === layer_.name
-        })) // Les couches dans showedLayers qui ne sont pas dans OL
-        .filter(layer => layer.type === LayersEnum.REGULATORY.code) // Les couches de type regulatoryLayer
+        .filter(layer => layersNotInCurrentOLMap(layer))
+        .filter(layer => layersOfTypeRegulatoryLayer(layer))
+
       layersToInsert.forEach(layerToInsert => {
         if (!layerToInsert) {
           return
@@ -163,15 +162,32 @@ const RegulatoryLayers = ({ map, mapMovingAndZoomEvent }) => {
     }
   }
 
+  function layersNotInCurrentOLMap (layer) {
+    return !map.getLayers()?.getArray().some(olLayer => olLayer.name ===
+      getLayerNameNormalized({ type: LayersEnum.REGULATORY.code, ...layer }))
+  }
+
+  function layersOfTypeRegulatoryLayer (layer) {
+    return layer.type === LayersEnum.REGULATORY.code
+  }
+
   function removeRegulatoryLayersToMap () {
     const _showedLayers = showedLayers.length ? showedLayers : []
     const layersToRemove = map?.getLayers()?.getArray()
-      .filter(OLLayer => !_showedLayers.some(layer_ => OLLayer.name === getLayerNameNormalized(layer_)))
-      .filter(OLLayer => OLLayer?.name?.includes(LayersEnum.REGULATORY.code))
+      .filter(olLayer => layersOfTypeRegulatoryLayerInCurrentMap(olLayer))
+      .filter(olLayer => layersNotPresentInShowedLayers(_showedLayers, olLayer))
 
     layersToRemove?.forEach(layerToRemove => {
       map.getLayers().remove(layerToRemove)
     })
+  }
+
+  function layersNotPresentInShowedLayers (_showedLayers, olLayer) {
+    return !_showedLayers.some(layer_ => getLayerNameNormalized(layer_) === olLayer.name)
+  }
+
+  function layersOfTypeRegulatoryLayerInCurrentMap (olLayer) {
+    return olLayer?.name?.includes(LayersEnum.REGULATORY.code)
   }
 
   return null


### PR DESCRIPTION
[Description]
- Les couches Regulatory et Admin n'utilisent plus state.layers comme passe-plat. La mise à jour des couches se fait uniquement en regardant les changements sur showedLayers
- utilisation des transient props sur les icones quand c'est possible
- ajout du raccourci de création de filtres

## Linked issues
- closes #518 
- Resolve #666
- Resolves #613 

----

- [ ] Tests E2E (Cypress)
