### PR TITLE
[Mission] Bloquer la suppression d'une mission si elle contient des actions d'autres centres

### DIFF
--- a/frontend/config/cypress.config.ts
+++ b/frontend/config/cypress.config.ts
@@ -16,18 +16,18 @@ export default defineConfig({
     specPattern: 'cypress/e2e/**/*.spec.ts'
   },
   env: {
-    /**
-     * When running Cypress tests, we modify this env var in spec file, so we use `window.Cypress.env()`
-     * instead of `import.meta.env` in application code.
-     */
-    FRONTEND_MISSION_FORM_AUTO_SAVE_ENABLED: true,
     'cypress-plugin-snapshots': {
       imageConfig: {
         threshold: 20,
         thresholdType: 'pixel'
       },
       updateSnapshots: false
-    }
+    },
+    /**
+     * When running Cypress tests, we modify this env var in spec file, so we use `window.Cypress.env()`
+     * instead of `import.meta.env` in application code.
+     */
+    FRONTEND_MISSION_FORM_AUTO_SAVE_ENABLED: true
   },
   projectId: '9b7q8z',
   retries: {

--- a/frontend/cypress/e2e/constants.ts
+++ b/frontend/cypress/e2e/constants.ts
@@ -8,12 +8,12 @@ export const FAKE_API_PUT_RESPONSE = {
   statusCode: 200
 }
 
-export const FAKE_FISH_MISSION_ACTIONS = {
+export const FAKE_MISSION_WITH_EXTERNAL_ACTIONS = {
   body: { canDelete: false, sources: ['MONITORENV'] },
   statusCode: 200
 }
 
-export const FAKE_ENV_MISSION_ACTIONS = {
+export const FAKE_MISSION_WITHOUT_EXTERNAL_ACTIONS = {
   body: { canDelete: true, sources: [] },
   statusCode: 200
 }

--- a/frontend/cypress/e2e/constants.ts
+++ b/frontend/cypress/e2e/constants.ts
@@ -7,3 +7,13 @@ export const FAKE_API_PUT_RESPONSE = {
   body: {},
   statusCode: 200
 }
+
+export const FAKE_FISH_MISSION_ACTIONS = {
+  body: { canDelete: false, sources: ['MONITORENV'] },
+  statusCode: 200
+}
+
+export const FAKE_ENV_MISSION_ACTIONS = {
+  body: { canDelete: true, sources: [] },
+  statusCode: 200
+}

--- a/frontend/cypress/e2e/side_window/mission_form/air_control.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/air_control.spec.ts
@@ -146,7 +146,7 @@ context('Side Window > Mission Form > Air Control', () => {
 
     cy.contains('Veuillez compléter les champs manquants dans cette action de contrôle.').should('exist')
     cy.contains('Veuillez indiquer votre trigramme dans "Clôturé par".').should('exist')
-    cy.contains('Ré-ouvrir la mission').should('not.exist')
+    cy.contains('Rouvrir la mission').should('not.exist')
 
     // Clôturé par
     // TODO Handle multiple inputs with same label via an `index` in monitor-ui.

--- a/frontend/cypress/e2e/side_window/mission_form/air_surveillance.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/air_surveillance.spec.ts
@@ -167,7 +167,7 @@ context('Side Window > Mission Form > Air Surveillance', () => {
     // TODO Handle multiple inputs with same label via an `index` in monitor-ui.
     cy.get('[name="closedBy"]').eq(1).type('Alice')
     cy.contains('Veuillez indiquer votre trigramme dans "Clôturé par".').should('not.exist')
-    cy.contains('Ré-ouvrir la mission').should('not.exist')
+    cy.contains('Rouvrir la mission').should('not.exist')
 
     // Mission is now valid for closure
     cy.contains('Veuillez compléter les champs manquants dans cette action de contrôle.').should('not.exist')

--- a/frontend/cypress/e2e/side_window/mission_form/land_control.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/land_control.spec.ts
@@ -251,7 +251,7 @@ context('Side Window > Mission Form > Land Control', () => {
     cy.contains('Veuillez indiquer si le navire est ciblé par le CNSP.').should('exist')
     cy.contains('Veuillez indiquer votre trigramme dans "Clôturé par".').should('exist')
 
-    cy.contains('Ré-ouvrir la mission').should('not.exist')
+    cy.contains('Rouvrir la mission').should('not.exist')
 
     // Obligations déclaratives et autorisations de pêche
     cy.fill('Bonne émission VMS', 'Oui')

--- a/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
@@ -402,7 +402,7 @@ context('Side Window > Mission Form > Sea Control', () => {
     cy.contains('Veuillez indiquer si le navire est ciblé par le CNSP.').should('exist')
     cy.contains('Veuillez indiquer votre trigramme dans "Clôturé par".').should('exist')
 
-    cy.contains('Ré-ouvrir la mission').should('not.exist')
+    cy.contains('Rouvrir la mission').should('not.exist')
 
     // Obligations déclaratives et autorisations de pêche
     cy.fill('Bonne émission VMS', 'Oui')

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2,13 +2,16 @@ import type { AnyObject } from '@mtes-mct/monitor-ui'
 
 // Don't forget to mirror any update here in the backend enum.
 export enum ApiErrorCode {
+  EXISTING_MISSION_ACTION = 'EXISTING_MISSION_ACTION',
   /** Thrown when attempting to delete an entity which has  to non-archived children. */
   FOREIGN_KEY_CONSTRAINT = 'FOREIGN_KEY_CONSTRAINT',
+
   /** Thrown when attempting to archive an entity linked to non-archived children. */
   UNARCHIVED_CHILD = 'UNARCHIVED_CHILD'
 }
 
 export interface BackendApiErrorResponse {
+  code: ApiErrorCode | null
   type: ApiErrorCode | null
 }
 

--- a/frontend/src/features/Mission/components/MissionForm/Loader.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/Loader.tsx
@@ -9,7 +9,7 @@ import { useCallback } from 'react'
 import styled from 'styled-components'
 import { LoadingSpinnerWall } from 'ui/LoadingSpinnerWall'
 
-import { BackToListIcon, Body, Footer, Header, HeaderTitle, Wrapper } from '.'
+import { BackToListIcon, Body, Footer, Header, HeaderTitle, RightButtonsContainer, Wrapper } from '.'
 import { AutoSaveTag } from './shared/AutoSaveTag'
 
 export function Loader() {
@@ -52,19 +52,18 @@ export function Loader() {
       </Body>
 
       <Footer>
-        <div>
-          {!!missionIdFromPath && (
-            <Button accent={Accent.SECONDARY} disabled Icon={Icon.Delete}>
-              Supprimer la mission
-            </Button>
-          )}
-        </div>
-        <div>
+        {!!missionIdFromPath && (
+          <Button accent={Accent.SECONDARY} disabled Icon={Icon.Delete}>
+            Supprimer la mission
+          </Button>
+        )}
+
+        <RightButtonsContainer>
           <AutoSaveTag />
           <Button accent={Accent.PRIMARY} disabled onClick={goToMissionList}>
             Fermer
           </Button>
-        </div>
+        </RightButtonsContainer>
       </Footer>
     </Wrapper>
   )

--- a/frontend/src/features/Mission/components/MissionForm/Loader.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/Loader.tsx
@@ -9,7 +9,7 @@ import { useCallback } from 'react'
 import styled from 'styled-components'
 import { LoadingSpinnerWall } from 'ui/LoadingSpinnerWall'
 
-import { BackToListIcon, Body, CloseButton, Footer, Header, HeaderTitle, Wrapper } from '.'
+import { BackToListIcon, Body, Footer, Header, HeaderTitle, Wrapper } from '.'
 import { AutoSaveTag } from './shared/AutoSaveTag'
 
 export function Loader() {
@@ -61,9 +61,9 @@ export function Loader() {
         </div>
         <div>
           <AutoSaveTag />
-          <CloseButton accent={Accent.PRIMARY} disabled onClick={goToMissionList}>
+          <Button accent={Accent.PRIMARY} disabled onClick={goToMissionList}>
             Fermer
-          </CloseButton>
+          </Button>
         </div>
       </Footer>
     </Wrapper>

--- a/frontend/src/features/Mission/components/MissionForm/index.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/index.tsx
@@ -607,7 +607,7 @@ export function MissionForm() {
             {!!missionIdFromPath && (
               <Button
                 accent={Accent.SECONDARY}
-                // disabled={isSaving || mainFormValues.missionSource !== Mission.MissionSource.MONITORFISH}
+                disabled={isSaving || mainFormValues.missionSource !== Mission.MissionSource.MONITORFISH}
                 Icon={Icon.Delete}
                 onClick={toggleDeletionConfirmationDialog}
               >

--- a/frontend/src/features/Mission/components/MissionForm/index.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/index.tsx
@@ -8,7 +8,15 @@ import { openSideWindowPath } from '@features/SideWindow/useCases/openSideWindow
 import { useMainAppDispatch } from '@hooks/useMainAppDispatch'
 import { useMainAppSelector } from '@hooks/useMainAppSelector'
 import { FrontendError } from '@libs/FrontendError'
-import { Accent, Button, customDayjs, Icon, logSoftError, NotificationEvent } from '@mtes-mct/monitor-ui'
+import {
+  Accent,
+  Button,
+  customDayjs,
+  humanizePastDate,
+  Icon,
+  logSoftError,
+  NotificationEvent
+} from '@mtes-mct/monitor-ui'
 import { assertNotNullish } from '@utils/assertNotNullish'
 import { Mission } from 'domain/entities/mission/types'
 import { getMissionStatus } from 'domain/entities/mission/utils'
@@ -17,7 +25,6 @@ import { isEqual } from 'lodash'
 import { omit } from 'lodash/fp'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
-import * as timeago from 'timeago.js'
 import { FrontendErrorBoundary } from 'ui/FrontendErrorBoundary'
 import { NoRsuiteOverrideWrapper } from 'ui/NoRsuiteOverrideWrapper'
 import { useDebouncedCallback } from 'use-debounce'
@@ -121,6 +128,11 @@ export function MissionForm() {
   }, [mainFormValues])
 
   const isMissionFormValid = areMissionFormsValuesValid(mainFormValues, actionsFormValues)
+
+  const formattedUpdateDate = useMemo(
+    () => mainFormValues.updatedAtUtc && humanizePastDate(mainFormValues.updatedAtUtc),
+    [mainFormValues.updatedAtUtc]
+  )
 
   const updateReduxSliceDraft = useDebouncedCallback(() => {
     dispatch(
@@ -603,55 +615,37 @@ export function MissionForm() {
           </FrontendErrorBoundary>
         </Body>
         <Footer>
-          <div>
-            {!!missionIdFromPath && (
-              <Button
-                accent={Accent.SECONDARY}
-                disabled={isSaving || mainFormValues.missionSource !== Mission.MissionSource.MONITORFISH}
-                Icon={Icon.Delete}
-                onClick={toggleDeletionConfirmationDialog}
-              >
-                Supprimer la mission
-              </Button>
-            )}
-          </div>
-          <div>
-            <MissionInfos>
-              {mainFormValues.createdAtUtc && mainFormValues.missionSource && (
-                <>
-                  Mission créée par le {Mission.MissionSourceLabel[mainFormValues.missionSource]} le{' '}
-                  {customDayjs(mainFormValues.createdAtUtc).utc().format('DD/MM/YYYY à HH:mm')}.{' '}
-                </>
-              )}
-              {!mainFormValues.createdAtUtc && <>Mission non enregistrée. </>}
-              {mainFormValues.updatedAtUtc && (
-                <>Dernière modification enregistrée {timeago.format(mainFormValues.updatedAtUtc, 'fr')}.</>
-              )}
-            </MissionInfos>
-            <AutoSaveTag isAutoSaveEnabled={isAutoSaveEnabled} />
-            {!isAutoSaveEnabled && (
-              <Button
-                accent={Accent.PRIMARY}
-                disabled={isSaving || !isMissionFormValid}
-                Icon={Icon.Save}
-                onClick={async () => {
-                  await createOrUpdate({
-                    actionsFormValues,
-                    mainFormValues
-                  })
+          {!!missionIdFromPath && (
+            <DeleteButton
+              accent={Accent.SECONDARY}
+              disabled={isSaving || mainFormValues.missionSource !== Mission.MissionSource.MONITORFISH}
+              Icon={Icon.Delete}
+              onClick={toggleDeletionConfirmationDialog}
+            >
+              Supprimer la mission
+            </DeleteButton>
+          )}
 
-                  goToMissionList()
-                }}
-              >
-                Enregistrer
-              </Button>
+          <Separator />
+
+          <MissionInfos>
+            {mainFormValues.createdAtUtc && mainFormValues.missionSource && (
+              <>
+                Mission créée par le {Mission.MissionSourceLabel[mainFormValues.missionSource]} le{' '}
+                {customDayjs(mainFormValues.createdAtUtc).utc().format('DD/MM/YYYY à HH[h]mm')}.{' '}
+              </>
             )}
+            {!mainFormValues.createdAtUtc && <>Mission non enregistrée. </>}
+            {mainFormValues.updatedAtUtc && <>Dernière modification enregistrée {formattedUpdateDate}.</>}
+          </MissionInfos>
+
+          <RightButtonsContainer>
+            <AutoSaveTag isAutoSaveEnabled={isAutoSaveEnabled} />
             {!mainFormValues.isClosed && (
               <Button
                 accent={Accent.SECONDARY}
                 data-cy="close-mission"
                 disabled={isSaving || !isMissionFormValid}
-                Icon={Icon.Confirm}
                 onClick={close}
               >
                 Clôturer
@@ -666,17 +660,34 @@ export function MissionForm() {
                 onClick={reopen}
                 type="button"
               >
-                Ré-ouvrir la mission
+                Rouvrir la mission
               </Button>
             )}
-            <CloseButton
-              accent={isAutoSaveEnabled ? Accent.PRIMARY : Accent.TERTIARY}
+            <Button
+              accent={isAutoSaveEnabled ? Accent.PRIMARY : Accent.SECONDARY}
               disabled={isSaving}
               onClick={goToMissionList}
             >
               Fermer
-            </CloseButton>
-          </div>
+            </Button>
+
+            {!isAutoSaveEnabled && (
+              <Button
+                accent={Accent.PRIMARY}
+                disabled={isSaving || !isMissionFormValid}
+                onClick={async () => {
+                  await createOrUpdate({
+                    actionsFormValues,
+                    mainFormValues
+                  })
+
+                  goToMissionList()
+                }}
+              >
+                Enregistrer
+              </Button>
+            )}
+          </RightButtonsContainer>
         </Footer>
       </Wrapper>
 
@@ -692,11 +703,6 @@ export function MissionForm() {
     </>
   )
 }
-
-const MissionInfos = styled.div`
-  font-style: italic;
-  color: ${p => p.theme.color.slateGray};
-`
 
 export const BackToListIcon = styled(Icon.Chevron)`
   margin-right: 12px;
@@ -746,30 +752,29 @@ export const Body = styled.div`
 `
 
 export const Footer = styled.div`
-  background-color: ${p => p.theme.color.white};
-  border-top: solid 2px ${p => p.theme.color.gainsboro};
+  align-items: center;
+  border-top: 1px solid ${p => p.theme.color.lightGray};
   display: flex;
-  flex-grow: 1;
+  gap: 16px;
   justify-content: space-between;
-  max-height: 62px;
-  min-height: 62px;
-
-  > div {
-    align-items: center;
-    display: flex;
-    flex-grow: 1;
-    padding: 0 24px;
-
-    :last-child {
-      justify-content: flex-end;
-
-      > button {
-        margin-left: 16px;
-      }
+  padding: 16px;
+`
+const DeleteButton = styled(Button)`
+  :not([disabled]) {
+    svg {
+      color: ${p => p.theme.color.maximumRed};
     }
   }
 `
 
-export const CloseButton = styled(Button)`
-  height: 34px;
+const Separator = styled.div``
+
+const MissionInfos = styled.div`
+  font-style: italic;
+  color: ${p => p.theme.color.slateGray};
+`
+
+const RightButtonsContainer = styled.div`
+  display: flex;
+  gap: 16px;
 `

--- a/frontend/src/features/Mission/components/MissionForm/index.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/index.tsx
@@ -774,7 +774,7 @@ const MissionInfos = styled.div`
   color: ${p => p.theme.color.slateGray};
 `
 
-const RightButtonsContainer = styled.div`
+export const RightButtonsContainer = styled.div`
   display: flex;
   gap: 16px;
 `

--- a/frontend/src/features/Mission/components/MissionForm/index.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/index.tsx
@@ -617,8 +617,11 @@ export function MissionForm() {
           </div>
           <div>
             <MissionInfos>
-              {mainFormValues.createdAtUtc && (
-                <>Mission créée le {customDayjs(mainFormValues.createdAtUtc).utc().format('D MMM YYYY, HH:mm')}. </>
+              {mainFormValues.createdAtUtc && mainFormValues.missionSource && (
+                <>
+                  Mission créée par le {Mission.MissionSourceLabel[mainFormValues.missionSource]} le{' '}
+                  {customDayjs(mainFormValues.createdAtUtc).utc().format('DD/MM/YYYY à HH:mm')}.{' '}
+                </>
               )}
               {!mainFormValues.createdAtUtc && <>Mission non enregistrée. </>}
               {mainFormValues.updatedAtUtc && (
@@ -692,6 +695,7 @@ export function MissionForm() {
 
 const MissionInfos = styled.div`
   font-style: italic;
+  color: ${p => p.theme.color.slateGray};
 `
 
 export const BackToListIcon = styled(Icon.Chevron)`

--- a/frontend/src/features/Mission/components/MissionForm/index.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/index.tsx
@@ -544,7 +544,10 @@ export function MissionForm() {
   )
 
   const toggleDeletionConfirmationDialog = useCallback(async () => {
-    if (missionIdRef.current) {
+    if (!missionIdRef.current) {
+      return
+    }
+    try {
       const response = dispatch(monitorenvMissionApi.endpoints.canDeleteMission.initiate(missionIdRef.current))
       const canDeleteMissionResponse = await response.unwrap()
       if (canDeleteMissionResponse.canDelete) {
@@ -554,6 +557,13 @@ export function MissionForm() {
       }
       setActionsSources(canDeleteMissionResponse.sources)
       setIsExternalActionsDialogOpen(true)
+    } catch (error) {
+      logSoftError({
+        isSideWindowError: true,
+        message: '`canDeleteMission` API call failed.',
+        originalError: error,
+        userMessage: "Nous n'avons pas pu vérifier si cette mission est supprimable."
+      })
     }
   }, [isDeletionConfirmationDialogOpen, dispatch])
 

--- a/frontend/src/features/Mission/components/MissionForm/shared/AutoSaveTag.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/shared/AutoSaveTag.tsx
@@ -16,8 +16,7 @@ export function AutoSaveTag({ isAutoSaveEnabled = false }: AutoSaveTagProps) {
 }
 
 const Wrapper = styled(Tag)`
-  margin-left: 24px;
+  margin: auto 0px auto 24px;
   vertical-align: middle;
-  align-self: unset;
   font-weight: 500;
 `

--- a/frontend/src/features/Mission/components/MissionForm/shared/ExternalActionsDialog.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/shared/ExternalActionsDialog.tsx
@@ -1,0 +1,53 @@
+import { Button, Dialog, Icon, THEME } from '@mtes-mct/monitor-ui'
+import { Mission } from 'domain/entities/mission/types'
+import styled from 'styled-components'
+
+type ExternalActionsModalProps = {
+  onClose: () => void
+  sources: Mission.MissionSource[]
+}
+
+export function ExternalActionsDialog({ onClose, sources }: ExternalActionsModalProps) {
+  const isCACEM = sources.includes(Mission.MissionSource.MONITORENV)
+
+  return (
+    <Dialog data-cy="external-actions-modal" isAbsolute>
+      <Dialog.Title>Supprimer la mission</Dialog.Title>
+      <Dialog.Body>
+        <Alert>
+          <Icon.Attention color={THEME.color.maximumRed} size={30} />
+        </Alert>
+        <Text>{`La mission ne peut pas être supprimée, car elle comporte des événements ajoutés par ${
+          isCACEM ? 'le CACEM' : ''
+        }.`}</Text>
+        <Bold>
+          {`Si vous souhaitez tout de même la supprimer, veuillez contacter  ${
+            isCACEM ? 'le CACEM' : ''
+          } pour qu'il supprime d'abord
+            ses événements.`}
+        </Bold>
+      </Dialog.Body>
+
+      <Dialog.Action>
+        <Button data-cy="external-actions-modal-close" onClick={onClose}>
+          Fermer
+        </Button>
+      </Dialog.Action>
+    </Dialog>
+  )
+}
+
+const Alert = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 10px;
+`
+const Text = styled.p`
+  color: ${props => props.theme.color.maximumRed} !important;
+  padding: 2px 40px;
+`
+const Bold = styled.p`
+  color: ${props => props.theme.color.maximumRed} !important;
+  font-weight: bold;
+  padding: 2px 40px;
+`

--- a/frontend/src/features/Mission/components/MissionForm/utils/getMissionDraftFromPartialMainFormValues.ts
+++ b/frontend/src/features/Mission/components/MissionForm/utils/getMissionDraftFromPartialMainFormValues.ts
@@ -15,6 +15,7 @@ export function getMissionDraftFromPartialMainFormValues(
       controlUnits: [INITIAL_MISSION_CONTROL_UNIT],
       isGeometryComputedFromControls: false,
       isValid: false,
+      missionSource: Mission.MissionSource.MONITORFISH,
       missionTypes: [Mission.MissionType.SEA],
       startDateTimeUtc: customDayjs().startOf('minute').toISOString(),
       ...partialMainFormValues

--- a/frontend/src/features/Mission/monitorenvMissionApi.ts
+++ b/frontend/src/features/Mission/monitorenvMissionApi.ts
@@ -1,5 +1,7 @@
 import { monitorenvApi } from '@api/api'
+import { ApiErrorCode } from '@api/types'
 import { FrontendApiError } from '@libs/FrontendApiError'
+import { UsageError } from '@libs/UsageError'
 import { ControlUnit } from '@mtes-mct/monitor-ui'
 import { Mission } from 'domain/entities/mission/types'
 
@@ -8,9 +10,20 @@ const DELETE_MISSION_ERROR_MESSAGE = "Nous n'avons pas pu supprimer la mission."
 const GET_MISSION_ERROR_MESSAGE = "Nous n'avons pas pu récupérer la mission."
 const GET_ENGAGED_CONTROL_UNITS_ERROR_MESSAGE = "Nous n'avons pas pu récupérer les unités en mission."
 const UPDATE_MISSION_ERROR_MESSAGE = "Nous n'avons pas pu mettre à jour la mission."
+const CAN_DELETE_MISSION_ERROR_MESSAGE = "Nous n'avons pas pu vérifier si cette mission est supprimable."
+const IMPOSSIBLE_MISSION_DELETION_ERROR_MESSAGE =
+  "Impossible de supprimer une mission avec des actions créées par d'autres centres."
+type CanDeleteMissionResponseType = {
+  canDelete: boolean
+  sources: Mission.MissionSource[]
+}
 
 export const monitorenvMissionApi = monitorenvApi.injectEndpoints({
   endpoints: builder => ({
+    canDeleteMission: builder.query<CanDeleteMissionResponseType, number>({
+      query: id => `/v1/missions/${id}/can_delete?source=${Mission.MissionSource.MONITORFISH}`,
+      transformErrorResponse: error => new FrontendApiError(CAN_DELETE_MISSION_ERROR_MESSAGE, error)
+    }),
     createMission: builder.mutation<Mission.Mission, Mission.MissionData>({
       query: mission => ({
         body: mission,
@@ -23,9 +36,15 @@ export const monitorenvMissionApi = monitorenvApi.injectEndpoints({
     deleteMission: builder.mutation<void, Mission.Mission['id']>({
       query: id => ({
         method: 'DELETE',
-        url: `/v1/missions/${id}`
+        url: `/v2/missions/${id}?source=${Mission.MissionSource.MONITORFISH}`
       }),
-      transformErrorResponse: response => new FrontendApiError(DELETE_MISSION_ERROR_MESSAGE, response)
+      transformErrorResponse: response => {
+        if (response.responseData.code === ApiErrorCode.EXISTING_MISSION_ACTION) {
+          return new UsageError(IMPOSSIBLE_MISSION_DELETION_ERROR_MESSAGE)
+        }
+
+        return new FrontendApiError(DELETE_MISSION_ERROR_MESSAGE, response)
+      }
     }),
 
     getEngagedControlUnits: builder.query<Array<ControlUnit.EngagedControlUnit>, void>({


### PR DESCRIPTION
- Utilisation de l'api v2 de `delete` qui check le `canDelete` avant toute chose
- J'en ai profité pour mettre à jour le footer pour qu'il soit ISO avec Env (boutons mis à jour, message d'update mis à jour avec la fonction monitor-ui)
<img width="1512" alt="Capture d’écran 2024-02-23 à 15 16 51" src="https://github.com/MTES-MCT/monitorfish/assets/23258718/188c43b4-f36e-49e7-ab44-8a4703e39dd0">
<img width="1512" alt="Capture d’écran 2024-02-23 à 15 16 32" src="https://github.com/MTES-MCT/monitorfish/assets/23258718/50bf7c8f-53b0-418b-a5ff-eebe2e0b0c48">
<img width="1512" alt="Capture d’écran 2024-02-23 à 15 16 23" src="https://github.com/MTES-MCT/monitorfish/assets/23258718/5e3fa571-d75f-4f98-988c-65109f693c2f">
<img width="1512" alt="Capture d’écran 2024-02-23 à 15 16 13" src="https://github.com/MTES-MCT/monitorfish/assets/23258718/16c1874f-ad17-47eb-b9bb-a92c2d3938ce">


## Linked issues

- Resolve #2803

----

- [x] Tests E2E (Cypress)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new test case to prevent deletion of a mission if actions have been created in `MonitorEnv`.
- **Enhancements**
	- Updated the text in various UI elements for semantic consistency and improved user experience.
- **Bug Fixes**
	- Adjusted UI text for better visibility validation in specific scenarios.
- **Tests**
	- Enhanced Cypress tests to cover new functionalities and scenarios related to mission actions and deletion.
- **Refactor**
	- Reordered configuration and added new constants for improved testing clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->