### PR TITLE
[Tech] Configure les paths dans tsconfig

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,8 @@
+import { useGetUserAuthorization } from '@hooks/authorization/useGetUserAuthorization'
 import { OnlyFontGlobalStyle, THEME, ThemeProvider } from '@mtes-mct/monitor-ui'
+import { LandingPage } from '@pages/LandingPage'
+import { UnsupportedBrowserPage } from '@pages/UnsupportedBrowserPage'
+import { isBrowserSupported } from '@utils/isBrowserSupported'
 import countries from 'i18n-iso-countries'
 import COUNTRIES_FR from 'i18n-iso-countries/langs/fr.json'
 import { useEffect } from 'react'
@@ -8,12 +12,8 @@ import { CustomProvider as RsuiteCustomProvider } from 'rsuite'
 import rsuiteFrFr from 'rsuite/locales/fr_FR'
 
 import { AuthorizationContext } from './context/AuthorizationContext'
-import { useGetUserAuthorization } from './hooks/authorization/useGetUserAuthorization'
-import { LandingPage } from './pages/LandingPage'
-import { UnsupportedBrowserPage } from './pages/UnsupportedBrowserPage'
 import { router } from './router'
 import { FrontendErrorBoundary } from './ui/FrontendErrorBoundary'
-import { isBrowserSupported } from './utils/isBrowserSupported'
 
 import type { AuthContextProps } from 'react-oidc-context'
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,6 +5,7 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "alwaysStrict": true,
+    "baseUrl": "./src",
     "checkJs": false,
     // Override inherited value for CommonJS > ESM compatibility purpose
     "esModuleInterop": true,
@@ -23,6 +24,16 @@
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "paths": {
+      "@api/*": ["api/*"],
+      "@components/*": ["components/*"],
+      "@features/*": ["features/*"],
+      "@hooks/*": ["hooks/*"],
+      "@libs/*": ["libs/*"],
+      "@pages/*": ["pages/*"],
+      "@store/*": ["store/*"],
+      "@utils/*": ["utils/*"]
+    },
     "skipLibCheck": true,
     "strict": true,
     "strictBindCallApply": true,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -27,6 +27,7 @@
     "paths": {
       "@api/*": ["api/*"],
       "@components/*": ["components/*"],
+      "@constants/*": ["constants/*"],
       "@features/*": ["features/*"],
       "@hooks/*": ["hooks/*"],
       "@libs/*": ["libs/*"],


### PR DESCRIPTION
- J'aurais pu mettre un `"@/*": ["*"],` mais je préfère être déclaratif pour ne garder que les paths qui correspondent à notre structure "officielle".
- La raison pour laquelle je n'ai pas mis les dossiers `auth/`, `context/`, `errors/` et `workers/` et que j'aimerais challenger leur emplacement actuel.

## Linked issues

- MTES-MCT/monitorenv#1193

----

- [ ] Tests E2E (Cypress)
