### PR TITLE
Préavis - Afficher le champ note dans la partie `ext`

### DIFF
--- a/frontend/src/features/Logbook/LogbookMessage.types.ts
+++ b/frontend/src/features/Logbook/LogbookMessage.types.ts
@@ -78,6 +78,7 @@ export namespace LogbookMessage {
 
   interface MessageBase {}
   export interface PnoMessage extends MessageBase {
+    authorTrigram: string | undefined
     catchOnboard: Catch[] | undefined
     catchToLand: Catch[] | undefined
     economicZone: string | undefined

--- a/frontend/src/features/PriorNotification/components/LogbookPriorNotificationForm/Form.tsx
+++ b/frontend/src/features/PriorNotification/components/LogbookPriorNotificationForm/Form.tsx
@@ -58,10 +58,14 @@ export function Form({ detail, initialFormValues }: FormProps) {
           <FormikEffect onChange={!isInvalidated ? (updateNote as any) : noop} />
 
           <FieldGroup>
-            <FormikTextarea label="Points d'attention identifiés par le CNSP" name="note" readOnly={isInvalidated} />
+            <FormikTextarea
+              label="Points d'attention identifiés par le CNSP"
+              name="note"
+              readOnly={!isSuperUser || isInvalidated}
+            />
           </FieldGroup>
 
-          <AuthorTrigramInput label="Par" name="authorTrigram" readOnly={isInvalidated} />
+          {isSuperUser && <AuthorTrigramInput label="Par" name="authorTrigram" readOnly={isInvalidated} />}
         </>
       </Formik>
 

--- a/frontend/src/features/PriorNotification/components/LogbookPriorNotificationForm/index.tsx
+++ b/frontend/src/features/PriorNotification/components/LogbookPriorNotificationForm/index.tsx
@@ -7,10 +7,12 @@ import { assertNotNullish } from '@utils/assertNotNullish'
 
 import { Footer } from './Footer'
 import { Form } from './Form'
+import { useIsSuperUser } from '../../../../auth/hooks/useIsSuperUser'
 import { PriorNotificationCard } from '../PriorNotificationCard'
 
 export function LogbookPriorNotificationForm() {
   const dispatch = useMainAppDispatch()
+  const isSuperUser = useIsSuperUser()
   const displayedError = useMainAppSelector(
     state => state.displayedError[DisplayedErrorKey.SIDE_WINDOW_PRIOR_NOTIFICATION_FORM_ERROR]
   )
@@ -45,7 +47,9 @@ export function LogbookPriorNotificationForm() {
         <Form detail={openedPriorNotificationDetail} initialFormValues={editedLogbookPriorNotificationFormValues} />
       }
       detail={openedPriorNotificationDetail}
-      footerChildren={<Footer detail={openedPriorNotificationDetail} onVerifyAndSend={verifyAndSend} />}
+      footerChildren={
+        isSuperUser ? <Footer detail={openedPriorNotificationDetail} onVerifyAndSend={verifyAndSend} /> : null
+      }
     />
   )
 }

--- a/frontend/src/features/PriorNotification/components/PriorNotificationList/index.tsx
+++ b/frontend/src/features/PriorNotification/components/PriorNotificationList/index.tsx
@@ -35,7 +35,6 @@ import { useGetPriorNotificationsQuery, useGetPriorNotificationsToVerifyQuery } 
 import { priorNotificationActions } from '../../slice'
 import { LogbookPriorNotificationForm } from '../LogbookPriorNotificationForm'
 import { ManualPriorNotificationForm } from '../ManualPriorNotificationForm'
-import { PriorNotificationCard } from '../PriorNotificationCard'
 
 import type { AllSeafrontGroup, NoSeafrontGroup, SeafrontGroup } from '@constants/seafront'
 
@@ -238,12 +237,6 @@ export function PriorNotificationList({ isFromUrl }: PriorNotificationListProps)
         </Body>
       </Page>
 
-      {openedPriorNotificationComponentType === OpenedPriorNotificationType.Card && (
-        <PriorNotificationCard
-          key={openedPriorNotificationDetail?.fingerprint}
-          detail={openedPriorNotificationDetail}
-        />
-      )}
       {openedPriorNotificationComponentType === OpenedPriorNotificationType.LogbookForm && (
         <LogbookPriorNotificationForm key={openedPriorNotificationDetail?.fingerprint} />
       )}

--- a/frontend/src/features/PriorNotification/components/shared/DownloadButton/__tests__/getHtmlContent.test.ts
+++ b/frontend/src/features/PriorNotification/components/shared/DownloadButton/__tests__/getHtmlContent.test.ts
@@ -25,6 +25,7 @@ describe('PriorNotificationCard/utils.getHtmlContent()', () => {
       isManuallyCreated: true,
       isSentByFailoverSoftware: false,
       message: {
+        authorTrigram: undefined,
         catchOnboard: [
           {
             conversionFactor: undefined,

--- a/frontend/src/features/PriorNotification/constants.ts
+++ b/frontend/src/features/PriorNotification/constants.ts
@@ -1,5 +1,4 @@
 export enum OpenedPriorNotificationType {
-  Card = 'Card',
   LogbookForm = 'LogbookForm',
   ManualForm = 'ManualForm'
 }

--- a/frontend/src/features/PriorNotification/useCases/openPriorNotificationCard.ts
+++ b/frontend/src/features/PriorNotification/useCases/openPriorNotificationCard.ts
@@ -6,6 +6,7 @@ import { Level } from '@mtes-mct/monitor-ui'
 import { handleThunkError } from '@utils/handleThunkError'
 import { displayedErrorActions } from 'domain/shared_slices/DisplayedError'
 import { displayOrLogError } from 'domain/use_cases/error/displayOrLogError'
+import { pick } from 'lodash'
 
 import { OpenedPriorNotificationType } from '../constants'
 import { priorNotificationApi } from '../priorNotificationApi'
@@ -24,7 +25,7 @@ export const openPriorNotificationCard =
     try {
       dispatch(displayedErrorActions.unset(DisplayedErrorKey.SIDE_WINDOW_PRIOR_NOTIFICATION_CARD_ERROR))
       dispatch(priorNotificationActions.closePriorNotificationCardAndForm())
-      dispatch(priorNotificationActions.openPriorNotification(OpenedPriorNotificationType.Card))
+      dispatch(priorNotificationActions.openPriorNotification(OpenedPriorNotificationType.LogbookForm))
 
       const priorNotificationDetail = await dispatch(
         priorNotificationApi.endpoints.getPriorNotificationDetail.initiate({
@@ -55,6 +56,8 @@ export const openPriorNotificationCard =
       }
 
       dispatch(priorNotificationActions.setOpenedPriorNotificationDetail(priorNotificationDetail))
+      const priorNotificationData = pick(priorNotificationDetail.logbookMessage.message, ['note', 'authorTrigram'])
+      dispatch(priorNotificationActions.setEditedLogbookPriorNotificationFormValues(priorNotificationData))
     } catch (err) {
       if (err instanceof FrontendApiError) {
         dispatch(


### PR DESCRIPTION
## Linked issues

- Le champ note des préavis n'est pas visible dans la partie `ext`

----

- [ ] Tests E2E (Cypress)
