### PR TITLE
[Contrôles] Correction de la sauvegarde du champ `is_from_poseidon`

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/mission_actions/MissionAction.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/mission_actions/MissionAction.kt
@@ -48,6 +48,7 @@ data class MissionAction(
     val otherComments: String? = null,
     val gearOnboard: List<GearControl> = listOf(),
     val speciesOnboard: List<SpeciesControl> = listOf(),
+    val isFromPoseidon: Boolean,
     var controlUnits: List<ControlUnit> = listOf(),
     var isDeleted: Boolean,
     var hasSomeGearsSeized: Boolean,

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/input/AddMissionActionDataInput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/input/AddMissionActionDataInput.kt
@@ -48,6 +48,7 @@ data class AddMissionActionDataInput(
     var hasSomeGearsSeized: Boolean = false,
     var hasSomeSpeciesSeized: Boolean = false,
     var closedBy: String? = null,
+    val isFromPoseidon: Boolean? = null,
 ) {
     fun toMissionAction() = MissionAction(
         vesselId = vesselId,
@@ -95,5 +96,6 @@ data class AddMissionActionDataInput(
         hasSomeGearsSeized = hasSomeGearsSeized,
         hasSomeSpeciesSeized = hasSomeSpeciesSeized,
         closedBy = closedBy,
+        isFromPoseidon = isFromPoseidon ?: false,
     )
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/outputs/MissionActionDataOutput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/outputs/MissionActionDataOutput.kt
@@ -52,6 +52,7 @@ data class MissionActionDataOutput(
     val hasSomeGearsSeized: Boolean,
     val hasSomeSpeciesSeized: Boolean,
     val closedBy: String? = null,
+    val isFromPoseidon: Boolean,
 ) {
     companion object {
         fun fromMissionAction(missionAction: MissionAction) = MissionActionDataOutput(
@@ -102,6 +103,7 @@ data class MissionActionDataOutput(
             hasSomeGearsSeized = missionAction.hasSomeGearsSeized,
             hasSomeSpeciesSeized = missionAction.hasSomeSpeciesSeized,
             closedBy = missionAction.closedBy,
+            isFromPoseidon = missionAction.isFromPoseidon,
         )
     }
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/MissionActionEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/MissionActionEntity.kt
@@ -174,7 +174,7 @@ class MissionActionEntity(
                 otherComments = missionAction.otherComments,
                 gearOnboard = mapper.writeValueAsString(missionAction.gearOnboard),
                 speciesOnboard = mapper.writeValueAsString(missionAction.speciesOnboard),
-                isFromPoseidon = false,
+                isFromPoseidon = missionAction.isFromPoseidon,
                 isDeleted = missionAction.isDeleted,
                 hasSomeGearsSeized = missionAction.hasSomeGearsSeized,
                 hasSomeSpeciesSeized = missionAction.hasSomeSpeciesSeized,
@@ -229,6 +229,7 @@ class MissionActionEntity(
         hasSomeGearsSeized = hasSomeGearsSeized,
         hasSomeSpeciesSeized = hasSomeSpeciesSeized,
         closedBy = closedBy,
+        isFromPoseidon = isFromPoseidon,
     )
 
     private fun <T> deserializeJSONList(mapper: ObjectMapper, json: String?, clazz: Class<T>): List<T> = json?.let {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/mission_actions/MissionActionUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/mission_actions/MissionActionUTests.kt
@@ -29,6 +29,7 @@ class MissionActionUTests {
             hasSomeGearsSeized = false,
             hasSomeSpeciesSeized = false,
             closedBy = "XYZ",
+            isFromPoseidon = false,
         )
 
         // When
@@ -57,6 +58,7 @@ class MissionActionUTests {
             hasSomeGearsSeized = false,
             hasSomeSpeciesSeized = false,
             closedBy = "XYZ",
+            isFromPoseidon = false,
         )
 
         // When
@@ -89,6 +91,7 @@ class MissionActionUTests {
             hasSomeGearsSeized = false,
             hasSomeSpeciesSeized = false,
             closedBy = "XYZ",
+            isFromPoseidon = false,
         )
 
         // When
@@ -118,6 +121,7 @@ class MissionActionUTests {
             hasSomeGearsSeized = false,
             hasSomeSpeciesSeized = false,
             closedBy = "XYZ",
+            isFromPoseidon = false,
         )
 
         // When
@@ -147,6 +151,7 @@ class MissionActionUTests {
             hasSomeGearsSeized = false,
             hasSomeSpeciesSeized = false,
             closedBy = "XYZ",
+            isFromPoseidon = false,
         )
 
         // When

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission_actions/AddMissionActionUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission_actions/AddMissionActionUTests.kt
@@ -45,6 +45,7 @@ class AddMissionActionUTests {
             hasSomeGearsSeized = false,
             hasSomeSpeciesSeized = false,
             closedBy = "XYZ",
+            isFromPoseidon = false,
         )
 
         // When
@@ -77,6 +78,7 @@ class AddMissionActionUTests {
             hasSomeGearsSeized = false,
             hasSomeSpeciesSeized = false,
             closedBy = "XYZ",
+            isFromPoseidon = false,
         )
         given(missionActionsRepository.save(anyOrNull())).willReturn(action)
         given(getMissionActionFacade.execute(anyOrNull())).willReturn(Facade.NAMO)

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission_actions/DeleteMissionActionUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission_actions/DeleteMissionActionUTests.kt
@@ -34,6 +34,7 @@ class DeleteMissionActionUTests {
             hasSomeGearsSeized = false,
             hasSomeSpeciesSeized = false,
             closedBy = "XYZ",
+            isFromPoseidon = false,
         )
         given(missionActionsRepository.findById(any())).willReturn(action)
 

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission_actions/GetMissionActionFacadeUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission_actions/GetMissionActionFacadeUTests.kt
@@ -42,6 +42,7 @@ class GetMissionActionFacadeUTests {
             isDeleted = false,
             hasSomeGearsSeized = false,
             hasSomeSpeciesSeized = false,
+            isFromPoseidon = false,
         )
         given(portRepository.find(any())).willReturn(Port("AEFAT", name = "Dummy name", facade = "NAMO"))
 
@@ -67,6 +68,7 @@ class GetMissionActionFacadeUTests {
             isDeleted = false,
             hasSomeGearsSeized = false,
             hasSomeSpeciesSeized = false,
+            isFromPoseidon = false,
         )
 
         // When
@@ -92,6 +94,7 @@ class GetMissionActionFacadeUTests {
             isDeleted = false,
             hasSomeGearsSeized = false,
             hasSomeSpeciesSeized = false,
+            isFromPoseidon = false,
         )
         given(facadeAreasRepository.findByIncluding(any())).willReturn(
             listOf(
@@ -127,6 +130,7 @@ class GetMissionActionFacadeUTests {
             isDeleted = false,
             hasSomeGearsSeized = false,
             hasSomeSpeciesSeized = false,
+            isFromPoseidon = false,
         )
 
         // When
@@ -152,6 +156,7 @@ class GetMissionActionFacadeUTests {
             isDeleted = false,
             hasSomeGearsSeized = false,
             hasSomeSpeciesSeized = false,
+            isFromPoseidon = false,
         )
         given(facadeAreasRepository.findByIncluding(any())).willReturn(listOf())
 

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission_actions/GetVesselControlsUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission_actions/GetVesselControlsUTests.kt
@@ -66,6 +66,7 @@ class GetVesselControlsUTests {
                 isDeleted = false,
                 hasSomeGearsSeized = false,
                 hasSomeSpeciesSeized = false,
+                isFromPoseidon = false,
             ),
             MissionAction(
                 id = 2,
@@ -78,6 +79,7 @@ class GetVesselControlsUTests {
                 isDeleted = false,
                 hasSomeGearsSeized = false,
                 hasSomeSpeciesSeized = false,
+                isFromPoseidon = false,
             ),
             MissionAction(
                 id = 3,
@@ -90,6 +92,7 @@ class GetVesselControlsUTests {
                 isDeleted = false,
                 hasSomeGearsSeized = false,
                 hasSomeSpeciesSeized = false,
+                isFromPoseidon = false,
             ),
         )
         given(missionActionsRepository.findVesselMissionActionsAfterDateTime(any(), any())).willReturn(

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission_actions/TestUtils.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission_actions/TestUtils.kt
@@ -20,6 +20,7 @@ object TestUtils {
                     isDeleted = false,
                     hasSomeGearsSeized = false,
                     hasSomeSpeciesSeized = false,
+                    isFromPoseidon = false,
                 )
             }
         }.flatten()

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission_actions/UpdateMissionActionUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission_actions/UpdateMissionActionUTests.kt
@@ -36,6 +36,7 @@ class UpdateMissionActionUTests {
             isDeleted = false,
             hasSomeGearsSeized = false,
             hasSomeSpeciesSeized = false,
+            isFromPoseidon = false,
         )
 
         // When

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/MissionActionsControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/MissionActionsControllerITests.kt
@@ -75,6 +75,7 @@ class MissionActionsControllerITests {
                         isDeleted = false,
                         hasSomeGearsSeized = false,
                         hasSomeSpeciesSeized = false,
+                        isFromPoseidon = true,
                     ),
                 ),
             ),
@@ -108,6 +109,7 @@ class MissionActionsControllerITests {
                     isDeleted = false,
                     hasSomeGearsSeized = false,
                     hasSomeSpeciesSeized = false,
+                    isFromPoseidon = true,
                 ),
             ),
         )
@@ -227,6 +229,7 @@ class MissionActionsControllerITests {
                             gearOnboard = listOf(gearControl),
                             hasSomeGearsSeized = false,
                             hasSomeSpeciesSeized = false,
+                            isFromPoseidon = true,
                         ),
                     ),
                 )
@@ -236,6 +239,7 @@ class MissionActionsControllerITests {
             .andExpect(status().isCreated)
             .andExpect(jsonPath("$.missionId", equalTo(2)))
             .andExpect(jsonPath("$.vesselId", equalTo(2)))
+            .andExpect(jsonPath("$.isFromPoseidon", equalTo(true)))
             .andExpect(jsonPath("$.actionDatetimeUtc", equalTo("2022-05-05T03:04:05Z")))
             .andExpect(jsonPath("$.faoAreas[0]", equalTo("25.6.9")))
             .andExpect(jsonPath("$.faoAreas[1]", equalTo("25.7.9")))

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/MissionsControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/MissionsControllerITests.kt
@@ -69,6 +69,7 @@ class MissionsControllerITests {
                             isDeleted = false,
                             hasSomeGearsSeized = false,
                             hasSomeSpeciesSeized = false,
+                            isFromPoseidon = false,
                         ),
                     ),
                 ),

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaMissionActionRepositoryITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaMissionActionRepositoryITests.kt
@@ -168,7 +168,7 @@ class JpaMissionActionRepositoryITests : AbstractDBTests() {
         val existingAction = jpaMissionActionsRepository.findById(expectedId)
         assertThat(existingAction.latitude).isEqualTo(47.44)
         assertThat(existingAction.longitude).isEqualTo(-0.52)
-        val updatedMission = existingAction.copy(isDeleted = true)
+        val updatedMission = existingAction.copy(isDeleted = true, isFromPoseidon = true)
 
         // When
         val updatedMissionAction = jpaMissionActionsRepository.save(updatedMission)
@@ -176,6 +176,7 @@ class JpaMissionActionRepositoryITests : AbstractDBTests() {
         // Then
         assertThat(updatedMissionAction.id).isEqualTo(expectedId)
         assertThat(updatedMissionAction.isDeleted).isTrue()
+        assertThat(updatedMissionAction.isFromPoseidon).isTrue()
         assertThat(updatedMissionAction.latitude).isEqualTo(47.44)
         assertThat(updatedMissionAction.longitude).isEqualTo(-0.52)
     }
@@ -237,6 +238,7 @@ class JpaMissionActionRepositoryITests : AbstractDBTests() {
             hasSomeGearsSeized = false,
             hasSomeSpeciesSeized = false,
             closedBy = "XYZ",
+            isFromPoseidon = false,
         )
 
         // When

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/TestUtils.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/TestUtils.kt
@@ -43,5 +43,6 @@ object TestUtils {
         hasSomeGearsSeized = false,
         hasSomeSpeciesSeized = false,
         closedBy = "XYZ",
+        isFromPoseidon = true,
     )
 }


### PR DESCRIPTION
## Linked issues

- Resolve #2448

----

- [ ] Tests E2E (Cypress)
