### PR TITLE
Tech - Correction du cache des unités de contrôles

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/repositories/ControlUnitRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/repositories/ControlUnitRepository.kt
@@ -1,9 +1,7 @@
 package fr.gouv.cnsp.monitorfish.domain.repositories
 
 import fr.gouv.cnsp.monitorfish.domain.entities.mission.ControlUnit
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
 
 interface ControlUnitRepository {
-    fun findAll(scope: CoroutineScope): Deferred<List<ControlUnit>>
+    fun findAll(): List<ControlUnit>
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/control_units/GetAllControlUnits.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/control_units/GetAllControlUnits.kt
@@ -3,7 +3,6 @@ package fr.gouv.cnsp.monitorfish.domain.use_cases.control_units
 import fr.gouv.cnsp.monitorfish.config.UseCase
 import fr.gouv.cnsp.monitorfish.domain.entities.mission.ControlUnit
 import fr.gouv.cnsp.monitorfish.domain.repositories.ControlUnitRepository
-import kotlinx.coroutines.runBlocking
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -14,8 +13,6 @@ class GetAllControlUnits(
     private val logger: Logger = LoggerFactory.getLogger(GetAllControlUnits::class.java)
 
     fun execute(): List<ControlUnit> {
-        return runBlocking {
-            return@runBlocking controlUnitsRepository.findAll(this).await()
-        }
+        return controlUnitsRepository.findAll()
     }
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/cache/CaffeineConfiguration.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/cache/CaffeineConfiguration.kt
@@ -94,7 +94,7 @@ class CaffeineConfiguration {
         val findBeaconCache = buildMinutesCache(findBeacon, ticker, 60)
 
         // Control Units
-        val controlUnitsCache = buildMinutesCache(controlUnits, ticker, oneWeek)
+        val controlUnitsCache = buildMinutesCache(controlUnits, ticker, oneDay)
 
         // FAO Areas
         val faoAreasCache = buildMinutesCache(faoAreas, ticker, oneWeek)

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/monitorenv/APIControlUnitRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/monitorenv/APIControlUnitRepository.kt
@@ -6,9 +6,7 @@ import fr.gouv.cnsp.monitorfish.domain.entities.mission.ControlUnit
 import fr.gouv.cnsp.monitorfish.domain.repositories.ControlUnitRepository
 import io.ktor.client.call.*
 import io.ktor.client.request.*
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.cache.annotation.Cacheable
@@ -22,8 +20,8 @@ class APIControlUnitRepository(
     private val logger: Logger = LoggerFactory.getLogger(APIControlUnitRepository::class.java)
 
     @Cacheable(value = ["control_units"])
-    override fun findAll(scope: CoroutineScope): Deferred<List<ControlUnit>> {
-        return scope.async {
+    override fun findAll(): List<ControlUnit> =
+        runBlocking {
             val missionsUrl = "${monitorenvProperties.url}/api/v1/control_units"
 
             try {
@@ -34,5 +32,4 @@ class APIControlUnitRepository(
                 listOf()
             }
         }
-    }
 }

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/monitorenv/APIControlUnitRepositoryITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/monitorenv/APIControlUnitRepositoryITests.kt
@@ -1,0 +1,63 @@
+package fr.gouv.cnsp.monitorfish.infrastructure.monitorenv
+
+import fr.gouv.cnsp.monitorfish.config.ApiClient
+import fr.gouv.cnsp.monitorfish.config.MonitorenvProperties
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import io.ktor.utils.io.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class APIControlUnitRepositoryITests {
+    @Test
+    fun `findAll Should return control units`() {
+        // Given
+        val mockEngine =
+            MockEngine { _ ->
+                respond(
+                    content =
+                        ByteReadChannel(
+                            """[
+                        {
+                          "id": 10016,
+                          "administration": "Douane",
+                          "isArchived": false,
+                          "name": "BSN Ste Maxime",
+                          "resources": [],
+                          "contact": null
+                        },
+                        {
+                          "id": 10017,
+                          "administration": "Douane",
+                          "isArchived": false,
+                          "name": "DF 25 Libecciu",
+                          "resources": [],
+                          "contact": null
+                        },
+                        {
+                          "id": 10018,
+                          "administration": "Douane",
+                          "isArchived": false,
+                          "name": "DF 61 Port-de-Bouc",
+                          "resources": [],
+                          "contact": null
+                        }
+                      ]""",
+                        ),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+        val apiClient = ApiClient(mockEngine)
+        val monitorenvProperties = MonitorenvProperties()
+        monitorenvProperties.url = "http://test"
+
+        // When
+        val controlUnits =
+            APIControlUnitRepository(monitorenvProperties, apiClient)
+                .findAll()
+
+        assertThat(controlUnits).hasSize(3)
+        assertThat(controlUnits.first().id).isEqualTo(10016)
+    }
+}


### PR DESCRIPTION
## Linked issues

- Resolve #3594 
- Le cache ne gère pas les `Deferred`, il faut le gérer manuellement

----

- [ ] Tests E2E (Cypress)
