### PR TITLE
Préavis - Déplacement du endpoint  de téléchargement des PDF sur `/api`

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationController.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationController.kt
@@ -13,12 +13,7 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.websocket.server.PathParam
 import org.springframework.data.domain.Sort
-import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import java.time.format.DateTimeFormatter.ISO_DATE_TIME
 
 @RestController
 @RequestMapping("/bff/v1/prior_notifications")
@@ -262,29 +257,5 @@ class PriorNotificationController(
         )
 
         return PriorNotificationDetailDataOutput.fromPriorNotification(updatedPriorNotification)
-    }
-
-    @GetMapping("/{reportId}/pdf")
-    @Operation(summary = "Get the PDF document")
-    fun getPdfDocument(
-        @PathParam("Logbook message `reportId`")
-        @PathVariable(name = "reportId")
-        reportId: String,
-    ): ResponseEntity<ByteArray?> {
-        val pdfDocument = getPriorNotificationPdfDocument.execute(reportId = reportId)
-        if (pdfDocument.pdfDocument == null) {
-            ResponseEntity.status(HttpStatus.NOT_FOUND).body(null)
-        }
-
-        val fileName = "preavis_debarquement_${pdfDocument.generationDatetimeUtc.format(ISO_DATE_TIME)}.pdf"
-        val headers = HttpHeaders().apply {
-            contentType = MediaType.APPLICATION_PDF
-            setContentDispositionFormData(
-                "attachment",
-                fileName,
-            )
-        }
-
-        return ResponseEntity(pdfDocument.pdfDocument, headers, HttpStatus.OK)
     }
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationController.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationController.kt
@@ -26,7 +26,6 @@ class PriorNotificationController(
     private val getPriorNotificationTypes: GetPriorNotificationTypes,
     private val updatePriorNotificationNote: UpdatePriorNotificationNote,
     private val verifyAndSendPriorNotification: VerifyAndSendPriorNotification,
-    private val getPriorNotificationPdfDocument: GetPriorNotificationPdfDocument,
 ) {
     @GetMapping("")
     @Operation(summary = "Get all prior notifications")

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicPriorNotificationController.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicPriorNotificationController.kt
@@ -1,0 +1,47 @@
+package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
+
+import fr.gouv.cnsp.monitorfish.domain.use_cases.prior_notification.GetPriorNotificationPdfDocument
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.websocket.server.PathParam
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.format.DateTimeFormatter.ISO_DATE_TIME
+
+@RestController
+@RequestMapping("/api/v1/prior_notifications")
+@Tag(name = "Prior notifications endpoints")
+class PublicPriorNotificationController(
+    private val getPriorNotificationPdfDocument: GetPriorNotificationPdfDocument,
+) {
+    // FIXME Move this API to `/bff`
+    @GetMapping("/pdf/{reportId}")
+    @Operation(summary = "Get the PDF document")
+    fun getPdfDocument(
+        @PathParam("Logbook message `reportId`")
+        @PathVariable(name = "reportId")
+        reportId: String,
+    ): ResponseEntity<ByteArray?> {
+        val pdfDocument = getPriorNotificationPdfDocument.execute(reportId = reportId)
+        if (pdfDocument.pdfDocument == null) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).body(null)
+        }
+
+        val fileName = "preavis_debarquement_${pdfDocument.generationDatetimeUtc.format(ISO_DATE_TIME)}.pdf"
+        val headers = HttpHeaders().apply {
+            contentType = MediaType.APPLICATION_PDF
+            setContentDispositionFormData(
+                "attachment",
+                fileName,
+            )
+        }
+
+        return ResponseEntity(pdfDocument.pdfDocument, headers, HttpStatus.OK)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationControllerITests.kt
@@ -6,8 +6,6 @@ import com.nhaarman.mockitokotlin2.anyOrNull
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.logbook.LogbookMessagePurpose
 import fr.gouv.cnsp.monitorfish.domain.entities.prior_notification.ManualPriorNotificationComputedValues
-import fr.gouv.cnsp.monitorfish.domain.entities.prior_notification.PdfDocument
-import fr.gouv.cnsp.monitorfish.domain.entities.prior_notification.PriorNotificationSource
 import fr.gouv.cnsp.monitorfish.domain.entities.prior_notification.PriorNotificationStats
 import fr.gouv.cnsp.monitorfish.domain.use_cases.prior_notification.*
 import fr.gouv.cnsp.monitorfish.domain.utils.PaginatedList
@@ -26,13 +24,14 @@ import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.ZonedDateTime
 
 @Import(SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(PriorNotificationController::class)])
