### PR TITLE
Utiliser les FAR plutôt que les DEP pour déterminer les engins de la marée

### DIFF
--- a/datascience/tests/test_pipeline/test_flows/test_current_segments.py
+++ b/datascience/tests/test_pipeline/test_flows/test_current_segments.py
@@ -38,8 +38,8 @@ def current_segments() -> pd.DataFrame:
             ],
             "trip_number": ["20210001", "20210002"],
             "gear_onboard": [
-                [{"gear": "OTM", "mesh": 80.0}],
-                [{"gear": "OTB", "mesh": 80.0}],
+                [{"gear": "OTM", "mesh": 80.0, "dimensions": None}],
+                [{"gear": "OTB", "mesh": 80.0, "dimensions": None}],
             ],
             "species_onboard": [
                 [


### PR DESCRIPTION
## Linked issues

- Resolve #2061


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the fishing catch data structure to include new fields such as `mesh` and `dimensions`, providing more detailed information on catches.
- **Refactor**
	- Improved data retrieval and processing for fishing activities by restructuring queries and aggregating gear information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->