### PR TITLE
[Missions] Remettre la phrase d'erreur sur le champ date quand il y a une incohérence

### DIFF
--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/AirControlForm.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/AirControlForm.tsx
@@ -1,5 +1,6 @@
+import { DatePickerField } from '@features/Mission/components/MissionForm/ActionForm/shared/DatePickerField'
 import { useMainAppSelector } from '@hooks/useMainAppSelector'
-import { FormikDatePicker, FormikEffect, FormikTextarea, Icon, useNewWindow } from '@mtes-mct/monitor-ui'
+import { FormikEffect, FormikTextarea, Icon } from '@mtes-mct/monitor-ui'
 import { Formik } from 'formik'
 import { noop } from 'lodash/fp'
 import { useMemo } from 'react'
@@ -25,8 +26,6 @@ type AirControlFormProps = Readonly<{
   onChange: (nextValues: MissionActionFormValues) => Promisable<void>
 }>
 export function AirControlForm({ initialValues, onChange }: AirControlFormProps) {
-  const { newWindowContainerRef } = useNewWindow()
-
   const isClosing = useMainAppSelector(store => store.missionForm.isClosing)
 
   const titleDate = useMemo(
@@ -55,16 +54,7 @@ export function AirControlForm({ initialValues, onChange }: AirControlFormProps)
           <FormBody>
             <VesselField />
 
-            <FormikDatePicker
-              baseContainer={newWindowContainerRef.current}
-              isErrorMessageHidden
-              isLight
-              isRequired
-              isStringDate
-              label="Date et heure du contrôle"
-              name="actionDatetimeUtc"
-              withTime
-            />
+            <DatePickerField />
 
             <FormikCoordinatesPicker />
 

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/LandControlForm.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/LandControlForm.tsx
@@ -1,12 +1,6 @@
+import { DatePickerField } from '@features/Mission/components/MissionForm/ActionForm/shared/DatePickerField'
 import { useMainAppSelector } from '@hooks/useMainAppSelector'
-import {
-  FormikCheckbox,
-  FormikDatePicker,
-  FormikEffect,
-  FormikTextarea,
-  Icon,
-  useNewWindow
-} from '@mtes-mct/monitor-ui'
+import { FormikCheckbox, FormikEffect, FormikTextarea, Icon } from '@mtes-mct/monitor-ui'
 import { Formik } from 'formik'
 import { noop } from 'lodash/fp'
 import { useMemo } from 'react'
@@ -38,8 +32,6 @@ type LandControlFormProps = Readonly<{
   onChange: (nextValues: MissionActionFormValues) => Promisable<void>
 }>
 export function LandControlForm({ initialValues, onChange }: LandControlFormProps) {
-  const { newWindowContainerRef } = useNewWindow()
-
   const isClosing = useMainAppSelector(store => store.missionForm.isClosing)
 
   const titleDate = useMemo(
@@ -68,16 +60,7 @@ export function LandControlForm({ initialValues, onChange }: LandControlFormProp
           <FormBody>
             <VesselField />
 
-            <FormikDatePicker
-              baseContainer={newWindowContainerRef.current}
-              isErrorMessageHidden
-              isLight
-              isRequired
-              isStringDate
-              label="Date et heure du contrôle"
-              name="actionDatetimeUtc"
-              withTime
-            />
+            <DatePickerField />
 
             <FormikPortSelect />
 

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/SeaControlForm.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/SeaControlForm.tsx
@@ -1,12 +1,6 @@
+import { DatePickerField } from '@features/Mission/components/MissionForm/ActionForm/shared/DatePickerField'
 import { useMainAppSelector } from '@hooks/useMainAppSelector'
-import {
-  FormikCheckbox,
-  FormikDatePicker,
-  FormikEffect,
-  FormikTextarea,
-  Icon,
-  useNewWindow
-} from '@mtes-mct/monitor-ui'
+import { FormikCheckbox, FormikEffect, FormikTextarea, Icon } from '@mtes-mct/monitor-ui'
 import { Formik } from 'formik'
 import { noop } from 'lodash/fp'
 import { useMemo } from 'react'
@@ -38,8 +32,6 @@ type SeaControlFormProps = Readonly<{
   onChange: (nextValues: MissionActionFormValues) => Promisable<void>
 }>
 export function SeaControlForm({ initialValues, onChange }: SeaControlFormProps) {
-  const { newWindowContainerRef } = useNewWindow()
-
   const isClosing = useMainAppSelector(store => store.missionForm.isClosing)
 
   const titleDate = useMemo(
@@ -68,16 +60,7 @@ export function SeaControlForm({ initialValues, onChange }: SeaControlFormProps)
           <FormBody>
             <VesselField />
 
-            <FormikDatePicker
-              baseContainer={newWindowContainerRef.current}
-              isErrorMessageHidden
-              isLight
-              isRequired
-              isStringDate
-              label="Date et heure du contrôle"
-              name="actionDatetimeUtc"
-              withTime
-            />
+            <DatePickerField />
 
             <FormikCoordinatesPicker />
 

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/DatePickerField.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/DatePickerField.tsx
@@ -1,0 +1,28 @@
+import { HIDDEN_ERROR } from '@features/Mission/components/MissionForm/constants'
+import { FieldError, FormikDatePicker, useNewWindow } from '@mtes-mct/monitor-ui'
+import { useFormikContext } from 'formik'
+
+import type { MissionActionFormValues } from '../../types'
+
+export function DatePickerField() {
+  const { newWindowContainerRef } = useNewWindow()
+  const { errors } = useFormikContext<MissionActionFormValues>()
+
+  const error = errors.actionDatetimeUtc
+
+  return (
+    <>
+      <FormikDatePicker
+        baseContainer={newWindowContainerRef.current}
+        isErrorMessageHidden
+        isLight
+        isRequired
+        isStringDate
+        label="Date et heure du contrôle"
+        name="actionDatetimeUtc"
+        withTime
+      />
+      {error && error !== HIDDEN_ERROR && <FieldError>{error}</FieldError>}
+    </>
+  )
+}

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/DatePickerField.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/DatePickerField.tsx
@@ -1,5 +1,5 @@
 import { HIDDEN_ERROR } from '@features/Mission/components/MissionForm/constants'
-import { FieldError, FormikDatePicker, useNewWindow } from '@mtes-mct/monitor-ui'
+import { FormikDatePicker, useNewWindow } from '@mtes-mct/monitor-ui'
 import { useFormikContext } from 'formik'
 
 import type { MissionActionFormValues } from '../../types'
@@ -11,18 +11,15 @@ export function DatePickerField() {
   const error = errors.actionDatetimeUtc
 
   return (
-    <>
-      <FormikDatePicker
-        baseContainer={newWindowContainerRef.current}
-        isErrorMessageHidden
-        isLight
-        isRequired
-        isStringDate
-        label="Date et heure du contrôle"
-        name="actionDatetimeUtc"
-        withTime
-      />
-      {error && error !== HIDDEN_ERROR && <FieldError>{error}</FieldError>}
-    </>
+    <FormikDatePicker
+      baseContainer={newWindowContainerRef.current}
+      isErrorMessageHidden={error === HIDDEN_ERROR}
+      isLight
+      isRequired
+      isStringDate
+      label="Date et heure du contrôle"
+      name="actionDatetimeUtc"
+      withTime
+    />
   )
 }

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/FormikCoordinatesPicker.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/FormikCoordinatesPicker.tsx
@@ -4,7 +4,7 @@ import { addOrEditControlCoordinates } from '@features/Mission/useCases/addOrEdi
 import { useListenForDrawedGeometry } from '@hooks/useListenForDrawing'
 import { useMainAppDispatch } from '@hooks/useMainAppDispatch'
 import { useMainAppSelector } from '@hooks/useMainAppSelector'
-import { FieldError, MultiZoneEditor, OPENLAYERS_PROJECTION, WSG84_PROJECTION } from '@mtes-mct/monitor-ui'
+import { MultiZoneEditor, OPENLAYERS_PROJECTION, WSG84_PROJECTION } from '@mtes-mct/monitor-ui'
 import { isCypress } from '@utils/isCypress'
 import { convertToGeoJSONGeometryObject } from 'domain/entities/layers'
 import { InteractionListener, OpenLayersGeometryType } from 'domain/entities/map/constants'
@@ -152,7 +152,7 @@ export function FormikCoordinatesPicker() {
           name: 'Nouvelle coordonnée'
         }}
         isAddButtonDisabled={!!coordinates.length || listener === InteractionListener.CONTROL_POINT}
-        isErrorMessageHidden
+        isErrorMessageHidden={error === HIDDEN_ERROR}
         isLight
         isRequired
         label="Lieu du contrôle"
@@ -164,7 +164,6 @@ export function FormikCoordinatesPicker() {
         onDelete={deleteCoordinates}
         onEdit={addOrEditCoordinates}
       />
-      {error && error !== HIDDEN_ERROR && <FieldError>{error}</FieldError>}
     </>
   )
 }


### PR DESCRIPTION
## Linked issues

- Resolve #3042 

----

- [ ] Tests E2E (Cypress)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new `DatePickerField` component for better date and time selection in mission action forms.

- **Refactor**
	- Replaced `FormikDatePicker` with `DatePickerField` across various mission action forms to ensure consistency and improve usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->