### PR TITLE
Take risk factors in last_positions table when raising alerts

### DIFF
--- a/datascience/src/pipeline/flows/position_alerts.py
+++ b/datascience/src/pipeline/flows/position_alerts.py
@@ -287,7 +287,7 @@ def extract_current_gears() -> pd.DataFrame:
 @task(checkpoint=False)
 def extract_current_risk_factors() -> pd.DataFrame:
     """
-    Extracts of vessels' current risk factor in `risk_factors` table.
+    Extracts vessels' current risk factor in `last_positions` table.
     """
     return extract(
         db_name="monitorfish_remote",

--- a/datascience/src/pipeline/queries/monitorfish/current_risk_factors.sql
+++ b/datascience/src/pipeline/queries/monitorfish/current_risk_factors.sql
@@ -3,4 +3,4 @@ SELECT
     ircs,
     external_immatriculation,
     risk_factor
-FROM risk_factors
+FROM last_positions

--- a/datascience/tests/test_pipeline/test_flows/test_position_alerts.py
+++ b/datascience/tests/test_pipeline/test_flows/test_position_alerts.py
@@ -11,6 +11,7 @@ from src.pipeline.flows.position_alerts import (
     ZonesTable,
     alert_has_gear_parameters,
     extract_current_gears,
+    extract_current_risk_factors,
     filter_on_gears,
     flow,
     get_alert_type_zones_table,
@@ -304,6 +305,19 @@ def test_extract_current_gears(reset_test_data):
     )
 
 
+def test_extract_current_risk_factors(reset_test_data):
+    risk_factors = extract_current_risk_factors.run()
+    expected_risk_factors = pd.DataFrame(
+        columns=pd.Index(["cfr", "ircs", "external_immatriculation", "risk_factor"]),
+        data=[
+            ["ABC000055481", "IL2468", "AS761555", 1.74110112659225],
+            ["ABC000542519", "FQ7058", "RO237719", 1.4142135623731],
+            [None, "OLY7853", "SB125334", 1.74110112659225],
+        ],
+    )
+    pd.testing.assert_frame_equal(risk_factors, expected_risk_factors)
+
+
 def test_filter_on_gears():
     positions_in_alert = pd.DataFrame(
         {
@@ -515,19 +529,19 @@ def test_flow_inserts_new_pending_alerts(reset_test_data):
                     "type": "THREE_MILES_TRAWLING_ALERT",
                     "seaFront": None,
                     "flagState": "NL",
-                    "riskFactor": None,
+                    "riskFactor": 1.74110112659225003,
                 },
                 {
                     "type": "THREE_MILES_TRAWLING_ALERT",
                     "seaFront": "Facade B",
                     "flagState": "FR",
-                    "riskFactor": 2.14443662414848,
+                    "riskFactor": None,
                 },
                 {
                     "type": "THREE_MILES_TRAWLING_ALERT",
                     "seaFront": "Facade A",
                     "flagState": "FR",
-                    "riskFactor": 2.09885592141872,
+                    "riskFactor": 1.41421356237310003,
                 },
             ],
             "vessel_identifier": [
@@ -615,13 +629,13 @@ def test_flow_filters_on_gears(reset_test_data):
                     "type": "THREE_MILES_TRAWLING_ALERT",
                     "seaFront": None,
                     "flagState": "NL",
-                    "riskFactor": None,
+                    "riskFactor": 1.74110112659225003,
                 },
                 {
                     "type": "THREE_MILES_TRAWLING_ALERT",
                     "seaFront": "Facade A",
                     "flagState": "FR",
-                    "riskFactor": 2.09885592141872,
+                    "riskFactor": 1.41421356237310003,
                 },
             ],
             "vessel_identifier": [
@@ -708,13 +722,13 @@ def test_flow_filters_on_time(reset_test_data):
                     "type": "THREE_MILES_TRAWLING_ALERT",
                     "seaFront": "Facade B",
                     "flagState": "FR",
-                    "riskFactor": 2.14443662414848,
+                    "riskFactor": None,
                 },
                 {
                     "type": "THREE_MILES_TRAWLING_ALERT",
                     "seaFront": "Facade A",
                     "flagState": "FR",
-                    "riskFactor": 2.09885592141872,
+                    "riskFactor": 1.41421356237310003,
                 },
             ],
             "vessel_identifier": [
@@ -796,7 +810,7 @@ def test_flow_filters_on_flag_states(reset_test_data):
                     "type": "THREE_MILES_TRAWLING_ALERT",
                     "seaFront": None,
                     "flagState": "NL",
-                    "riskFactor": None,
+                    "riskFactor": 1.74110112659225003,
                 },
             ],
             "vessel_identifier": [


### PR DESCRIPTION
## Linked issues
- Resolve #949 

## Explication
Les navires pour lesquels on reçoit des positions mais qui n'ont pas de JPE et qui n'ont jamais fait l'objet de contrôles figurent dans la table `last_positions`, mais pas dans la table `risk_factors`. Pour ces navires, un facteur de risque par défaut est néanmoins présent dans la table `last_position`, donc il vaut mieux prendre les facteurs de risque dans cette table plutôt que dans `risk_factors`.

Inversement, `risk_factors` contient des facteurs de risque sur des navires qui n'émettent pas de positions (<12m) qui ne sont donc _pas_ dans la table `last_positions`, mais on ne lèvera jamais d'alertes de chalutage sur ces navires (ce n'est pas possible puisqu'on ne connait pas leur position) donc il n'est pas utile de prendre les facteurs de risque dans la table `risk_factors` pour ces navires non plus.

En conclusion, pour les alertes de chalutage, il faut prendre les facteurs de risque de la table de `last_positions`, qui contient les facteurs de risque de tous les navires sur lesquels on est susceptible de lever une alerte sur la base de positions.