### PR TITLE
Préavis – Ajouter dans le formulaire de préavis manuels la possibilité de joindre des fichiers (certificats de capture, formulaires 2B, 3A...) et de les supprimer

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -53,3 +53,6 @@ log4j2.script.enableLanguages=javascript
 springdoc.packagesToScan=fr.gouv.cnsp.monitorfish
 monitorfish.sentry.enabled=${monitorfish.sentry.enabled}
 monitorfish.sentry.dsn=${sentry.dsn}
+
+# Multipart uploads
+spring.servlet.multipart.max-file-size=10MB

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -55,4 +55,4 @@ monitorfish.sentry.enabled=${monitorfish.sentry.enabled}
 monitorfish.sentry.dsn=${sentry.dsn}
 
 # Multipart uploads
-spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-file-size=5MB

--- a/frontend/cypress/e2e/side_window/manual_prior_notification_form/form.spec.ts
+++ b/frontend/cypress/e2e/side_window/manual_prior_notification_form/form.spec.ts
@@ -143,16 +143,16 @@ context('Side Window > Manual Prior Notification Form > Form', () => {
   })
 
   it('Should attach and remove a document to a manual prior notification', () => {
-    cy.intercept('GET', `/bff/v1/prior_notifications/00000000-0000-4000-0000-000000000002/uploads`).as('getUploads')
+    cy.intercept('GET', `/bff/v1/prior_notifications/00000000-0000-4000-0000-000000000008/uploads`).as('getUploads')
     cy.intercept(
       'POST',
-      `/bff/v1/prior_notifications/00000000-0000-4000-0000-000000000002/uploads?isManualPriorNotification=false&operationDate=*`
+      `/bff/v1/prior_notifications/00000000-0000-4000-0000-000000000008/uploads?isManualPriorNotification=true&operationDate=*`
     ).as('uploadDocument')
-    cy.intercept('DELETE', `/bff/v1/prior_notifications/00000000-0000-4000-0000-000000000002/uploads/*`).as(
+    cy.intercept('DELETE', `/bff/v1/prior_notifications/00000000-0000-4000-0000-000000000008/uploads/*`).as(
       'deleteDocument'
     )
 
-    editSideWindowPriorNotification(`DOS FIN`, '00000000-0000-4000-0000-000000000002')
+    editSideWindowPriorNotification(`DÉVOILÉ`, '00000000-0000-4000-0000-000000000008')
 
     cy.wait('@getUploads')
 

--- a/frontend/cypress/e2e/side_window/manual_prior_notification_form/form.spec.ts
+++ b/frontend/cypress/e2e/side_window/manual_prior_notification_form/form.spec.ts
@@ -142,6 +142,48 @@ context('Side Window > Manual Prior Notification Form > Form', () => {
     })
   })
 
+  it('Should attach and remove a document to a manual prior notification', () => {
+    cy.intercept('GET', `/bff/v1/prior_notifications/00000000-0000-4000-0000-000000000002/uploads`).as('getUploads')
+    cy.intercept(
+      'POST',
+      `/bff/v1/prior_notifications/00000000-0000-4000-0000-000000000002/uploads?isManualPriorNotification=false&operationDate=*`
+    ).as('uploadDocument')
+    cy.intercept('DELETE', `/bff/v1/prior_notifications/00000000-0000-4000-0000-000000000002/uploads/*`).as(
+      'deleteDocument'
+    )
+
+    editSideWindowPriorNotification(`DOS FIN`, '00000000-0000-4000-0000-000000000002')
+
+    cy.wait('@getUploads')
+
+    cy.fixture('sample.pdf').then(fileContent => {
+      cy.get('input[type=file]').selectFile(
+        {
+          contents: Cypress.Buffer.from(fileContent),
+          fileName: 'sample.pdf',
+          mimeType: 'application/pdf'
+        },
+        {
+          action: 'select',
+          force: true
+        }
+      )
+
+      cy.wait('@uploadDocument').then(() => {
+        cy.wait('@getUploads').wait(500)
+
+        cy.contains('.rs-uploader-file-item', 'sample.pdf')
+          .find('.rs-uploader-file-item-btn-remove .rs-icon')
+          .forceClick()
+
+        cy.wait('@deleteDocument')
+        cy.wait('@getUploads').wait(500)
+
+        cy.contains('sample.pdf').should('not.exist')
+      })
+    })
+  })
+
   it('Should display the expected manual prior notification form validation errors', () => {
     // -------------------------------------------------------------------------
     // Base form validation errors

--- a/frontend/src/features/PriorNotification/components/LogbookPriorNotificationForm/Form.tsx
+++ b/frontend/src/features/PriorNotification/components/LogbookPriorNotificationForm/Form.tsx
@@ -83,6 +83,7 @@ export function Form({ detail, initialFormValues }: FormProps) {
 
           <UploadFiles
             isManualPriorNotification={false}
+            isReadOnly={isReadOnly}
             operationDate={detail.operationDate}
             reportId={detail.reportId}
           />

--- a/frontend/src/features/PriorNotification/components/ManualPriorNotificationForm/Content.tsx
+++ b/frontend/src/features/PriorNotification/components/ManualPriorNotificationForm/Content.tsx
@@ -197,7 +197,12 @@ export function Content({ detail, isValidatingOnChange, onClose, onSubmit, onVer
             <>
               <hr style={{ marginBottom: 24 }} />
 
-              <UploadFiles isManualPriorNotification operationDate={detail.operationDate} reportId={detail.reportId} />
+              <UploadFiles
+                isManualPriorNotification
+                isReadOnly={isReadOnly}
+                operationDate={detail.operationDate}
+                reportId={detail.reportId}
+              />
             </>
           )}
 

--- a/frontend/src/features/PriorNotification/components/ManualPriorNotificationForm/Content.tsx
+++ b/frontend/src/features/PriorNotification/components/ManualPriorNotificationForm/Content.tsx
@@ -23,6 +23,7 @@ import { PriorNotification } from '../../PriorNotification.types'
 import { CardBanner } from '../shared/CardBanner'
 import { DownloadButton } from '../shared/DownloadButton'
 import { TagBar } from '../shared/TagBar'
+import { UploadFiles } from '../shared/UploadFiles'
 
 import type { ManualPriorNotificationFormValues } from './types'
 import type { Promisable } from 'type-fest'
@@ -191,6 +192,14 @@ export function Content({ detail, isValidatingOnChange, onClose, onSubmit, onVer
           <hr />
 
           <Form isReadOnly={isReadOnly} />
+
+          {detail && (
+            <>
+              <hr style={{ marginBottom: 24 }} />
+
+              <UploadFiles isManualPriorNotification operationDate={detail.operationDate} reportId={detail.reportId} />
+            </>
+          )}
 
           {!!detail && (
             <InvalidateButton

--- a/frontend/src/features/PriorNotification/components/shared/UploadFiles.tsx
+++ b/frontend/src/features/PriorNotification/components/shared/UploadFiles.tsx
@@ -17,10 +17,11 @@ import type { FileType } from 'rsuite/esm/Uploader'
 
 type UploadFilesProps = Readonly<{
   isManualPriorNotification: boolean
+  isReadOnly: boolean
   operationDate: string
   reportId: string
 }>
-export function UploadFiles({ isManualPriorNotification, operationDate, reportId }: UploadFilesProps) {
+export function UploadFiles({ isManualPriorNotification, isReadOnly, operationDate, reportId }: UploadFilesProps) {
   const dispatch = useMainAppDispatch()
   const headers = useAuthRequestHeaders()
 
@@ -89,8 +90,13 @@ export function UploadFiles({ isManualPriorNotification, operationDate, reportId
         onPreview={download}
         onRemove={remove}
         onSuccess={refetch}
+        readOnly={isReadOnly}
       >
-        <File>Glissez ou déposez des fichier à ajouter au préavis.</File>
+        <File>
+          {isReadOnly
+            ? `Ce préavis est en lecture seule, vous ne pouvez pas y déposer de fichier pour l'instant.`
+            : `Glissez ou déposez des fichier à ajouter au préavis.`}
+        </File>
       </Uploader>
     </Wrapper>
   )


### PR DESCRIPTION
> [!NOTE]
> Reste ensuite à envoyer ces documents par email côté Pipeline.

## Linked issues

- #3320

----

- [x] Tests E2E (Cypress)
