### PR TITLE
[Missions] Affichage des contrôles du formulaire sur la cartographie et nombre d'étiquettes

### DIFF
--- a/frontend/src/domain/entities/controls.ts
+++ b/frontend/src/domain/entities/controls.ts
@@ -2,6 +2,8 @@ import { customDayjs } from '@mtes-mct/monitor-ui'
 
 import { MissionAction } from '../types/missionAction'
 
+import type { MissionActionFormValues } from '../../features/SideWindow/MissionForm/types'
+
 import InfractionType = MissionAction.InfractionType
 
 export const INITIAL_LAST_CONTROLS: MissionAction.LastControls = {
@@ -72,23 +74,27 @@ export const getYearsToActions = (
 /**
  * Get the number of infractions in a control - Take care of infractions without NATINF
  */
-export const getNumberOfInfractions = (control: MissionAction.MissionAction | undefined): number => {
+export const getNumberOfInfractions = (
+  control: MissionAction.MissionAction | MissionActionFormValues | undefined
+): number => {
   if (!control) {
     return 0
   }
 
   return (
-    control.gearInfractions.length +
-    control.logbookInfractions.length +
-    control.speciesInfractions.length +
-    control.otherInfractions.length
+    (control.gearInfractions?.length || 0) +
+    (control.logbookInfractions?.length || 0) +
+    (control.speciesInfractions?.length || 0) +
+    (control.otherInfractions?.length || 0)
   )
 }
 
 /**
  * Get the number of infractions with records in a control
  */
-export const getNumberOfInfractionsWithRecord = (control: MissionAction.MissionAction | undefined): number => {
+export const getNumberOfInfractionsWithRecord = (
+  control: MissionAction.MissionAction | MissionActionFormValues | undefined
+): number => {
   if (!control) {
     return 0
   }
@@ -96,10 +102,10 @@ export const getNumberOfInfractionsWithRecord = (control: MissionAction.MissionA
   const infractionWithRecordFilter = infraction => infraction.infractionType === InfractionType.WITH_RECORD
 
   return (
-    control.gearInfractions.filter(infractionWithRecordFilter).length +
-    control.logbookInfractions.filter(infractionWithRecordFilter).length +
-    control.speciesInfractions.filter(infractionWithRecordFilter).length +
-    control.otherInfractions.filter(infractionWithRecordFilter).length
+    (control.gearInfractions?.filter(infractionWithRecordFilter).length || 0) +
+    (control.logbookInfractions?.filter(infractionWithRecordFilter).length || 0) +
+    (control.speciesInfractions?.filter(infractionWithRecordFilter).length || 0) +
+    (control.otherInfractions?.filter(infractionWithRecordFilter).length || 0)
   )
 }
 

--- a/frontend/src/domain/use_cases/draw/addFeatureToDrawedFeature.ts
+++ b/frontend/src/domain/use_cases/draw/addFeatureToDrawedFeature.ts
@@ -13,14 +13,14 @@ export const addFeatureToDrawedFeature = (featureToAdd: Feature<Geometry>) => (d
     return
   }
 
+  if (geometryToAdd.getType() === OpenLayersGeometryType.POINT) {
+    const nextGeometry = convertToGeoJSONGeometryObject(geometryToAdd)
+    dispatch(setGeometry(nextGeometry))
+
+    return
+  }
+
   if (!geometry) {
-    if (geometryToAdd.getType() === OpenLayersGeometryType.POINT) {
-      const nextGeometry = convertToGeoJSONGeometryObject(geometryToAdd)
-      dispatch(setGeometry(nextGeometry))
-
-      return
-    }
-
     // @ts-ignore
     const nextGeometry = convertToGeoJSONGeometryObject(new MultiPolygon([geometryToAdd]))
     dispatch(setGeometry(nextGeometry))
@@ -28,8 +28,8 @@ export const addFeatureToDrawedFeature = (featureToAdd: Feature<Geometry>) => (d
     return
   }
 
-  const nextGeometry = addGeometryToMultiPolygonGeoJSON(geometry, geometryToAdd)
-  if (nextGeometry) {
-    dispatch(setGeometry(nextGeometry))
+  const nextGeometryTwo = addGeometryToMultiPolygonGeoJSON(geometry, geometryToAdd)
+  if (nextGeometryTwo) {
+    dispatch(setGeometry(nextGeometryTwo))
   }
 }

--- a/frontend/src/domain/use_cases/map/fitMultiPolygonToExtent.ts
+++ b/frontend/src/domain/use_cases/map/fitMultiPolygonToExtent.ts
@@ -10,7 +10,7 @@ import type { Coordinate } from 'ol/coordinate'
 import type { MultiPolygon } from 'ol/geom'
 
 export const fitMultiPolygonToExtent = (geometry: GeoJSONNamespace.Geometry | undefined) => dispatch => {
-  if (!geometry) {
+  if (!(geometry as GeoJSONNamespace.MultiPolygon)?.coordinates?.length) {
     return
   }
 
@@ -19,6 +19,10 @@ export const fitMultiPolygonToExtent = (geometry: GeoJSONNamespace.Geometry | un
   }).readGeometry(geometry)
 
   const coordinates = (geometryObject as MultiPolygon).getCoordinates()
+  const extent = boundingExtent(flattenDepth<Coordinate>(coordinates, 2))
+  if (!extent) {
+    return
+  }
 
-  dispatch(fitToExtent(boundingExtent(flattenDepth<Coordinate>(coordinates, 2))))
+  dispatch(fitToExtent(extent))
 }

--- a/frontend/src/features/SideWindow/MissionForm/MainForm/FormikLocationPicker.tsx
+++ b/frontend/src/features/SideWindow/MissionForm/MainForm/FormikLocationPicker.tsx
@@ -61,6 +61,9 @@ export function FormikLocationPicker() {
       }
 
       const extent = transformExtent(boundingExtent(firstRing), WSG84_PROJECTION, OPENLAYERS_PROJECTION)
+      if (!extent) {
+        return
+      }
 
       dispatch(fitToExtent(extent))
     },

--- a/frontend/src/features/map/layers/Mission/MissionsLabelsLayer/utils.ts
+++ b/frontend/src/features/map/layers/Mission/MissionsLabelsLayer/utils.ts
@@ -4,7 +4,7 @@ import { drawMovedLabelLine } from '../../../../../domain/entities/vessel/label'
 import type { ControlUnit } from '../../../../../domain/types/controlUnit'
 
 const NOT_FOUND = -1
-const MAX_MISSIONS_LABELS_DISPLAYED = 100
+const MAX_MISSIONS_LABELS_DISPLAYED = 15
 
 export function getFeaturesAndLabels(featureIdToCoordinates, feature, labelLineFeatureId) {
   const controlUnits = feature.get('controlUnits') as ControlUnit.ControlUnit[]

--- a/frontend/src/features/map/layers/Mission/SelectedMissionActionsLayer/index.tsx
+++ b/frontend/src/features/map/layers/Mission/SelectedMissionActionsLayer/index.tsx
@@ -5,7 +5,7 @@ import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import { selectedMissionActionsStyles } from './styles'
 import { LayerProperties } from '../../../../../domain/entities/layers/constants'
 import { MonitorFishLayer } from '../../../../../domain/entities/layers/types'
-import { getMissionActionFeature } from '../../../../../domain/entities/mission'
+import { getMissionActionFeature, getMissionActionFeatures } from '../../../../../domain/entities/mission'
 import { useGetFilteredMissionsQuery } from '../../../../../domain/entities/mission/hooks/useGetFilteredMissionsQuery'
 import { useMainAppSelector } from '../../../../../hooks/useMainAppSelector'
 
@@ -16,7 +16,7 @@ import type { MutableRefObject } from 'react'
 
 export function UnmemoizedSelectedMissionActionsLayer({ map }) {
   const { missions } = useGetFilteredMissionsQuery()
-  const selectedMissionGeoJSON = useMainAppSelector(store => store.mission.selectedMissionGeoJSON)
+  const { draft, draftId, selectedMissionGeoJSON } = useMainAppSelector(store => store.mission)
   const selectedMissionActions = useMemo(() => {
     if (!selectedMissionGeoJSON) {
       return []
@@ -76,6 +76,16 @@ export function UnmemoizedSelectedMissionActionsLayer({ map }) {
 
     getVectorSource().addFeatures(selectedMissionActions)
   }, [selectedMissionActions, getVectorSource])
+
+  useEffect(() => {
+    getVectorSource().clear(true)
+    if (!draft || !draftId) {
+      return
+    }
+
+    const actionFeatures = getMissionActionFeatures({ ...draft, id: draftId })
+    getVectorSource().addFeatures(actionFeatures)
+  }, [draft, draftId, getVectorSource])
 
   return null
 }

--- a/frontend/src/features/map/layers/Mission/SelectedMissionLayer.tsx
+++ b/frontend/src/features/map/layers/Mission/SelectedMissionLayer.tsx
@@ -7,7 +7,7 @@ import { missionZoneStyle } from './MissionLayer/styles'
 import { LayerProperties } from '../../../../domain/entities/layers/constants'
 import { MonitorFishLayer } from '../../../../domain/entities/layers/types'
 import { OPENLAYERS_PROJECTION } from '../../../../domain/entities/map/constants'
-import { getMissionFeatureZone, getMissionFeatureZoneFromDraft } from '../../../../domain/entities/mission'
+import { getMissionFeatureZone } from '../../../../domain/entities/mission'
 import { useGetFilteredMissionsQuery } from '../../../../domain/entities/mission/hooks/useGetFilteredMissionsQuery'
 import { useMainAppSelector } from '../../../../hooks/useMainAppSelector'
 
@@ -90,7 +90,7 @@ export function UnmemoizedSelectedMissionLayer({ map }) {
       return
     }
 
-    const missionFeature = getMissionFeatureZoneFromDraft({ ...draft, id: draftId })
+    const missionFeature = getMissionFeatureZone({ ...draft, id: draftId })
     getVectorSource().addFeature(missionFeature)
   }, [draft, draftId, getVectorSource])
 

--- a/frontend/src/features/map/overlays/ControlOverlay/ControlDetails.tsx
+++ b/frontend/src/features/map/overlays/ControlOverlay/ControlDetails.tsx
@@ -131,11 +131,12 @@ const CloseButton = styled(IconButton)`
 
 const Details = styled.div`
   color: ${p => p.theme.color.slateGray};
+  margin-top: 4px;
 `
 
 const SeizureOrInfractions = styled.div`
   line-height: 22px;
-  margin-top: 6px;
+  margin-top: 8px;
   margin-bottom: 6px;
   color: ${p => p.theme.color.slateGray};
   white-space: nowrap;

--- a/frontend/src/features/map/overlays/MissionUnitLabelOverlay/MissionUnitLabel.tsx
+++ b/frontend/src/features/map/overlays/MissionUnitLabelOverlay/MissionUnitLabel.tsx
@@ -19,20 +19,19 @@ const Wrapper = styled.div<{
   box-shadow: 0px 2px 3px #70778580;
   line-height: 20px;
   cursor: grabbing;
-  height: 22px;
+  height: 20px;
   display: flex;
   border-radius: 1px;
   background-color: ${p => p.color};
 `
 
 const ZoneText = styled.span`
-  margin: 2px 8px 3px 8px;
-  font-size: 13px;
+  margin: 0px 6px 3px 6px;
+  font-size: 11px;
   font-weight: 500;
   user-select: none;
   color: ${p => p.theme.color.white};
   line-height: 17px;
-  vertical-align: middle;
   max-width: 250px;
   text-overflow: ellipsis;
   overflow: hidden;


### PR DESCRIPTION
## Linked issues

- #1780 
  - Modifier la position du contrôle sur la carto en temps réél quand on change la valeur du champ Coordonnées dans le formulaire du contrôle
  - Lors de la modification d'un point de contrôle, remplacer le point précédent avec le nouveau point 
- #1743
  - Taille des étiquettes des missions
  - Nombre d'étiquette max affichée (15 au lieu de 100)

----

- [ ] Tests E2E (Cypress)
