### PR TITLE
Add other info to regulations table

### DIFF
--- a/backend/src/main/resources/db/migration/layers/V0.157__Update_regulations_table.sql
+++ b/backend/src/main/resources/db/migration/layers/V0.157__Update_regulations_table.sql
@@ -1,6 +1,8 @@
 ALTER TABLE public.regulations
     ADD COLUMN other_info varchar;
 
+DROP VIEW regulations_view;
+
 CREATE OR REPLACE VIEW regulations_view AS
 SELECT id,
        law_type,

--- a/backend/src/main/resources/db/migration/layers/V0.157__Update_regulations_table.sql
+++ b/backend/src/main/resources/db/migration/layers/V0.157__Update_regulations_table.sql
@@ -1,0 +1,22 @@
+ALTER TABLE public.regulations
+    ADD COLUMN other_info varchar;
+
+CREATE OR REPLACE VIEW regulations_view AS
+SELECT id,
+       law_type,
+       facade,
+       topic,
+       zone,
+       region,
+       other_info,
+       fishing_period,
+       species,
+       gears,
+       regulatory_references,
+       geometry_simplified,
+       row_hash,
+       next_id
+FROM regulations;
+
+ALTER TABLE regulations_view
+    RENAME COLUMN geometry_simplified to geometry;

--- a/datascience/src/pipeline/queries/cross/regulations.sql
+++ b/datascience/src/pipeline/queries/cross/regulations.sql
@@ -5,6 +5,7 @@ SELECT
     topic,
     zone,
     region,
+    other_info,
     fishing_period,
     gears,
     species,

