### PR TITLE
Fix rsuite v5 styles

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -223,19 +223,6 @@ a:hover, a:focus {
     min-height: 210px !important;
 }
 
-.rs-modal-header {
-    border-top-left-radius: 2px;
-    border-top-right-radius: 2px;
-    padding: 5px 14px 8px 14px;
-    background: #3B4559;
-}
-
-.rs-modal-header .rs-modal-title {
-    color: #F0F0F0;
-    font-size: 22px;
-    font-weight: normal;
-}
-
 .rs-table-cell-header, .rs-table-cell[role="columnheader"], .rs-table-cell-header:focus, .rs-table-cell[role="columnheader"]:focus, .rs-table-cell-header:hover, .rs-table-cell[role="columnheader"]:hover {
     background: #E5E5EB;
     color: white;
@@ -275,19 +262,6 @@ a:hover, a:focus {
     position: absolute;
     background-color: #575757;
     border-radius: 4px;
-}
-
-.rs-table-cell-content > .rs-checkbox {
-    margin-top: -10px;
-    margin-left: -10px;
-}
-
-.rs-modal-header-close {
-    background: unset;
-    right: 10px !important;
-    top: 9px !important;
-    font-size: 15px !important;
-    color: #E5E5EB !important;
 }
 
 .rs-picker-default .rs-btn, .rs-picker-input .rs-btn, .rs-picker-default .rs-picker-toggle, .rs-picker-input .rs-picker-toggle {
@@ -403,22 +377,6 @@ a:hover, a:focus {
     padding: 10px 7px;
 }
 
-.rs-table-cell-header-icon-sort {
-    color: #707785;
-    line-height: 1.66666667;
-    position: absolute;
-    right: 9px;
-    top: 10px;
-}
-
-.rs-table-cell-header-icon-sort-asc::after {
-    color: #707785;
-}
-
-.rs-table-cell-header-icon-sort-desc::after {
-    color: #707785;
-}
-
 .rs-table-hover .rs-table-row:not(.rs-table-row-header):hover, .rs-table-hover .rs-table-row:hover .rs-table-cell-group, .rs-table-hover .rs-table-row:hover .rs-table-cell {
   /* background: rgba(107, 131, 158, 0.15) !important; */ /* shadowBlueLittleOpacity */
   background: #d6dce3 !important; /* shadowBlueLight */
@@ -441,4 +399,8 @@ a:hover, a:focus {
 
 .hover-border:hover {
     border-bottom: 1px solid rgb(40, 47, 62);
+}
+
+.rs-btn-primary:hover {
+  color: inherit;
 }

--- a/frontend/src/features/backoffice/edit_regulation/custom_form/CustomSelectComponent.js
+++ b/frontend/src/features/backoffice/edit_regulation/custom_form/CustomSelectComponent.js
@@ -83,6 +83,10 @@ const CustomSelectPicker = styled(SelectPicker)`
   .grouped.rs-picker-select-menu-item {
     padding-left: 0px;
   }
+
+  .rs-picker-toggle {
+    width: ${p => p.width ? p.width - 40 : 160};
+  }
 `
 
 export default CustomSelectComponent

--- a/frontend/src/features/backoffice/edit_regulation/fishing_period/TimeInterval.js
+++ b/frontend/src/features/backoffice/edit_regulation/fishing_period/TimeInterval.js
@@ -72,6 +72,10 @@ const Wrapper = styled.div`
   ${props => props.$isLast ? '' : 'margin-bottom: 5px;'}
   color: ${COLORS.slateGray};
   opacity: ${props => props.disabled ? '0.4' : '1'};
+
+  .rs-picker-toggle {
+    width: 40px;
+  }
 `
 
 export default TimeInterval

--- a/frontend/src/features/backoffice/edit_regulation/gear_regulation/RegulatedGear.js
+++ b/frontend/src/features/backoffice/edit_regulation/gear_regulation/RegulatedGear.js
@@ -20,7 +20,7 @@ const RegulatedGear = props => {
     remarks
   } = props
 
-  return (<>
+  return (<Wrapper>
       <ContentLine data-cy='regulatory-gear-line'>
         <Label>{code ? `Engin ${id + 1}` : `Catégorie ${id + 1}`}</Label>
         <Tag
@@ -99,10 +99,18 @@ const RegulatedGear = props => {
           $isGray={remarks}
         />
       </ContentLine>
-    </>
+    </Wrapper>
   )
 }
-const SecondCustomInput = styled(CustomInput)` 
+
+const Wrapper = styled.div`
+  .rs-picker-toggle {
+    width: 120px;
+  }
+`
+
+const SecondCustomInput = styled(CustomInput)`
   margin-left: 10px;
 `
+
 export default RegulatedGear

--- a/frontend/src/features/backoffice/fleet_segments/NewFleetSegmentModal.js
+++ b/frontend/src/features/backoffice/fleet_segments/NewFleetSegmentModal.js
@@ -6,6 +6,7 @@ import { FleetSegmentInput, INPUT_TYPE, renderTagPickerValue } from '../tableCel
 import { useSelector } from 'react-redux'
 import { PrimaryButton } from '../../commonStyles/Buttons.style'
 import { cleanInputString } from '../../../utils/cleanInputString'
+import StyledModalHeader from '../../commonComponents/StyledModalHeader'
 
 // TODO Use Formik + Yup to handle and validate form
 export function NewFleetSegmentModal ({ faoAreasList, onCancel, onSubmit }) {
@@ -49,13 +50,13 @@ export function NewFleetSegmentModal ({ faoAreasList, onCancel, onSubmit }) {
       size={'xs'}
       style={{ marginTop: 50 }}
     >
-      <Modal.Header>
+      <StyledModalHeader>
         <Modal.Title>
           <Title>
             Ajouter un segment de flotte
           </Title>
         </Modal.Title>
-      </Modal.Header>
+      </StyledModalHeader>
       <Body>
         <Columns>
           <Column>

--- a/frontend/src/features/backoffice/tableCells.js
+++ b/frontend/src/features/backoffice/tableCells.js
@@ -172,6 +172,7 @@ export const TagPickerCell = ({ rowData, dataKey, data, id, onChange, ...props }
       {
         isOpened
           ? <TagPicker
+            virtualized
             searchable
             value={rowData[dataKey]}
             style={tagPickerStyle}

--- a/frontend/src/features/commonComponents/StyledModalHeader.js
+++ b/frontend/src/features/commonComponents/StyledModalHeader.js
@@ -1,0 +1,34 @@
+import styled from 'styled-components'
+import Modal from 'rsuite/Modal'
+
+const StyledModalHeader = styled(Modal.Header)`
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  padding: ${props => props.isFull ? '5px 14px 8px 14px' : '4px 14px 5px 14px'};
+  background: #3B4559;
+
+  .rs-modal-title {
+    color: #F0F0F0;
+    font-size: ${props => props.isFull ? 22 : 16}px;
+    font-weight: normal;
+  }
+
+  .rs-modal-header-close {
+    right: 13px;
+    top: 10px;
+    color: #E5E5EB;
+    margin: unset;
+    padding: unset;
+
+    :hover {
+      right: 13px;
+    }
+  }
+
+  .rs-icon {
+    width: 21px;
+    height: 21px;
+  }
+`
+
+export default StyledModalHeader

--- a/frontend/src/features/commonStyles/Backoffice.style.js
+++ b/frontend/src/features/commonStyles/Backoffice.style.js
@@ -96,7 +96,7 @@ export const CustomCheckbox = styled(Checkbox)`
   .rs-checkbox-checker {
     padding-top: 0px !important;
     padding-left: 24px !important;
-} 
+}
 `
 
 export const customRadioGroup = css`
@@ -105,7 +105,7 @@ export const customRadioGroup = css`
   align-items: center;
 `
 
-export const AuthorizedRadio = styled(RadioGroup)` 
+export const AuthorizedRadio = styled(RadioGroup)`
   ${customRadioGroup}
 `
 

--- a/frontend/src/features/map/overlays/map_menu/TrackRangeModal.js
+++ b/frontend/src/features/map/overlays/map_menu/TrackRangeModal.js
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 import { COLORS } from '../../../../constants/constants'
 import { Modal } from 'rsuite'
 import DateRange from '../../../vessel_sidebar/actions/track_request/DateRange'
+import StyledModalHeader from '../../../commonComponents/StyledModalHeader'
 
 /**
  * @typedef {object} TrackRangeModalProps
@@ -23,13 +24,13 @@ export const TrackRangeModal = ({ isOpen, onChange, onClose, selectedDates }) =>
       size={'xs'}
       style={{ marginTop: 100 }}
     >
-      <Modal.Header>
+      <StyledModalHeader>
         <Modal.Title>
           <Title>
             Afficher la piste VMS sur une période précise
           </Title>
         </Modal.Title>
-      </Modal.Header>
+      </StyledModalHeader>
       <Body>
         <DateRange
           defaultValue={selectedDates}

--- a/frontend/src/features/side_window/SideWindow.js
+++ b/frontend/src/features/side_window/SideWindow.js
@@ -246,6 +246,13 @@ const Wrapper = styled.div`
     background: ${COLORS.slateGray} 0% 0% no-repeat padding-box;
     top: 1px;
   }
+  .rs-toggle {
+    margin-right: 5px;
+    margin-left: 5px;
+  }
+  .rs-toggle > input {
+    width: unset;
+  }
 
   .rs-list-item {
     box-shadow: unset;

--- a/frontend/src/features/side_window/beacon_malfunctions/BeaconMalfunctionDetailsFollowUp.js
+++ b/frontend/src/features/side_window/beacon_malfunctions/BeaconMalfunctionDetailsFollowUp.js
@@ -220,7 +220,6 @@ const BeaconMalfunctionDetailsFollowUp = ({ beaconMalfunctionWithDetails, smallS
             <SubmitCommentRow style={submitCommentRowStyle}>
               Équipe SIP
               <Toggle
-                style={{ background: `${userType === UserType.OPS ? '#C8DCE6' : COLORS.lightGray}` }}
                 value={userType === UserType.OPS}
                 onChange={checked => dispatch(setUserType(checked ? UserType.OPS : UserType.SIP))}
                 size="sm"

--- a/frontend/src/features/vessel_filters/SaveVesselFiltersModal.js
+++ b/frontend/src/features/vessel_filters/SaveVesselFiltersModal.js
@@ -7,6 +7,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { ReactComponent as FilterSVG } from '../icons/Icone_filtres_dark.svg'
 import { CirclePicker } from 'react-color'
 import TagList from './TagList'
+import StyledModalHeader from '../commonComponents/StyledModalHeader'
 
 const styles = {
   width: 200,
@@ -47,13 +48,13 @@ const SaveVesselFiltersModal = ({ isOpen, setIsOpen, filters, addFilter, closeAn
       style={{ marginTop: 100 }}
       onClose={cancel}
     >
-      <Modal.Header>
+      <StyledModalHeader>
         <Modal.Title>
           <Title>
             Enregistrer le filtre
           </Title>
         </Modal.Title>
-      </Modal.Header>
+      </StyledModalHeader>
       <Modal.Body>
         <InputGroup inside style={styles}>
           <InputGroup.Addon>
@@ -130,7 +131,7 @@ const SaveButton = styled.button`
   font-size: 13px;
   color: ${COLORS.gainsboro};
   float: right;
-  
+
   :hover {
     background: ${COLORS.charcoal};
   }
@@ -144,7 +145,7 @@ const CancelButton = styled.button`
   color: ${COLORS.gunMetal};
   margin: -28px 0px 20px 10px;
   float: right;
-  
+
   :disabled {
     border: 1px solid ${COLORS.lightGray};
     color: ${COLORS.lightGray};

--- a/frontend/src/features/vessel_list/DownloadVesselListModal.js
+++ b/frontend/src/features/vessel_list/DownloadVesselListModal.js
@@ -9,6 +9,7 @@ import { CSVOptions } from './dataFormatting'
 import { OPENLAYERS_PROJECTION } from '../../domain/entities/map'
 import { getCoordinates } from '../../coordinates'
 import { useSelector } from 'react-redux'
+import StyledModalHeader from '../commonComponents/StyledModalHeader'
 
 const optionsCSV = {
   fieldSeparator: ',',
@@ -111,13 +112,13 @@ const DownloadVesselListModal = ({ filteredVessels, isOpen, setIsOpen }) => {
       style={{ marginTop: 100 }}
       onClose={() => setIsOpen(false)}
     >
-      <Modal.Header>
+      <StyledModalHeader>
         <Modal.Title>
           <Title>
             Télécharger la liste des navires
           </Title>
         </Modal.Title>
-      </Modal.Header>
+      </StyledModalHeader>
       <Modal.Body>
         <Description>Sélectionnez les colonnes à télécharger</Description>
         <StyledCheckboxGroup
@@ -208,7 +209,7 @@ const DownloadButton = styled.button`
   margin: 20px 20px 20px 10px;
   font-size: 13px;
   color: ${COLORS.gainsboro};
-  
+
   :hover {
     background: ${COLORS.charcoal};
   }

--- a/frontend/src/features/vessel_list/VesselList.js
+++ b/frontend/src/features/vessel_list/VesselList.js
@@ -35,6 +35,7 @@ import { ReactComponent as PreviewSVG } from '../icons/Oeil_apercu_carte.svg'
 import { setProcessingRegulationSearchedZoneExtent } from '../../domain/shared_slices/Regulatory'
 import { getExtentFromGeoJSON } from '../../utils'
 import { COLORS } from '../../constants/constants'
+import StyledModalHeader from '../commonComponents/StyledModalHeader'
 
 const NOT_FOUND = -1
 
@@ -339,14 +340,14 @@ const VesselList = ({ namespace }) => {
           open={vesselListModalIsOpen}
           onClose={() => closeAndResetVesselList()}
         >
-          <Modal.Header>
+          <StyledModalHeader isFull>
             <Modal.Title>
               <Vessel
                 isTitle={true}
                 background={COLORS.charcoal}
               /> Liste des navires avec VMS
             </Modal.Title>
-          </Modal.Header>
+          </StyledModalHeader>
           <Modal.Body>
             <Title>FILTRER LA LISTE</Title>
             <VesselListFilters

--- a/frontend/src/features/vessel_list/VesselListTable.js
+++ b/frontend/src/features/vessel_list/VesselListTable.js
@@ -1,10 +1,17 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import styled from 'styled-components'
 import { useSelector } from 'react-redux'
 import { Checkbox, Table } from 'rsuite'
 
 import { ReactComponent as FlagSVG } from '../icons/flag.svg'
-import { CellUsingVesselProperty, ContentWithEllipsis, CellWithTitle, CheckedCell, FlagCell, TimeAgoCell } from './tableCells'
+import {
+  CellUsingVesselProperty,
+  CellWithTitle,
+  CheckedCell,
+  ContentWithEllipsis,
+  FlagCell, StyledCheckbox,
+  TimeAgoCell
+} from './tableCells'
 import { sortVesselsByProperty } from './tableSort'
 import { COLORS } from '../../constants/constants'
 
@@ -34,7 +41,7 @@ const VesselListTable = ({
     setSortType(sortType)
   }
 
-  const getVessels = useCallback(() => {
+  const showedVessels = useMemo(() => {
     if (sortColumn && sortType) {
       return filteredVessels
         .slice()
@@ -63,7 +70,7 @@ const VesselListTable = ({
         virtualized
         height={seeMoreIsOpen ? 480 : 530}
         rowHeight={36}
-        data={getVessels()}
+        data={showedVessels}
         sortColumn={sortColumn}
         sortType={sortType}
         onSortColumn={handleSortColumn}
@@ -75,7 +82,7 @@ const VesselListTable = ({
       >
         <Column resizable width={35} fixed>
           <HeaderCell>
-            <Checkbox
+            <StyledCheckbox
               checked={allVesselsChecked.globalCheckbox && vessels.filter(vessel => vessel.checked === true).length === vessels.length}
               onChange={() => updateAllVesselsChecked()} />
           </HeaderCell>
@@ -181,7 +188,22 @@ const VesselListTable = ({
   )
 }
 
-const TableContent = styled.div``
+const TableContent = styled.div`
+  .rs-table-cell-header-icon-sort {
+    color: ${COLORS.slateGray};
+    position: absolute;
+    right: 0px;
+    top: 13px;
+  }
+
+  .rs-table-cell-header-icon-sort-asc::after {
+    color: ${COLORS.slateGray};
+  }
+
+  .rs-table-cell-header-icon-sort-desc::after {
+    color: ${COLORS.slateGray};
+  }
+`
 
 const VesselsCount = styled.span`
   color: ${COLORS.slateGray};

--- a/frontend/src/features/vessel_list/tableCells.js
+++ b/frontend/src/features/vessel_list/tableCells.js
@@ -18,7 +18,7 @@ export const CheckedCell = ({ rowData, dataKey, onChange, ...props }) => {
 
   return (
     <Cell key={defaultValue} {...props} className={'table-content-editing'} >
-      <Checkbox
+      <StyledCheckbox
         defaultValue={defaultValue}
         defaultChecked={defaultChecked}
         onChange={value => {
@@ -28,6 +28,11 @@ export const CheckedCell = ({ rowData, dataKey, onChange, ...props }) => {
     </Cell>
   )
 }
+
+export const StyledCheckbox = styled(Checkbox)`
+  margin-top: -33px;
+  margin-left: -10px;
+`
 
 export const FlagCell = ({ rowData, vesselProperty, baseUrl, ...props }) => (
   <Cell {...props} style={{ padding: 0 }}>

--- a/frontend/src/features/vessel_sidebar/actions/track_request/DateRange.js
+++ b/frontend/src/features/vessel_sidebar/actions/track_request/DateRange.js
@@ -96,6 +96,13 @@ const Wrapper = styled.div`
   .rs-picker-daterange {
     background: ${p => p.isEmpty ? COLORS.gainsboro : 'transparent'};
   }
+
+  input {
+    font-size: 13px;
+  }
+  .rs-picker-toggle-placeholder {
+    font-size: 13px;
+  }
 `
 
 export default DateRange

--- a/frontend/src/features/vessel_sidebar/reporting/current/ConfirmDeletionModal.js
+++ b/frontend/src/features/vessel_sidebar/reporting/current/ConfirmDeletionModal.js
@@ -6,6 +6,7 @@ import { COLORS } from '../../../../constants/constants'
 import { CancelButton, ValidateButton } from '../../../commonStyles/Buttons.style'
 import { Modal } from 'rsuite'
 import deleteReporting from '../../../../domain/use_cases/reporting/deleteReporting'
+import StyledModalHeader from '../../../commonComponents/StyledModalHeader'
 
 const ConfirmDeletionModal = ({ modalIsOpenForId, closeModal }) => {
   const dispatch = useDispatch()
@@ -18,13 +19,13 @@ const ConfirmDeletionModal = ({ modalIsOpenForId, closeModal }) => {
       style={{ marginTop: 100 }}
       onClose={closeModal}
     >
-      <Modal.Header>
+      <StyledModalHeader>
         <Modal.Title>
           <Title>
             Voulez-vous supprimer le signalement ?
           </Title>
         </Modal.Title>
-      </Modal.Header>
+      </StyledModalHeader>
       <Body>
         <FooterButton>
           <ValidateButton

--- a/frontend/src/features/vessel_sidebar/risk_factor/RiskFactorExplanationModal.js
+++ b/frontend/src/features/vessel_sidebar/risk_factor/RiskFactorExplanationModal.js
@@ -14,6 +14,7 @@ import {
   getRiskFactorColor
 } from '../../../domain/entities/riskFactor'
 import { basePrimaryButton, SecondaryButton } from '../../commonStyles/Buttons.style'
+import StyledModalHeader from '../../commonComponents/StyledModalHeader'
 
 const RiskFactorExplanationModal = ({ isOpen, setIsOpen }) => {
   return (
@@ -24,13 +25,13 @@ const RiskFactorExplanationModal = ({ isOpen, setIsOpen }) => {
       style={{ marginTop: 50 }}
       onClose={() => setIsOpen(false)}
     >
-      <Modal.Header>
+      <StyledModalHeader>
         <Modal.Title>
           <ModalTitle>
             Explication de la note de risque des navires
           </ModalTitle>
         </Modal.Title>
-      </Modal.Header>
+      </StyledModalHeader>
       <ModalBodyStyled>
         <Title>principe du facteur de risque</Title>
         <Line/>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -79,12 +79,12 @@ code {
     background: #3B4559;
 }
 
-.rs-slider-graduator > ul > li::before {
+.rs-slider-graduator > ol > li::before {
     visibility: hidden;
 }
 
 
-.rs-slider-graduator > ul > li:last-child::after, .rs-slider-graduator > ul > li::before {
+.rs-slider-graduator > ol > li:last-child::after, .rs-slider-graduator > ul > li::before {
     top: -3px;
     border: none;
 }


### PR DESCRIPTION
Pour ne pas bloquer la prochaine MEP (mercredi 27), j'ai fait les changements pour fix les points remontés sur la revue https://github.com/MTES-MCT/monitorfish/pull/1226#pullrequestreview-1033950198
Cela nous permet à court terme de ne pas avoir de régression sur les composants rsuite suite au passage à la v5, par contre il faudra sortir les styles proprement par la suite, en remboursant cette dette technique.

@ivangabriele Pourrais-tu regarder cette PR ?

----

- [ ] Tests E2E (Cypress)
