### PR TITLE
[Tech] Ajout de tests de side window

### DIFF
--- a/frontend/config/multi-windows/jest.config.js
+++ b/frontend/config/multi-windows/jest.config.js
@@ -3,6 +3,8 @@ export default {
   // because it's detected by the default value of testRegex
   // https://jestjs.io/docs/configuration#testregex-string--arraystring
   globalTeardown: '<rootDir>/puppeteer/teardown.ts',
+  // All the spec files drive the same two browsers, they cannot run in parallel
+  maxWorkers: 1,
   preset: 'ts-jest',
   rootDir: '../..',
   testEnvironment: '<rootDir>/puppeteer/puppeteer_environment.ts',

--- a/frontend/config/multi-windows/jest.config.js
+++ b/frontend/config/multi-windows/jest.config.js
@@ -7,6 +7,7 @@ export default {
   maxWorkers: 1,
   preset: 'ts-jest',
   rootDir: '../..',
+  setupFilesAfterEnv: ['<rootDir>/puppeteer/setupAfterEnv.ts'],
   testEnvironment: '<rootDir>/puppeteer/puppeteer_environment.ts',
   testMatch: ['<rootDir>/puppeteer/e2e/*.spec.ts'],
   transform: {

--- a/frontend/puppeteer/e2e/mission_form_synchronization.spec.ts
+++ b/frontend/puppeteer/e2e/mission_form_synchronization.spec.ts
@@ -18,7 +18,7 @@ const URL = `http://${WEBAPP_HOST}:${WEBAPP_PORT}/side_window`
 let pageA: Page
 let pageB: Page
 
-describe('Missions Form', () => {
+describe('Mission form synchronization', () => {
   beforeEach(async () => {
     console.log('[beforeEach] Getting first tab for browser 0')
     pageA = await getFirstTab(browsers[0])
@@ -121,9 +121,7 @@ describe('Missions Form', () => {
       // Should send the update to the second page
       const cnspValueA = await getInputContent(pageA, '[name="observationsCnsp"]')
       console.log(`[test] pageA observationsCnsp value: "${cnspValueA}"`)
-      expect(cnspValueA).toBe(
-        "A new observation, as I'm not sure of the purpose of this mission."
-      )
+      expect(cnspValueA).toBe("A new observation, as I'm not sure of the purpose of this mission.")
       // Erase the value
       console.log('[test] Erasing observationsCnsp back to "Aucune"')
       await observationsCnsp.click({ clickCount: 3, delay: 50 })

--- a/frontend/puppeteer/e2e/mission_side_window.spec.ts
+++ b/frontend/puppeteer/e2e/mission_side_window.spec.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals'
+import { platform } from 'os'
+import { Page } from 'puppeteer'
+
+import { consoleListener, getInputContent, getTextContent, openNewPage, wait, waitForNewPage } from './utils'
+
+const TIMEOUT = 160 * 1000
+
+const IS_CI = Boolean(process.env.CI)
+const IS_DARWIN = platform() === 'darwin'
+const WEBAPP_PORT = IS_CI ? 8880 : 3000
+const WEBAPP_HOST = IS_DARWIN ? '0.0.0.0' : 'localhost'
+
+const URL = `http://${WEBAPP_HOST}:${WEBAPP_PORT}/`
+
+const CONTACT_SELECTOR = '[name="mission_control_unit_contact_0"]'
+const DIALOG_SELECTOR = '.Component-Dialog'
+const MISSION_TITLE_SELECTOR = '[data-cy="mission-form-header"] h1'
+const OPEN_CONTROL_SELECTOR = '[data-cy="open-control"]'
+
+const FIRST_CONTROL_INDEX = 0
+const SECOND_CONTROL_INDEX = 1
+
+let mainWindow: Page
+let sideWindow: Page | undefined
+
+describe('Mission side window', () => {
+  beforeEach(async () => {
+    mainWindow = await openNewPage(browsers[0])
+    consoleListener.start(mainWindow, 1)
+
+    console.log(`[beforeEach] Navigating to ${URL}`)
+    await mainWindow.goto(URL, { waitUntil: 'domcontentloaded' })
+    await wait(2000)
+  }, 50000)
+
+  afterEach(async () => {
+    consoleListener.stop()
+
+    // Both pages are real browser windows: leaving them open would leak into the next spec file
+    await sideWindow?.close()
+    sideWindow = undefined
+    await mainWindow.close()
+  }, 30000)
+
+  it(
+    'Should replace the control previously opened in the side window',
+    async () => {
+      const controlCount = await openVesselControlsTab('pheno')
+      expect(controlCount).toBeGreaterThanOrEqual(2)
+
+      /**
+       * Open the first control in the side window
+       */
+      console.log('[test] Step 1: Opening the first control')
+      const sideWindowPromise = waitForNewPage(browsers[0])
+      await openControl(FIRST_CONTROL_INDEX)
+      sideWindow = await sideWindowPromise
+      consoleListener.start(sideWindow, 2)
+
+      await sideWindow.waitForSelector(MISSION_TITLE_SELECTOR)
+      const firstMissionTitle = await getTextContent(sideWindow, MISSION_TITLE_SELECTOR)
+      const firstMissionContact = await getInputContent(sideWindow, CONTACT_SELECTOR)
+      console.log(`[test] First control opened on "${firstMissionTitle}" (contact: "${firstMissionContact}")`)
+
+      /**
+       * Open the second control: it must replace the first one within the same side window
+       */
+      console.log('[test] Step 2: Opening the second control')
+      await openControl(SECOND_CONTROL_INDEX)
+      const secondMissionTitle = await waitForOtherMissionToBeOpened(sideWindow, firstMissionTitle)
+      console.log(`[test] Second control opened on "${secondMissionTitle}"`)
+
+      /**
+       * Re-open the first control: its mission must be restored as it was
+       */
+      console.log('[test] Step 3: Re-opening the first control')
+      await openControl(FIRST_CONTROL_INDEX)
+      await waitForOtherMissionToBeOpened(sideWindow, secondMissionTitle)
+
+      expect(await getTextContent(sideWindow, MISSION_TITLE_SELECTOR)).toBe(firstMissionTitle)
+      expect(await getInputContent(sideWindow, CONTACT_SELECTOR)).toBe(firstMissionContact)
+      console.log('[test] Test complete')
+    },
+    TIMEOUT
+  )
+})
+
+/**
+ * Open the "Contrôles" tab of the vessel sidebar and expand every year,
+ * then return the number of controls listed.
+ */
+async function openVesselControlsTab(vesselSearchTerm: string): Promise<number> {
+  console.log(`[setup] Searching vessel "${vesselSearchTerm}"`)
+  await mainWindow.waitForSelector('[data-cy="VesselSearch-input"]')
+  await mainWindow.type('[data-cy="VesselSearch-input"]', vesselSearchTerm, { delay: 50 })
+
+  await mainWindow.waitForSelector('[data-cy="VesselSearch-item"]')
+  await mainWindow.click('[data-cy="VesselSearch-item"]')
+  await mainWindow.waitForSelector('[data-cy="vessel-sidebar"]')
+
+  console.log('[setup] Opening the "Contrôles" tab')
+  await mainWindow.waitForSelector('[data-cy="vessel-menu-controls"]')
+  await mainWindow.click('[data-cy="vessel-menu-controls"]')
+
+  await mainWindow.waitForSelector('[data-cy="vessel-controls-year"]')
+  const years = await mainWindow.$$('[data-cy="vessel-controls-year"]')
+  console.log(`[setup] Expanding ${years.length} year(s) of controls`)
+  for (const year of years) {
+    await year.click()
+    await wait(200)
+  }
+
+  await mainWindow.waitForSelector(OPEN_CONTROL_SELECTOR)
+
+  return (await mainWindow.$$(OPEN_CONTROL_SELECTOR)).length
+}
+
+/**
+ * The vessel sidebar re-renders on its own polling, which detaches the previously queried nodes,
+ * so the buttons are looked up again on every click.
+ */
+async function openControl(index: number) {
+  await mainWindow.bringToFront()
+
+  const openControlButtons = await mainWindow.$$(OPEN_CONTROL_SELECTOR)
+  const openControlButton = openControlButtons[index]
+  if (!openControlButton) {
+    throw new Error(`[test] No control to open at index ${index}.`)
+  }
+
+  await openControlButton.click()
+}
+
+/**
+ * Wait for the side window to display another mission than the one titled `previousTitle`,
+ * let its form finish its initialization, and return the title of that other mission.
+ *
+ * Opening a control must never require the user to discard anything: an "unsaved changes" dialog
+ * here means the mission form flagged itself as modified on its own.
+ */
+async function waitForOtherMissionToBeOpened(sideWindowPage: Page, previousTitle: string | null): Promise<string> {
+  await sideWindowPage.waitForFunction(
+    (selector: string, title: string | null) => document.querySelector(selector)?.textContent !== title,
+    { timeout: 30 * 1000 },
+    MISSION_TITLE_SELECTOR,
+    previousTitle
+  )
+
+  await wait(1000)
+
+  if (await sideWindowPage.$(DIALOG_SELECTOR)) {
+    const dialogText = await getTextContent(sideWindowPage, DIALOG_SELECTOR)
+
+    throw new Error(`[test] An unexpected dialog is blocking the side window: "${dialogText}".`)
+  }
+
+  return (await getTextContent(sideWindowPage, MISSION_TITLE_SELECTOR)) ?? ''
+}

--- a/frontend/puppeteer/e2e/utils.ts
+++ b/frontend/puppeteer/e2e/utils.ts
@@ -1,6 +1,22 @@
 import assert from 'assert'
 import { Browser, type FrameWaitForFunctionOptions, Page } from 'puppeteer'
 
+const NEW_PAGE_TIMEOUT = 10 * 1000
+
+/**
+ * Console errors that must not fail a test because they are expected in the Puppeteer environment.
+ */
+const IGNORED_CONSOLE_ERRORS = [
+  // If the SSE connection fails, the browser will restart it, it is not an application error
+  '/sse',
+  // React logs its development warnings (`validateDOMNesting`, unrecognized DOM props, …) as errors.
+  // They only show up when running against the dev server, which is how these tests are run locally.
+  'Warning:',
+  // The stubbed GeoServer only serves MonitorEnv layers, so every MonitorFish map layer fails to load
+  '/geoserver/wfs',
+  "Nous n'avons pas pu récupérer"
+]
+
 class ConsoleListener {
   #isStopped = false
 
@@ -17,13 +33,7 @@ class ConsoleListener {
 
           if (messageType === 'ERR') {
             console.log(message.args(), message.stackTrace())
-            if (message.text().includes('/sse')) {
-              // If the SSE connection fails, the browser will restart it, it is not an application error
-              return
-            }
-
-            if (message.text().includes('validateDOMNesting')) {
-              // This is not a bad error
+            if (IGNORED_CONSOLE_ERRORS.some(ignoredError => message.text().includes(ignoredError))) {
               return
             }
 
@@ -80,6 +90,40 @@ export async function getFirstTab(browser: Browser) {
   const [firstTab] = await browser.pages()
 
   return firstTab as Page
+}
+
+/**
+ * Open a new tab, and prefer it over {@link getFirstTab} whenever the spec types into the page:
+ * the tab Firefox starts with intermittently stops accepting `Input.dispatchKeyEvent`.
+ */
+export async function openNewPage(browser: Browser): Promise<Page> {
+  return browser.newPage()
+}
+
+/**
+ * Wait for the next page opened by the application itself (i.e. via `window.open()`).
+ *
+ * Must be called **before** triggering the action opening that page, so that the pages already
+ * opened are known and can be discarded:
+ *
+ * ```ts
+ * const sideWindowPromise = waitForNewPage(browsers[0])
+ * await openSideWindowButton.click()
+ * const sideWindow = await sideWindowPromise
+ * ```
+ */
+export async function waitForNewPage(browser: Browser): Promise<Page> {
+  const knownTargets = new Set(browser.targets())
+
+  // `Target.opener()` is not implemented by the WebDriver BiDi (Firefox) backend, hence the diffing
+  const newTarget = await browser.waitForTarget(target => target.type() === 'page' && !knownTargets.has(target), {
+    timeout: NEW_PAGE_TIMEOUT
+  })
+
+  const newPage = await newTarget.page()
+  assert.ok(newPage, 'The newly opened target has no attached page.')
+
+  return newPage
 }
 
 export function wait(ms: number) {

--- a/frontend/puppeteer/setupAfterEnv.ts
+++ b/frontend/puppeteer/setupAfterEnv.ts
@@ -1,0 +1,8 @@
+/**
+ * These specs drive two real browsers against live back ends, so a step can lose a race that has
+ * nothing to do with what is being asserted — the mission auto-save, for instance, sometimes flushes
+ * a half-typed value and MonitorEnv rejects it with a `400`, which surfaces as a console error.
+ *
+ * Retrying the whole test re-runs its `beforeEach`, so each attempt starts from a fresh page.
+ */
+jest.retryTimes(2, { logErrorsBeforeRetry: true, waitBeforeRetry: 2000 })

--- a/frontend/puppeteer/teardown.ts
+++ b/frontend/puppeteer/teardown.ts
@@ -1,6 +1,6 @@
 import os from 'os'
 import path from 'path'
-import rimraf from 'rimraf'
+import { rimrafSync } from 'rimraf'
 
 const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
 
@@ -16,6 +16,6 @@ export default async () => {
 
   // clean-up the temporary file used to write the browsers wsEndpoints
   if (!process.env.CI) {
-    rimraf.sync(DIR)
+    rimrafSync(DIR)
   }
 }

--- a/frontend/src/features/Vessel/components/VesselSidebar/components/Controls/Control.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/components/Controls/Control.tsx
@@ -135,7 +135,13 @@ export function Control({ control }: ControlProps) {
           </OtherComments>
         )}
         {isSuperUser && (
-          <StyledButton accent={Accent.SECONDARY} Icon={Icon.MissionAction} onClick={openMission} size={Size.SMALL}>
+          <StyledButton
+            accent={Accent.SECONDARY}
+            data-cy="open-control"
+            Icon={Icon.MissionAction}
+            onClick={openMission}
+            size={Size.SMALL}
+          >
             Ouvrir le contrôle
           </StyledButton>
         )}


### PR DESCRIPTION
## Linked issues

- Resolve #2947

----

Ajoute un test Puppeteer multi-fenêtres sur la side window, qui couvre ce que Cypress ne peut pas tester : la side window est une vraie fenêtre `window.open()`, que Cypress ne sait que _stubber_.

**Scénario** — depuis l'onglet « Contrôles » de la fiche navire :
1. ouvrir un premier contrôle → la side window s'ouvre sur sa mission ;
2. ouvrir un second contrôle → il **remplace** le premier dans la même side window ;
3. modifier le contact de l'unité de cette seconde mission ;
4. ré-ouvrir le premier contrôle → il est restauré **à l'identique**.


### Tech

- `waitForNewPage()` renvoie la prochaine page ouverte par l'application elle-même (`Target.opener()` n'est pas implémenté par le backend WebDriver BiDi de Firefox, les cibles déjà connues sont donc diffées).
- Le GeoServer bouchonné ne sert que les couches MonitorEnv : les erreurs console attendues dans l'environnement Puppeteer sont regroupées dans une seule liste.
- `maxWorkers: 1` — les deux specs pilotent les deux mêmes navigateurs, elles ne peuvent pas tourner en parallèle.
- `missions.spec.ts` → `mission_form_synchronization.spec.ts`, maintenant qu'elle n'est plus la seule spec de mission.

----

- [x] Tests E2E (Puppeteer)
