### PR TITLE
Récupérer toutes les balises de Poséidon, pas uniquement celles qui sont associées à un navire à l'instant T

### DIFF
--- a/backend/src/main/resources/db/migration/internal/V0.284__Update_beacons_table.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.284__Update_beacons_table.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.beacons
+ALTER COLUMN logging_datetime_utc
+DROP NOT NULL

--- a/datascience/src/pipeline/queries/fmc/beacons.sql
+++ b/datascience/src/pipeline/queries/fmc/beacons.sql
@@ -8,7 +8,9 @@ SELECT
     ctb.est_cotier AS is_coastal
 FROM FMC2.FMC_BALISE b
 LEFT JOIN FMC2.FMC_BALISE_NAVIRE bn
-ON b.id_fmc_balise = bn.id_fmc_balise
+ON
+    b.id_fmc_balise = bn.id_fmc_balise
+    AND bn.est_courant = 1
 LEFT JOIN FMC2.FMC_NAVIRE n
 ON n.id_fmc_navire = bn.id_fmc_navire
 LEFT JOIN FMC2.FMC_BALISE_STATUT st
@@ -17,4 +19,3 @@ LEFT JOIN FMC2.FMC_CODE_STATUT_BALISE cst
 ON cst.idc_fmc_statut_balise = st.idc_fmc_statut_balise
 LEFT JOIN FMC2.FMC_CODE_TYPE_BALISE ctb
 ON ctb.idc_fmc_type_balise = b.idc_fmc_type_balise
-WHERE bn.est_courant = 1

--- a/datascience/tests/test_pipeline/test_flows/test_beacons.py
+++ b/datascience/tests/test_pipeline/test_flows/test_beacons.py
@@ -53,7 +53,7 @@ def beacons(logging_datetime_utc) -> pd.DataFrame:
                 None,
             ],
             "satellite_operator_id": [1, 1, 2, 2, 3, None, None],
-            "logging_datetime_utc": [d, d, d, d, d, d, d],
+            "logging_datetime_utc": [d, d, d, d, d, d, None],
             "beacon_type": ["A1", "B", "A2", None, "A1", "B", "A2"],
             "is_coastal": [0, 1, 0, None, 0, 1, 0],
         }
@@ -77,7 +77,7 @@ def transformed_beacons(logging_datetime_utc) -> pd.DataFrame:
                 None,
             ],
             "satellite_operator_id": [1, 1, 2, 2, 3, None, None],
-            "logging_datetime_utc": [d, d, d, d, d, d, d],
+            "logging_datetime_utc": [d, d, d, d, d, d, None],
             "beacon_type": ["A1", "B", "A2", None, "A1", "B", "A2"],
             "is_coastal": [False, True, False, None, False, True, False],
         }
@@ -123,7 +123,6 @@ def test_transform_satellite_operators(
 
 
 def test_load_beacons(reset_test_data, transformed_beacons):
-
     load_beacons.run(transformed_beacons)
 
     loaded_beacons = read_query(


### PR DESCRIPTION
## Linked issues

- Resolve #1721

## TODO
Vérifier en front que l'affichage est OK avec des `NULL` dans les champs :
- `vessel_id`
- `beacon_status`
- `logging_datetime_utc`
- `beacon_type`
- `is_coastal`