### PR TITLE
Révocation des droits en modification pour tous les utilisateurs sur le schéma `public`

### DIFF
--- a/backend/src/main/resources/db/migration/internal/V0.242__Update_database_permissions.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.242__Update_database_permissions.sql
@@ -1,0 +1,1 @@
+REVOKE ALL ON schema public FROM PUBLIC;


### PR DESCRIPTION
## Linked issues

- Resolve #2800

## Explications
Metabase est bien connecté à la base avec un user `metabase` auquel on a attribué le rôle `readaccess`, créé avec seulement les droits en lecture, mais par défaut tous les utilisateurs ont des droits étendus sur le schéma `public`. Mieux retirer ces droits par défaut et gérer explicitement les droits par user.