### PR TITLE
[Point d'intérêt] L'icône des points placés est décalée par rapport à la position réelle 

### DIFF
--- a/frontend/src/features/map/layers/styles/interestPoint.style.tsx
+++ b/frontend/src/features/map/layers/styles/interestPoint.style.tsx
@@ -44,7 +44,10 @@ export const getInterestPointStyle = (feature, resolution) => {
   }
 
   const style = interestPointStylesCache.get(type)
-  style[0].getImage().setScale(1 / resolution ** (1 / 8) + 0.3)
+  const scale = 1 / resolution ** (1 / 8) + 0.3
+  const verticalIconOffset = 18
+  style[0].getImage().setScale(scale)
+  style[0].getImage().setDisplacement([0, verticalIconOffset * scale])
 
   return style
 }

--- a/frontend/src/features/map/layers/styles/interestPoint.style.tsx
+++ b/frontend/src/features/map/layers/styles/interestPoint.style.tsx
@@ -44,10 +44,18 @@ export const getInterestPointStyle = (feature, resolution) => {
   }
 
   const style = interestPointStylesCache.get(type)
-  const scale = 1 / resolution ** (1 / 8) + 0.3
-  const verticalIconOffset = 18
-  style[0].getImage().setScale(scale)
-  style[0].getImage().setDisplacement([0, verticalIconOffset * scale])
+
+  const SCALE_BASE = 1 / 8 // Scale factor to reduce the size of the icon when dezooming
+  const SCALE_ADDITION = 0.3 // Minimum scale number
+  const VERTICAL_ICON_OFFSET = 18
+
+  const scale = 1 / resolution ** SCALE_BASE + SCALE_ADDITION
+  const verticalIconOffset = VERTICAL_ICON_OFFSET
+
+  const iconImage = style[0].getImage()
+
+  iconImage.setScale(scale)
+  iconImage.setDisplacement([0, verticalIconOffset * scale])
 
   return style
 }


### PR DESCRIPTION
## Linked issues

- Resolve #3074

----

- [ ] Tests E2E (Cypress)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the calculation of scale and vertical icon offset for map interest points for better visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->