-class PublicPriorNotificationControllerITests {
+class PriorNotificationControllerITests {
     @Autowired
     private lateinit var api: MockMvc
 
@@ -56,9 +55,6 @@ class PublicPriorNotificationControllerITests {
 
     @MockBean
     private lateinit var updatePriorNotificationNote: UpdatePriorNotificationNote
-
-    @MockBean
-    private lateinit var getPriorNotificationPdfDocument: GetPriorNotificationPdfDocument
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper
@@ -339,61 +335,5 @@ class PublicPriorNotificationControllerITests {
                     equalTo(fakePriorNotification.logbookMessageTyped.typedMessage.note),
                 ),
             )
-    }
-
-    @Test
-    fun `getPdf Should get the PDF of a prior notification`() {
-        val dummyPdfContent = """
-            %PDF-1.4
-            1 0 obj
-            << /Type /Catalog /Pages 2 0 R >>
-            endobj
-            2 0 obj
-            << /Type /Pages /Kids [3 0 R] /Count 1 >>
-            endobj
-            3 0 obj
-            << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R >>
-            endobj
-            4 0 obj
-            << /Length 55 >>
-            stream
-            BT
-            /F1 24 Tf
-            100 700 Td
-            (Hello, World!) Tj
-            ET
-            endstream
-            endobj
-            xref
-            0 5
-            0000000000 65535 f
-            0000000010 00000 n
-            0000000062 00000 n
-            0000000113 00000 n
-            0000000218 00000 n
-            trailer
-            << /Size 5 /Root 1 0 R >>
-            startxref
-            291
-            %%EOF
-        """.trimIndent().toByteArray()
-
-        // Given
-        given(getPriorNotificationPdfDocument.execute("REPORT_ID"))
-            .willReturn(
-                PdfDocument(
-                    reportId = "REPORT_ID",
-                    source = PriorNotificationSource.LOGBOOK,
-                    generationDatetimeUtc = ZonedDateTime.now(),
-                    pdfDocument = dummyPdfContent,
-                ),
-            )
-
-        // When
-        api.perform(get("/api/v1/prior_notifications/pdf/REPORT_ID"))
-            // Then
-            .andExpect(status().isOk)
-            .andExpect(content().contentType(MediaType.APPLICATION_PDF))
-            .andExpect(content().bytes(dummyPdfContent))
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PublicPriorNotificationControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PublicPriorNotificationControllerITests.kt
@@ -32,7 +32,7 @@ import java.time.ZonedDateTime
 @Import(SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(PriorNotificationController::class)])
-class PriorNotificationControllerITests {
+class PublicPriorNotificationControllerITests {
     @Autowired
     private lateinit var api: MockMvc
 
@@ -390,7 +390,7 @@ class PriorNotificationControllerITests {
             )
 
         // When
-        api.perform(get("/bff/v1/prior_notifications/REPORT_ID/pdf"))
+        api.perform(get("/api/v1/prior_notifications/pdf/REPORT_ID"))
             // Then
             .andExpect(status().isOk)
             .andExpect(content().contentType(MediaType.APPLICATION_PDF))

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicPriorNotificationControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicPriorNotificationControllerITests.kt
@@ -1,0 +1,90 @@
+package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import fr.gouv.cnsp.monitorfish.config.SentryConfig
+import fr.gouv.cnsp.monitorfish.domain.entities.prior_notification.PdfDocument
+import fr.gouv.cnsp.monitorfish.domain.entities.prior_notification.PriorNotificationSource
+import fr.gouv.cnsp.monitorfish.domain.use_cases.prior_notification.GetPriorNotificationPdfDocument
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.ZonedDateTime
+
+@Import(SentryConfig::class)
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(value = [(PublicPriorNotificationController::class)])
+class PublicPriorNotificationControllerITests {
+    @Autowired
+    private lateinit var api: MockMvc
+
+    @MockBean
+    private lateinit var getPriorNotificationPdfDocument: GetPriorNotificationPdfDocument
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Test
+    fun `getPdf Should get the PDF of a prior notification`() {
+        val dummyPdfContent = """
+            %PDF-1.4
+            1 0 obj
+            << /Type /Catalog /Pages 2 0 R >>
+            endobj
+            2 0 obj
+            << /Type /Pages /Kids [3 0 R] /Count 1 >>
+            endobj
+            3 0 obj
+            << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R >>
+            endobj
+            4 0 obj
+            << /Length 55 >>
+            stream
+            BT
+            /F1 24 Tf
+            100 700 Td
+            (Hello, World!) Tj
+            ET
+            endstream
+            endobj
+            xref
+            0 5
+            0000000000 65535 f
+            0000000010 00000 n
+            0000000062 00000 n
+            0000000113 00000 n
+            0000000218 00000 n
+            trailer
+            << /Size 5 /Root 1 0 R >>
+            startxref
+            291
+            %%EOF
+        """.trimIndent().toByteArray()
+
+        // Given
+        given(getPriorNotificationPdfDocument.execute("REPORT_ID"))
+            .willReturn(
+                PdfDocument(
+                    reportId = "REPORT_ID",
+                    source = PriorNotificationSource.LOGBOOK,
+                    generationDatetimeUtc = ZonedDateTime.now(),
+                    pdfDocument = dummyPdfContent,
+                ),
+            )
+
+        // When
+        api.perform(get("/api/v1/prior_notifications/pdf/REPORT_ID"))
+            // Then
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_PDF))
+            .andExpect(content().bytes(dummyPdfContent))
+    }
+}

--- a/frontend/cypress/e2e/side_window/prior_notification_card/card.spec.ts
+++ b/frontend/cypress/e2e/side_window/prior_notification_card/card.spec.ts
@@ -216,6 +216,6 @@ context('Side Window > Prior Notification Card > Card', () => {
     cy.clickButton('Télécharger')
 
     // Verify that window.open was called with the correct URL
-    cy.get('@windowOpen').should('be.calledWith', '/bff/v1/prior_notifications/FAKE_OPERATION_102/pdf', '_blank')
+    cy.get('@windowOpen').should('be.calledWith', '/api/v1/prior_notifications/pdf/FAKE_OPERATION_102', '_blank')
   })
 })

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -148,7 +148,21 @@ const monitorfishPublicBaseQuery = retry(
 )
 
 export const monitorfishPublicApi = createApi({
-  baseQuery: normalizeRtkBaseQuery(monitorfishPublicBaseQuery),
+  baseQuery: async (args: RTKBaseQueryArgs, api, extraOptions) => {
+    const result = await normalizeRtkBaseQuery(monitorfishPublicBaseQuery)(args, api, extraOptions)
+    if (result.error) {
+      const error: CustomRTKResponseError = {
+        path: typeof args === 'string' ? args : args.url,
+        requestData: typeof args === 'string' ? undefined : args.body,
+        responseData: result.error.data as BackendApi.ResponseBodyError,
+        status: result.error.status
+      }
+
+      return { error }
+    }
+
+    return result
+  },
   endpoints: () => ({}),
   reducerPath: 'monitorfishPublicApi',
   tagTypes: ['Infractions']

--- a/frontend/src/features/PriorNotification/components/shared/DownloadButton/index.tsx
+++ b/frontend/src/features/PriorNotification/components/shared/DownloadButton/index.tsx
@@ -24,7 +24,7 @@ export function DownloadButton({ isDisabled = false, pnoLogbookMessage, reportId
   const isPriorNotificationPDFDocumentAvailable = useMemo(() => !isError, [isError])
   const hasAuthorizedLandingDownload =
     isSuperUser && getAlpha2CodeFromAlpha2or3Code(pnoLogbookMessage.flagState) !== 'FR'
-  const pdfUrl = `/bff/v1/prior_notifications/${reportId}/pdf`
+  const pdfUrl = `/api/v1/prior_notifications/pdf/${reportId}`
 
   const gearsWithName = useMemo(() => {
     if (!getGearsApiQuery.data || !pnoLogbookMessage?.tripGears) {

--- a/frontend/src/features/PriorNotification/priorNotificationApi.ts
+++ b/frontend/src/features/PriorNotification/priorNotificationApi.ts
@@ -1,4 +1,4 @@
-import { monitorfishApi } from '@api/api'
+import { monitorfishApi, monitorfishPublicApi } from '@api/api'
 import { BackendApi } from '@api/BackendApi.types'
 import { RtkCacheTagType } from '@api/constants'
 import { FrontendApiError } from '@libs/FrontendApiError'
@@ -65,18 +65,6 @@ export const priorNotificationApi = monitorfishApi.injectEndpoints({
       providesTags: (_, __, reportId) => [{ id: reportId, type: RtkCacheTagType.PriorNotification }],
       query: reportId => `/prior_notifications/manual/${reportId}`,
       transformErrorResponse: response => new FrontendApiError(GET_PRIOR_NOTIFICATION_DATA_ERROR_MESSAGE, response)
-    }),
-
-    // https://redux-toolkit.js.org/rtk-query/api/fetchBaseQuery#parsing-a-response
-    getPriorNotificationPDF: builder.query<string, string>({
-      extraOptions: { maxRetries: 0 },
-      forceRefetch: () => true,
-      query: reportId => ({
-        method: 'GET',
-        responseHandler: response => response.text(),
-        url: `/prior_notifications/${reportId}/pdf`
-      }),
-      transformErrorResponse: response => new FrontendApiError(GET_PRIOR_NOTIFICATION_PDF_ERROR_MESSAGE, response)
     }),
 
     getPriorNotifications: builder.query<
@@ -173,9 +161,22 @@ export const priorNotificationApi = monitorfishApi.injectEndpoints({
   })
 })
 
-export const {
-  useGetPriorNotificationDetailQuery,
-  useGetPriorNotificationPDFQuery,
-  useGetPriorNotificationsQuery,
-  useGetPriorNotificationTypesQuery
-} = priorNotificationApi
+export const priorNotificationPublicApi = monitorfishPublicApi.injectEndpoints({
+  endpoints: builder => ({
+    getPriorNotificationPDF: builder.query<string, string>({
+      extraOptions: { maxRetries: 0 },
+      forceRefetch: () => true,
+      query: reportId => ({
+        method: 'GET',
+        responseHandler: response => response.text(),
+        url: `/v1/prior_notifications/pdf/${reportId}`
+      }),
+      transformErrorResponse: response => new FrontendApiError(GET_PRIOR_NOTIFICATION_PDF_ERROR_MESSAGE, response)
+    })
+  })
+})
+
+export const { useGetPriorNotificationDetailQuery, useGetPriorNotificationsQuery, useGetPriorNotificationTypesQuery } =
+  priorNotificationApi
+
+export const { useGetPriorNotificationPDFQuery } = priorNotificationPublicApi

--- a/frontend/src/features/PriorNotification/useCases/updatePriorNotificationNote.ts
+++ b/frontend/src/features/PriorNotification/useCases/updatePriorNotificationNote.ts
@@ -3,7 +3,7 @@ import { FrontendApiError } from '@libs/FrontendApiError'
 import { handleThunkError } from '@utils/handleThunkError'
 import { displayOrLogError } from 'domain/use_cases/error/displayOrLogError'
 
-import { priorNotificationApi } from '../priorNotificationApi'
+import { priorNotificationApi, priorNotificationPublicApi } from '../priorNotificationApi'
 
 import type { MainAppThunk } from '@store'
 
@@ -18,7 +18,7 @@ export const updatePriorNotificationNote =
         })
       ).unwrap()
 
-      await dispatch(priorNotificationApi.endpoints.getPriorNotificationPDF.initiate(reportId)).unwrap()
+      await dispatch(priorNotificationPublicApi.endpoints.getPriorNotificationPDF.initiate(reportId)).unwrap()
     } catch (err) {
       if (err instanceof FrontendApiError) {
         dispatch(displayOrLogError(err, undefined, true, DisplayedErrorKey.SIDE_WINDOW_PRIOR_NOTIFICATION_FORM_ERROR))


### PR DESCRIPTION
## Linked issues

- Car on ne peut pas sécuriser ce endpoint avec `window.open`.
- Pour éviter de bloquer l'activation de Cerbère

----

- [ ] Tests E2E (Cypress)
