### PR TITLE
Préavis – Ajouter l'adresse du CNSP à la diffusion des préavis

### DIFF
--- a/datascience/src/pipeline/flows/distribute_pnos.py
+++ b/datascience/src/pipeline/flows/distribute_pnos.py
@@ -651,7 +651,7 @@ def create_email(pno: RenderedPno, test_mode: bool) -> PnoToSend:
             else:
                 return None
         else:
-            to = pno.emails
+            to = pno.emails + ["cnsp@example.org"]
 
         message = create_html_email(
             to=to,

--- a/datascience/tests/test_pipeline/test_flows/test_distribute_pnos.py
+++ b/datascience/tests/test_pipeline/test_flows/test_distribute_pnos.py
@@ -1639,7 +1639,7 @@ def test_create_email(
         assert pno_to_send.message["To"] == "pno.test@email.fr"
     else:
         assert (
-            pno_to_send.message["To"] == "alternative@email, some.email@control.unit.4"
+            pno_to_send.message["To"] == "alternative@email, some.email@control.unit.4, cnsp@example.org"
         )
     assert pno_to_send.message["From"] == "monitorfish@test.email"
     assert pno_to_send.message["Cc"] is None


### PR DESCRIPTION
## Linked issues

- Resolve #3596

----

- [ ] Tests E2E (Cypress)
