### PR TITLE
[Mission] Ajout d'un fond blanc sur le formulaire lorsque le warning d'une unité déjà en cours de mission est visible

### DIFF
--- a/frontend/src/features/Mission/components/MissionForm/MainForm/FormikMultiControlUnitPicker/ControlUnitWarningMessage.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/MainForm/FormikMultiControlUnitPicker/ControlUnitWarningMessage.tsx
@@ -83,6 +83,8 @@ export function ControlUnitWarningMessage({
 
 const StyledMessage = styled(Message)`
   margin-top: 8px;
+  position: relative;
+  z-index: 10;
 `
 const Warning = styled.p`
   color: ${({ theme }) => theme.color.goldenPoppy};

--- a/frontend/src/features/Mission/components/MissionForm/index.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/index.tsx
@@ -66,6 +66,7 @@ export function MissionForm() {
   const dispatch = useMainAppDispatch()
   const missionIdFromPath = useMainAppSelector(store => store.sideWindow.selectedPath.id)
   const draft = useMainAppSelector(store => store.missionForm.draft)
+  const hasEngagedControlUnit = useMainAppSelector(state => !!state.missionForm.engagedControlUnit)
   assertNotNullish(draft)
 
   const missionIdRef = useRef<number | undefined>(missionIdFromPath)
@@ -575,9 +576,19 @@ export function MissionForm() {
       {isExternalActionsDialogOpen && (
         <ExternalActionsDialog onClose={() => setIsExternalActionsDialogOpen(false)} sources={actionsSources} />
       )}
+      {hasEngagedControlUnit && <DisabledMissionBackground />}
     </>
   )
 }
+
+const DisabledMissionBackground = styled.div`
+  position: absolute;
+  background-color: ${p => p.theme.color.white};
+  opacity: 0.6;
+  width: 100%;
+  height: 100%;
+  z-index: 5;
+`
 
 export const BackToListIcon = styled(Icon.Chevron)`
   margin-right: 12px;


### PR DESCRIPTION
## Linked issues

- Resolve #2925

----

- [ ] Tests E2E (Cypress)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Added functionality to track engagement status in missions, improving user interaction and feedback.
- **Style**
	- Improved visibility of warning messages in mission control unit selection.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->