### PR TITLE
Fix last positions

### DIFF
--- a/datascience/src/pipeline/queries/monitorfish/compute_last_positions.sql
+++ b/datascience/src/pipeline/queries/monitorfish/compute_last_positions.sql
@@ -14,7 +14,7 @@ WITH last_n_minutes_positions AS (
         date_time,
         ROW_NUMBER() OVER (
             PARTITION BY internal_reference_number, external_reference_number, ircs
-            ORDER BY date_time DESC) AS rk
+            ORDER BY date_time, id DESC) AS rk
     FROM positions
     WHERE date_time > CURRENT_TIMESTAMP - make_interval(mins => :minutes)
     AND date_time < CURRENT_TIMESTAMP + INTERVAL '1 day'
@@ -62,6 +62,9 @@ emission_periods AS (
 )
 
 SELECT
+    -- The DISTINCT ON clause is required to remove possible duplicates due to vessels
+    -- for which we receive each position multiple times
+    DISTINCT ON (pos.internal_reference_number, pos.external_reference_number, pos.ircs)
     pos.id,
     pos.internal_reference_number AS cfr,
     pos.external_reference_number AS external_immatriculation,

--- a/datascience/tests/test_pipeline/test_flows/test_last_positions.py
+++ b/datascience/tests/test_pipeline/test_flows/test_last_positions.py
@@ -10,6 +10,7 @@ from src.pipeline.flows.last_positions import (
     add_vessel_identifier,
     compute_emission_period,
     concatenate,
+    drop_duplicates,
     drop_unchanched_new_last_positions,
     estimate_current_positions,
     extract_last_positions,
@@ -54,6 +55,20 @@ class TestLastPositionsFlow(unittest.TestCase):
         self.assertEqual(validate_action.run("replace"), "replace")
         with self.assertRaises(ValueError):
             validate_action.run("unknown_option")
+
+    def test_drop_duplicates(self):
+        positions = pd.DataFrame(
+            {
+                "cfr": ["A", "A", "B", "C"],
+                "external_immatriculation": ["AA", "A-A", "BB", "CC"],
+                "ircs": ["AAA", "AAA", "BBB", "CCC"],
+                "other_columns": ["some", "some", "more", "data"],
+            }
+        )
+
+        res = drop_duplicates.run(positions)
+        expected_res = positions.iloc[[0, 2, 3]]
+        pd.testing.assert_frame_equal(res, expected_res)
 
     def test_drop_unchanched_new_last_positions(self):
         previous_last_positions = pd.DataFrame(

--- a/datascience/tests/test_pipeline/test_processing.py
+++ b/datascience/tests/test_pipeline/test_processing.py
@@ -15,6 +15,7 @@ from src.pipeline.processing import (
     df_to_dict_series,
     df_values_to_json,
     df_values_to_psql_arrays,
+    drop_duplicates_by_decreasing_priority,
     drop_rows_already_in_table,
     get_unused_col_name,
     is_a_value,
@@ -599,3 +600,28 @@ class TestProcessingMethods(unittest.TestCase):
         )
 
         pd.testing.assert_series_equal(res, expected)
+
+    def test_drop_duplicates_by_decreasing_priority(self):
+
+        df = pd.DataFrame(
+            {
+                "A": [1, 2, 3, None, 1, 2, 3, 4, None, 22, None, None, None],
+                "B": [1, 2, 3, None, 1, 22, 3, 4, None, 2, None, None, 6],
+                "C": [1, 2, 3, 4, 1, 2, 33, 4, None, 2, 2, 5, 6],
+                "D": ["W", "h", "a", "t", "e", "v", "e", "r", "d", "a", "t", "a", "a"],
+            },
+            index=[1, 2, 4, 14, 4, 32, 41, 2, 9, 13, 31, 4, 7],
+        )
+
+        res = drop_duplicates_by_decreasing_priority(df, subset=["A", "B", "C"])
+
+        expected_res = df.iloc[[0, 1, 2, 7, 9, 12, 11]]
+
+        pd.testing.assert_frame_equal(res, expected_res)
+
+        with self.assertRaises(TypeError):
+            drop_duplicates_by_decreasing_priority(df, {"not", "a", "list"})
+
+        with self.assertRaises(TypeError):
+            empty_list = []
+            drop_duplicates_by_decreasing_priority(df, empty_list)


### PR DESCRIPTION
## Linked issues

- Resolve #861 

----

Pour certains navires, on reçoit les signaux VMS plusieurs fois avec des identifiants différents. On peut par exemple recevoir pour un même navire les positions suivantes :

| date_time                   | cfr   | external_immatriculation   | ircs   |   latitude |   longitude |
|:-----------------------------|:------|:----------------------------------|:--------|------------:|------------:|
| 2021-01-01 11:12:00 | A     | I MMAT                             | callme |      45.23 |       -3.56 |
| 2021-01-01 11:12:00 | A     | i-mmat                              | callme |      45.23 |       -3.56 |
| 2021-01-01 12:12:00 | A     | I MMAT                            | callme |      45.36 |       -3.12 |
| 2021-01-01 12:12:00 | A     | i-mmat                             | callme |      45.36 |       -3.12 |

En plus d'un `DROP DUPLICATES` dans la requête qui extrait les positions de la table de `positions` pour éliminer les duplications de positions pour un même navire ayant tous les identifiants identiques, il faut donc faire un traitement pour éliminer les duplications partielles (sur un sous ensemble des identifiants). C'est ce que fait la fonction `drop_duplicates_by_decreasing_priority`.