### PR TITLE
Contrôles - Modification de la date de début d'actions par RapportNav

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/mission/mission_actions/MissionAction.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/mission/mission_actions/MissionAction.kt
@@ -17,7 +17,8 @@ data class MissionAction(
     val districtCode: String? = null,
     val faoAreas: List<String> = listOf(),
     val actionType: MissionActionType,
-    val actionDatetimeUtc: ZonedDateTime,
+    @Patchable
+    var actionDatetimeUtc: ZonedDateTime,
     @Patchable
     var actionEndDatetimeUtc: ZonedDateTime? = null,
     val emitsVms: ControlCheck? = null,

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/mission/mission_actions/PatchableMissionAction.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/mission/mission_actions/PatchableMissionAction.kt
@@ -4,6 +4,7 @@ import java.time.ZonedDateTime
 import java.util.*
 
 data class PatchableMissionAction(
+    val actionDatetimeUtc  : Optional<ZonedDateTime>?,
     val actionEndDatetimeUtc: Optional<ZonedDateTime>?,
     val observationsByUnit: Optional<String>?,
 )

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/input/PatchableMissionActionDataInput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/input/PatchableMissionActionDataInput.kt
@@ -5,11 +5,13 @@ import java.time.ZonedDateTime
 import java.util.*
 
 data class PatchableMissionActionDataInput(
+    val actionDatetimeUtc: Optional<ZonedDateTime>?,
     val actionEndDatetimeUtc: Optional<ZonedDateTime>?,
     val observationsByUnit: Optional<String>?,
 ) {
     fun toPatchableMissionAction(): PatchableMissionAction {
         return PatchableMissionAction(
+            actionDatetimeUtc = actionDatetimeUtc,
             actionEndDatetimeUtc = actionEndDatetimeUtc,
             observationsByUnit = observationsByUnit,
         )

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission/mission_actions/PatchMissionActionUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission/mission_actions/PatchMissionActionUTests.kt
@@ -30,11 +30,14 @@ class PatchMissionActionUTests {
     @Test
     fun `execute Should patch an existing action`() {
         // Given
+        val originalDateTime = ZonedDateTime.now()
+        val expectedDateTime = originalDateTime.plusDays(1)
+        val expectedEndDateTime = originalDateTime.plusDays(2)
         val action = MissionAction(
             id = null,
             vesselId = null,
             missionId = 1,
-            actionDatetimeUtc = ZonedDateTime.now(),
+            actionDatetimeUtc = originalDateTime,
             portLocode = "AEFAT",
             actionType = MissionActionType.LAND_CONTROL,
             gearOnboard = listOf(),
@@ -49,9 +52,10 @@ class PatchMissionActionUTests {
             completion = Completion.TO_COMPLETE,
         )
         given(missionActionsRepository.findById(any())).willReturn(action)
-        val expectedDateTime = ZonedDateTime.now()
+
         val patch = PatchableMissionAction(
-            actionEndDatetimeUtc = Optional.of(expectedDateTime),
+            actionDatetimeUtc = Optional.of(expectedDateTime),
+            actionEndDatetimeUtc = Optional.of(expectedEndDateTime),
             observationsByUnit = Optional.of("An observation"),
         )
 
@@ -63,9 +67,52 @@ class PatchMissionActionUTests {
             verify(missionActionsRepository).save(capture())
 
             assertThat(allValues.first().observationsByUnit).isEqualTo("An observation")
-            assertThat(allValues.first().actionEndDatetimeUtc).isEqualTo(expectedDateTime)
+            assertThat(allValues.first().actionDatetimeUtc).isEqualTo(expectedDateTime)
+            assertThat(allValues.first().actionEndDatetimeUtc).isEqualTo(expectedEndDateTime)
             assertThat(allValues.first().userTrigram).isEqualTo("LTH")
             assertThat(allValues.first().actionType).isEqualTo(MissionActionType.LAND_CONTROL)
+        }
+    }
+
+    @Test
+    fun `execute Should patch an existing action without overriding the start datetime if not provided`() {
+        // Given
+        val originalDateTime = ZonedDateTime.now()
+        val expectedEndDateTime = originalDateTime.plusDays(2)
+        val action = MissionAction(
+            id = null,
+            vesselId = null,
+            missionId = 1,
+            actionDatetimeUtc = originalDateTime,
+            portLocode = "AEFAT",
+            actionType = MissionActionType.LAND_CONTROL,
+            gearOnboard = listOf(),
+            seizureAndDiversion = true,
+            isDeleted = false,
+            hasSomeGearsSeized = false,
+            hasSomeSpeciesSeized = false,
+            completedBy = "XYZ",
+            isFromPoseidon = false,
+            flagState = CountryCode.FR,
+            userTrigram = "LTH",
+            completion = Completion.TO_COMPLETE,
+        )
+        given(missionActionsRepository.findById(any())).willReturn(action)
+
+        val patch = PatchableMissionAction(
+            actionDatetimeUtc = null,
+            actionEndDatetimeUtc = Optional.of(expectedEndDateTime),
+            observationsByUnit = null,
+        )
+
+        // When
+        PatchMissionAction(missionActionsRepository, patchMissionAction).execute(123, patch)
+
+        // Then
+        argumentCaptor<MissionAction>().apply {
+            verify(missionActionsRepository).save(capture())
+            assertThat(allValues.first().actionDatetimeUtc).isEqualTo(originalDateTime)
+            assertThat(allValues.first().actionEndDatetimeUtc).isEqualTo(expectedEndDateTime)
         }
     }
 }


### PR DESCRIPTION
## Description

La date de début d'une action est aussi censée être éditable par les unités terrain.

Dites moi si j'ai oublié des choses dans la PR

----

- [ ] Tests E2E (Cypress)