--- a/frontend/cypress/e2e/backoffice_update_regulation.spec.ts
+++ b/frontend/cypress/e2e/backoffice_update_regulation.spec.ts
@@ -70,6 +70,7 @@ context('Update Regulation', () => {
     cy.get('[type="checkbox"]').eq(2).check({ force: true })
 
     // When save form
+    cy.get('[data-cy="regulatory-general-other-info"]').scrollIntoView().type('Une information générale')
     cy.get('[data-cy="validate-button"]').click()
     cy.wait(200)
 
@@ -79,6 +80,7 @@ context('Update Regulation', () => {
       expect(request.body).contain('<Value>Reg. MEMN</Value>')
       expect(request.body).contain('<Value>Praires Ouest cotentin</Value>')
       expect(request.body).contain('<Value>Normandie, Bretagne</Value>')
+      expect(request.body).contain('<Name>otherInfo</Name><Value>Une information générale</Value>')
       expect(request.body).contain('"reference":"texte de reference"')
       expect(request.body).contain(
         '"url":"http://legipeche.metier.i2/arrete-prefectoral-168-2020-modifie-delib-2020-pr-a10301.html?id_rub=634"',

--- a/frontend/src/domain/entities/regulatory.js
+++ b/frontend/src/domain/entities/regulatory.js
@@ -141,6 +141,7 @@ export const mapToRegulatoryFeatureObject = properties => {
     fishingPeriod,
     speciesRegulation,
     gearRegulation,
+    otherInfo,
     nextId
   } = properties
 
@@ -153,6 +154,7 @@ export const mapToRegulatoryFeatureObject = properties => {
     fishing_period: JSON.stringify(fishingPeriod),
     species: JSON.stringify(speciesRegulation),
     gears: JSON.stringify(gearRegulation),
+    otherInfo: otherInfo,
     next_id: nextId
   }
 }
@@ -329,14 +331,16 @@ export const REGULATORY_REFERENCE_KEYS = {
   REGULATORY_REFERENCES: 'regulatoryReferences',
   FISHING_PERIOD: 'fishingPeriod',
   SPECIES_REGULATION: 'speciesRegulation',
-  GEAR_REGULATION: 'gearRegulation'
+  GEAR_REGULATION: 'gearRegulation',
+  OTHER_INFO: 'otherInfo'
 }
 
 export const DEFAULT_REGULATION = {
   [REGULATORY_REFERENCE_KEYS.REGULATORY_REFERENCES]: [DEFAULT_REGULATORY_TEXT],
   [REGULATORY_REFERENCE_KEYS.FISHING_PERIOD]: DEFAULT_FISHING_PERIOD_VALUES,
   [REGULATORY_REFERENCE_KEYS.SPECIES_REGULATION]: DEFAULT_SPECIES_REGULATION,
-  [REGULATORY_REFERENCE_KEYS.GEAR_REGULATION]: DEFAULT_GEAR_REGULATION
+  [REGULATORY_REFERENCE_KEYS.GEAR_REGULATION]: DEFAULT_GEAR_REGULATION,
+  [REGULATORY_REFERENCE_KEYS.OTHER_INFO]: null
 }
 
 export const GEARS_CATEGORIES_WITH_MESH = [

--- a/frontend/src/features/backoffice/edit_regulation/EditRegulation.js
+++ b/frontend/src/features/backoffice/edit_regulation/EditRegulation.js
@@ -38,22 +38,29 @@ import createOrUpdateRegulation from '../../../domain/use_cases/layer/regulation
 
 import { formatDataForSelectPicker } from '../../../utils'
 import { CancelButton, ValidateButton } from '../../commonStyles/Buttons.style'
-import { Footer, FooterButton, Section, Title } from '../../commonStyles/Backoffice.style'
+import { Footer, FooterButton, OtherRemark, Section, Title } from '../../commonStyles/Backoffice.style'
 import {
   resetState,
   setAtLeastOneValueIsMissing,
   setIsConfirmModalOpen,
   setIsRemoveModalOpen,
   setProcessingRegulation,
-  setRegulationModified,
   setRegulatoryTextCheckedMap,
-  setSaveOrUpdateRegulation, setStatus
+  setSaveOrUpdateRegulation,
+  setStatus,
+  updateProcessingRegulationByKey
 } from '../Regulation.slice'
 import { setError } from '../../../domain/shared_slices/Global'
-import { DEFAULT_REGULATION, FRANCE, LAWTYPES_TO_TERRITORY } from '../../../domain/entities/regulatory'
+import {
+  DEFAULT_REGULATION,
+  FRANCE,
+  LAWTYPES_TO_TERRITORY,
+  REGULATORY_REFERENCE_KEYS
+} from '../../../domain/entities/regulatory'
 import SpeciesRegulation from './species_regulation/SpeciesRegulation'
 import getAllSpecies from '../../../domain/use_cases/species/getAllSpecies'
 import { STATUS } from '../constants'
+import { CustomInput, Label } from '../../commonStyles/Input.style'
 
 const EditRegulation = ({ title, isEdition }) => {
   const dispatch = useDispatch()
@@ -98,7 +105,8 @@ const EditRegulation = ({ title, isEdition }) => {
     zone,
     region,
     id,
-    regulatoryReferences
+    regulatoryReferences,
+    otherInfo
   } = processingRegulation
 
   useEffect(() => {
@@ -238,6 +246,13 @@ const EditRegulation = ({ title, isEdition }) => {
       })
   }
 
+  const setOtherInfo = value => {
+    dispatch(updateProcessingRegulationByKey({
+      key: REGULATORY_REFERENCE_KEYS.OTHER_INFO,
+      value
+    }))
+  }
+
   return (
     <>
     <Wrapper>
@@ -287,6 +302,19 @@ const EditRegulation = ({ title, isEdition }) => {
             <FishingPeriodSection />
             <SpeciesRegulation />
             <GearRegulation />
+            <OtherRemark show>
+              <Label>Remarques générales</Label>
+              <CustomInput
+                data-cy={'regulatory-general-other-info'}
+                as="textarea"
+                rows={2}
+                placeholder=''
+                value={otherInfo || ''}
+                onChange={event => setOtherInfo(event.target.value)}
+                width={'500px'}
+                $isGray={otherInfo && otherInfo !== ''}
+              />
+            </OtherRemark>
           </ContentWrapper>
         </Body>
         <Footer>

--- a/frontend/src/features/backoffice/edit_regulation/custom_form/CustomSelectComponent.js
+++ b/frontend/src/features/backoffice/edit_regulation/custom_form/CustomSelectComponent.js
@@ -85,7 +85,7 @@ const CustomSelectPicker = styled(SelectPicker)`
   }
 
   .rs-picker-toggle {
-    width: ${p => p.width ? p.width - 40 : 160};
+    width: ${p => p.width ? p.width - 40 : 160}px;
   }
 `
 

--- a/frontend/src/features/backoffice/edit_regulation/fishing_period/FishingPeriodSection.js
+++ b/frontend/src/features/backoffice/edit_regulation/fishing_period/FishingPeriodSection.js
@@ -26,7 +26,7 @@ const FishingPeriodSection = () => {
       fishingPeriod={fishingPeriod}
     />
     <OtherRemark show={show}>
-      <Label>Remarques générales</Label>
+      <Label>Remarques</Label>
       <CustomInput
         as="textarea"
         rows={2}

--- a/frontend/src/features/backoffice/edit_regulation/gear_regulation/GearRegulation.js
+++ b/frontend/src/features/backoffice/edit_regulation/gear_regulation/GearRegulation.js
@@ -88,7 +88,7 @@ const GearRegulation = () => {
       />
     </RegulatedGearsForms>
     <OtherRemark show={show}>
-      <Label>Remarques générales</Label>
+      <Label>Remarques</Label>
       <CustomInput
         as="textarea"
         rows={2}

--- a/frontend/src/features/backoffice/edit_regulation/species_regulation/SpeciesRegulation.js
+++ b/frontend/src/features/backoffice/edit_regulation/species_regulation/SpeciesRegulation.js
@@ -98,7 +98,7 @@ const SpeciesRegulation = () => {
       />
     </RegulatedSpeciesForms>
     <OtherRemark show={show}>
-      <Label>Remarques générales</Label>
+      <Label>Remarques</Label>
       <CustomInput
         data-cy={'regulatory-species-other-info'}
         as="textarea"

--- a/infra/local/md5_trigger_function.sql
+++ b/infra/local/md5_trigger_function.sql
@@ -14,6 +14,7 @@ BEGIN
         COALESCE(NEW.topic::text, '') ||
         COALESCE(NEW.zone::text, '') ||
         COALESCE(NEW.region::text, '') ||
+        COALESCE(NEW.other_info::text, '') ||
         COALESCE(NEW.fishing_period::text, '') ||
         COALESCE(NEW.species::text, '') ||
         COALESCE(NEW.gears::text, '') ||


### PR DESCRIPTION
## Linked issues

- Resolve #1329 

### Exécuter au CROSS

Migration:
```
ALTER TABLE public.regulations
    ADD COLUMN other_info varchar;

CREATE OR REPLACE VIEW regulations_view AS
SELECT id,
       law_type,
       facade,
       topic,
       zone,
       region,
       other_info,
       fishing_period,
       species,
       gears,
       regulatory_references,
       geometry_simplified,
       row_hash,
       next_id
FROM regulations;

ALTER TABLE regulations_view
    RENAME COLUMN geometry_simplified to geometry;
```

Trigger :
```
DROP FUNCTION IF EXISTS prod.compute_reglementation_md5 CASCADE;

CREATE FUNCTION prod.compute_regulations_md5() RETURNS trigger AS $$
BEGIN
    NEW.row_hash := md5(
        COALESCE(NEW.law_type::text, '') ||
        COALESCE(NEW.facade::text, '') ||
        COALESCE(NEW.topic::text, '') ||
        COALESCE(NEW.zone::text, '') ||
        COALESCE(NEW.region::text, '') ||
        COALESCE(NEW.other_info::text, '') ||
        COALESCE(NEW.fishing_period::text, '') ||
        COALESCE(NEW.species::text, '') ||
        COALESCE(NEW.gears::text, '') ||
        COALESCE(NEW.regulatory_details::text, '') ||
        COALESCE(NEW.regulatory_references::text, '') ||
        COALESCE(NEW.geometry::text, '')  ||
        COALESCE(NEW.next_id::text, '')
        );
    RETURN NEW;
END;
$$ LANGUAGE plpgsql;

CREATE TRIGGER compute_regulations_md5
    BEFORE INSERT OR UPDATE ON prod.regulations
    FOR EACH ROW
EXECUTE PROCEDURE prod.compute_regulations_md5();
```

----

- [ ] Tests E2E (Cypress)
