### PR TITLE
Diffusion des préavis à des destinataires hors unités

### DIFF
--- a/backend/src/main/resources/db/migration/internal/V0.285__Create_pno_extra_subscriptions_table.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.285__Create_pno_extra_subscriptions_table.sql
@@ -1,0 +1,9 @@
+-- Port subscriptions for which recipients other than control units need to receive PNOs
+CREATE TABLE IF NOT EXISTS public.pno_extra_subscriptions (
+    pno_type_name VARCHAR NOT NULL,
+    port_locode VARCHAR NOT NULL,
+    recipient_name VARCHAR NOT NULL,
+    recipient_organization VARCHAR NOT NULL,
+    communication_means communication_means NOT NULL,
+    recipient_email_address_or_number VARCHAR NOT NULL
+);

--- a/datascience/src/pipeline/entities/pnos.py
+++ b/datascience/src/pipeline/entities/pnos.py
@@ -201,6 +201,7 @@ class ReturnToPortPurpose(Enum):
 class PnoAddressee:
     name: str
     organization: str
+    communication_means: CommunicationMeans
     email_address_or_number: str
 
 
@@ -213,6 +214,7 @@ class RenderedPno:
     is_verified: bool
     is_being_sent: bool
     trip_segments: list
+    pno_types: List[str]
     port_locode: str
     facade: str
     source: PnoSource
@@ -222,26 +224,31 @@ class RenderedPno:
     html_email_body: str | None = None
     sms_content: str | None = None
     control_units: List[ControlUnit] | None = None
+    additional_addressees: List[PnoAddressee] = None
 
     def get_addressees(
         self, communication_means: CommunicationMeans
     ) -> List[PnoAddressee]:
+        addressees = []
+
         if self.control_units:
             if communication_means == CommunicationMeans.EMAIL:
-                addressees = [
+                addressees += [
                     PnoAddressee(
                         name=control_unit.control_unit_name,
                         organization=control_unit.administration,
+                        communication_means=CommunicationMeans.EMAIL,
                         email_address_or_number=email,
                     )
                     for control_unit in self.control_units
                     for email in control_unit.emails
                 ]
             elif communication_means == CommunicationMeans.SMS:
-                addressees = [
+                addressees += [
                     PnoAddressee(
                         name=control_unit.control_unit_name,
                         organization=control_unit.administration,
+                        communication_means=CommunicationMeans.SMS,
                         email_address_or_number=phone_number,
                     )
                     for control_unit in self.control_units
@@ -252,8 +259,18 @@ class RenderedPno:
                     f"Unexpected communication_means {communication_means}"
                 )
 
-        else:
-            addressees = []
+        if self.additional_addressees:
+            addressees += [
+                PnoAddressee(
+                    name=add.name,
+                    organization=add.organization,
+                    communication_means=communication_means,
+                    email_address_or_number=add.email_address_or_number,
+                )
+                for add in self.additional_addressees
+                if add.communication_means is communication_means
+            ]
+
         return addressees
 
 

--- a/datascience/src/pipeline/queries/monitorfish/pno_extra_subscriptions.sql
+++ b/datascience/src/pipeline/queries/monitorfish/pno_extra_subscriptions.sql
@@ -1,0 +1,8 @@
+SELECT
+    pno_type_name,
+    port_locode,
+    recipient_name,
+    recipient_organization,
+    communication_means,
+    recipient_email_address_or_number
+FROM pno_extra_subscriptions

--- a/datascience/tests/test_data/remote_database/V666.41__Reset_test_pno_extra_subscriptions.sql
+++ b/datascience/tests/test_data/remote_database/V666.41__Reset_test_pno_extra_subscriptions.sql
@@ -1,0 +1,9 @@
+DELETE FROM pno_extra_subscriptions;
+INSERT INTO pno_extra_subscriptions (
+        pno_type_name, port_locode, recipient_name, recipient_organization, communication_means, recipient_email_address_or_number
+) VALUES
+    ('Préavis type 2',     'FRDPE',   'Nozey Joey',         'PNO sniffers',             'EMAIL',             'nozey.joey@pno.snif'),
+    ('Préavis type 1',     'FRZJZ',   'Nozey Joey',         'PNO sniffers',             'EMAIL',             'nozey.joey@pno.snif'),
+    ('Préavis type 2',     'FRZJZ',   'Nozey Joey',         'PNO sniffers',             'EMAIL',             'nozey.joey@pno.snif'),
+    ('Préavis type 2',     'FRZJZ',       'Ronald',            'Mc Donald',             'EMAIL',      'ronald.mcdonald@ham.burger'),
+    ('Préavis type 2',     'FRZJZ',       'Ronald',            'Mc Donald',               'SMS',                      '0000000000');

--- a/datascience/tests/test_pipeline/test_entities/test_pnos.py
+++ b/datascience/tests/test_pipeline/test_entities/test_pnos.py
@@ -1,0 +1,140 @@
+import dataclasses
+
+import pytest
+
+from src.pipeline.entities.communication_means import CommunicationMeans
+from src.pipeline.entities.control_units import ControlUnit
+from src.pipeline.entities.pnos import PnoAddressee, PnoSource, RenderedPno
+
+
+@pytest.fixture
+def rendered_pno() -> RenderedPno:
+    return RenderedPno(
+        report_id=4,
+        vessel_id=25,
+        cfr="VESSELCFR",
+        vessel_name="VESSELNAME",
+        is_verified=True,
+        is_being_sent=False,
+        trip_segments=["Segment 1", "Segment 2"],
+        pno_types=["Préavis type 1", "Préavis type 7"],
+        port_locode="FRAAA",
+        facade="Facade 5",
+        source=PnoSource.LOGBOOK,
+        control_units=[
+            ControlUnit(
+                control_unit_id=2,
+                control_unit_name="Unité 2",
+                administration="Administration 1",
+                emails=["alternative@email", "some.email@control.unit.4"],
+                phone_numbers=["'00 11 22 33 44 55"],
+            ),
+            ControlUnit(
+                control_unit_id=3,
+                control_unit_name="Unité 3",
+                administration="Administration 1",
+                emails=[],
+                phone_numbers=["44 44 44 44 44"],
+            ),
+        ],
+        additional_addressees=[
+            PnoAddressee(
+                name="Nozey Joey",
+                organization="PNO sniffers",
+                communication_means=CommunicationMeans.EMAIL,
+                email_address_or_number="nozey.joey@pno.snif",
+            ),
+            PnoAddressee(
+                name="Ronald",
+                organization="Mc Donald",
+                communication_means=CommunicationMeans.SMS,
+                email_address_or_number="0000000000",
+            ),
+            PnoAddressee(
+                name="Ronald",
+                organization="Mc Donald",
+                communication_means=CommunicationMeans.EMAIL,
+                email_address_or_number="ronald.mcdonald@ham.burger",
+            ),
+        ],
+    )
+
+
+def test_rendered_pno_get_addressees_returns_email_addressees(rendered_pno):
+    addressees = rendered_pno.get_addressees(
+        communication_means=CommunicationMeans.EMAIL
+    )
+    assert addressees == [
+        PnoAddressee(
+            name="Unité 2",
+            organization="Administration 1",
+            communication_means=CommunicationMeans.EMAIL,
+            email_address_or_number="alternative@email",
+        ),
+        PnoAddressee(
+            name="Unité 2",
+            organization="Administration 1",
+            communication_means=CommunicationMeans.EMAIL,
+            email_address_or_number="some.email@control.unit.4",
+        ),
+        PnoAddressee(
+            name="Nozey Joey",
+            organization="PNO sniffers",
+            communication_means=CommunicationMeans.EMAIL,
+            email_address_or_number="nozey.joey@pno.snif",
+        ),
+        PnoAddressee(
+            name="Ronald",
+            organization="Mc Donald",
+            communication_means=CommunicationMeans.EMAIL,
+            email_address_or_number="ronald.mcdonald@ham.burger",
+        ),
+    ]
+
+
+def test_rendered_pno_get_addressees_returns_sms_addressees(rendered_pno):
+    addressees = rendered_pno.get_addressees(communication_means=CommunicationMeans.SMS)
+    assert addressees == [
+        PnoAddressee(
+            name="Unité 2",
+            organization="Administration 1",
+            communication_means=CommunicationMeans.SMS,
+            email_address_or_number="'00 11 22 33 44 55",
+        ),
+        PnoAddressee(
+            name="Unité 3",
+            organization="Administration 1",
+            communication_means=CommunicationMeans.SMS,
+            email_address_or_number="44 44 44 44 44",
+        ),
+        PnoAddressee(
+            name="Ronald",
+            organization="Mc Donald",
+            communication_means=CommunicationMeans.SMS,
+            email_address_or_number="0000000000",
+        ),
+    ]
+
+
+def test_rendered_pno_get_addressees_with_empty_lists(rendered_pno):
+    rendered_pno = dataclasses.replace(
+        rendered_pno,
+        control_units=[],
+        additional_addressees=[],
+    )
+    assert rendered_pno.get_addressees(communication_means=CommunicationMeans.SMS) == []
+    assert (
+        rendered_pno.get_addressees(communication_means=CommunicationMeans.EMAIL) == []
+    )
+
+
+def test_rendered_pno_get_addressees_with_nones(rendered_pno):
+    rendered_pno = dataclasses.replace(
+        rendered_pno,
+        control_units=None,
+        additional_addressees=None,
+    )
+    assert rendered_pno.get_addressees(communication_means=CommunicationMeans.SMS) == []
+    assert (
+        rendered_pno.get_addressees(communication_means=CommunicationMeans.EMAIL) == []
+    )

--- a/datascience/tests/test_pipeline/test_flows/test_distribute_pnos.py
+++ b/datascience/tests/test_pipeline/test_flows/test_distribute_pnos.py
@@ -34,6 +34,7 @@ from src.pipeline.entities.control_units import ControlUnit
 from src.pipeline.entities.fleet_segments import FishingGear, FleetSegment
 from src.pipeline.entities.missions import Infraction
 from src.pipeline.entities.pnos import (
+    PnoAddressee,
     PnoSource,
     PnoToRender,
     PnoToSend,
@@ -48,6 +49,7 @@ from src.pipeline.flows.distribute_pnos import (
     execute_prior_notification_attachments_query,
     extract_facade_email_addresses,
     extract_fishing_gear_names,
+    extract_pno_extra_subscriptions,
     extract_pnos_to_generate,
     extract_species_names,
     flow,
@@ -918,6 +920,7 @@ def pno_pdf_document_to_distribute_targeted_vessel_and_segments() -> RenderedPno
         vessel_name="Le navire 123-abc",
         is_verified=False,
         is_being_sent=True,
+        pno_types=["Préavis type 1", "Préavis type 2"],
         trip_segments=[
             FleetSegment("NWW01", "Chalutiers"),
             FleetSegment("NWW02", "Autres"),
@@ -954,6 +957,26 @@ def pno_pdf_document_to_distribute_targeted_vessel_and_segments_assigned(
                 phone_numbers=["44 44 44 44 44"],
             ),
         ],
+        additional_addressees=[
+            PnoAddressee(
+                name="Nozey Joey",
+                organization="PNO sniffers",
+                communication_means=CommunicationMeans.EMAIL,
+                email_address_or_number="nozey.joey@pno.snif",
+            ),
+            PnoAddressee(
+                name="Ronald",
+                organization="Mc Donald",
+                communication_means=CommunicationMeans.SMS,
+                email_address_or_number="0000000000",
+            ),
+            PnoAddressee(
+                name="Ronald",
+                organization="Mc Donald",
+                communication_means=CommunicationMeans.EMAIL,
+                email_address_or_number="ronald.mcdonald@ham.burger",
+            ),
+        ],
     )
 
 
@@ -968,6 +991,7 @@ def pno_pdf_document_to_distribute_receive_all_pnos_from_port() -> RenderedPno:
         is_being_sent=True,
         trip_segments=[],
         port_locode="FRDPE",
+        pno_types=["Préavis type 1"],
         facade="Unknown facade",
         source=PnoSource.MANUAL,
         generation_datetime_utc=datetime(2023, 6, 6, 23, 50, 0),
@@ -990,6 +1014,7 @@ def pno_pdf_document_to_distribute_receive_all_pnos_from_port_assigned(
                 phone_numbers=[],
             )
         ],
+        additional_addressees=[],
     )
 
 
@@ -1004,6 +1029,7 @@ def pno_pdf_document_to_distribute_without_addressees() -> RenderedPno:
         is_being_sent=True,
         trip_segments=[],
         port_locode="FRDKK",
+        pno_types=["Préavis type 1", "Préavis type 2"],
         facade="SA",
         source=PnoSource.MANUAL,
         generation_datetime_utc=datetime(2023, 6, 6, 23, 50, 0),
@@ -1018,9 +1044,7 @@ def pno_pdf_document_to_distribute_without_addressees_assigned(
     return dataclasses.replace(
         pno_pdf_document_to_distribute_without_addressees,
         control_units=[],
-        # control_unit_ids=set(),
-        # emails=[],
-        # phone_numbers=[],
+        additional_addressees=[],
     )
 
 
@@ -1035,6 +1059,7 @@ def pno_pdf_document_to_distribute_verified() -> RenderedPno:
         is_being_sent=True,
         trip_segments=[],
         port_locode="FRLEH",
+        pno_types=["Some PNO type"],
         facade="NAMO",
         source=PnoSource.LOGBOOK,
         generation_datetime_utc=datetime(2023, 6, 6, 23, 50, 0),
@@ -1064,6 +1089,7 @@ def pno_pdf_document_to_distribute_verified_assigned(
                 phone_numbers=["44 44 44 44 44"],
             ),
         ],
+        additional_addressees=[],
     )
 
 
@@ -1123,6 +1149,7 @@ def logbook_rendered_pno():
         is_being_sent=True,
         trip_segments=["Segment1", "Segment2"],
         port_locode="FRBOL",
+        pno_types=["Some PNO type"],
         facade="NAMO",
         source=PnoSource.LOGBOOK,
         html_for_pdf="<html>Html for PDF</html>",
@@ -1160,6 +1187,7 @@ def manual_rendered_pno():
         is_being_sent=True,
         trip_segments=["Segment3"],
         port_locode="FRBOL",
+        pno_types=["Some other PNO type"],
         facade="SA",
         source=PnoSource.MANUAL,
         html_for_pdf="<html>Html for PDF manual</html>",
@@ -1393,6 +1421,44 @@ def prior_notification_attachments() -> dict:
     }
 
 
+@pytest.fixture
+def pno_extra_subscriptions() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "pno_type_name": [
+                "Préavis type 1",
+                "Préavis type 2",
+                "Préavis type 2",
+                "Préavis type 2",
+                "Préavis type 2",
+            ],
+            "port_locode": ["FRZJZ", "FRDPE", "FRZJZ", "FRZJZ", "FRZJZ"],
+            "recipient_name": [
+                "Nozey Joey",
+                "Nozey Joey",
+                "Ronald",
+                "Nozey Joey",
+                "Ronald",
+            ],
+            "recipient_organization": [
+                "PNO sniffers",
+                "PNO sniffers",
+                "Mc Donald",
+                "PNO sniffers",
+                "Mc Donald",
+            ],
+            "communication_means": ["EMAIL", "EMAIL", "SMS", "EMAIL", "EMAIL"],
+            "recipient_email_address_or_number": [
+                "nozey.joey@pno.snif",
+                "nozey.joey@pno.snif",
+                "0000000000",
+                "nozey.joey@pno.snif",
+                "ronald.mcdonald@ham.burger",
+            ],
+        }
+    )
+
+
 def test_extract_pnos_to_generate(reset_test_data, extracted_pnos):
     approximate_datetime_columns = [
         "operation_datetime_utc",
@@ -1432,6 +1498,17 @@ def test_extract_fishing_gear_names(reset_test_data, fishing_gear_names):
 def test_extract_facade_email_addresses(reset_test_data, facade_email_addresses):
     res = extract_facade_email_addresses.run()
     assert res == facade_email_addresses
+
+
+def test_extract_pno_extra_subscriptions(reset_test_data, pno_extra_subscriptions):
+    subscriptions = (
+        extract_pno_extra_subscriptions.run()
+        .sort_values(
+            ["pno_type_name", "port_locode", "recipient_email_address_or_number"]
+        )
+        .reset_index(drop=True)
+    )
+    pd.testing.assert_frame_equal(subscriptions, pno_extra_subscriptions)
 
 
 def test_to_pnos_to_render(extracted_pnos):
@@ -1659,6 +1736,7 @@ def test_load_pno_pdf_documents(reset_test_data):
                 is_being_sent=is_being_sent,
                 trip_segments=[],
                 port_locode="FRBOL",
+                pno_types=[],
                 facade="NAMO",
                 source=PnoSource.LOGBOOK,
                 generation_datetime_utc=datetime(2020, 5, 6, 8, 52, 42),
@@ -1736,11 +1814,13 @@ def test_attribute_addressees_uses_target_vessels_and_segments(
     pno_units_targeting_vessels,
     pno_units_ports_and_segments_subscriptions,
     monitorenv_control_units,
+    pno_extra_subscriptions,
 ):
     res = attribute_addressees.run(
         pno_pdf_document_to_distribute_targeted_vessel_and_segments,
         pno_units_targeting_vessels,
         pno_units_ports_and_segments_subscriptions,
+        pno_extra_subscriptions,
         monitorenv_control_units,
     )
     assert res == pno_pdf_document_to_distribute_targeted_vessel_and_segments_assigned
@@ -1752,11 +1832,13 @@ def test_attribute_addressees_uses_receive_all_pnos_from_port(
     pno_units_targeting_vessels,
     pno_units_ports_and_segments_subscriptions,
     monitorenv_control_units,
+    pno_extra_subscriptions,
 ):
     res = attribute_addressees.run(
         pno_pdf_document_to_distribute_receive_all_pnos_from_port,
         pno_units_targeting_vessels,
         pno_units_ports_and_segments_subscriptions,
+        pno_extra_subscriptions,
         monitorenv_control_units,
     )
     assert res == pno_pdf_document_to_distribute_receive_all_pnos_from_port_assigned
@@ -1768,11 +1850,13 @@ def test_attribute_addressees_returns_empty_addressees(
     pno_units_targeting_vessels,
     pno_units_ports_and_segments_subscriptions,
     monitorenv_control_units,
+    pno_extra_subscriptions,
 ):
     res = attribute_addressees.run(
         pno_pdf_document_to_distribute_without_addressees,
         pno_units_targeting_vessels,
         pno_units_ports_and_segments_subscriptions,
+        pno_extra_subscriptions,
         monitorenv_control_units,
     )
     assert res == pno_pdf_document_to_distribute_without_addressees_assigned
@@ -1784,11 +1868,13 @@ def test_attribute_addressees_when_is_verified(
     pno_units_targeting_vessels,
     pno_units_ports_and_segments_subscriptions,
     monitorenv_control_units,
+    pno_extra_subscriptions,
 ):
     res = attribute_addressees.run(
         pno_pdf_document_to_distribute_verified,
         pno_units_targeting_vessels,
         pno_units_ports_and_segments_subscriptions,
+        pno_extra_subscriptions,
         monitorenv_control_units,
     )
     assert res == pno_pdf_document_to_distribute_verified_assigned
@@ -1863,7 +1949,8 @@ def test_create_email(
         assert pno_to_send.message["Cc"] is None
     else:
         assert (
-            pno_to_send.message["To"] == "alternative@email, some.email@control.unit.4"
+            pno_to_send.message["To"]
+            == "alternative@email, some.email@control.unit.4, nozey.joey@pno.snif, ronald.mcdonald@ham.burger"
         )
         assert pno_to_send.message["Cc"] == "namo@email"
     assert pno_to_send.message["From"] == "monitorfish@test.email"
@@ -1963,7 +2050,7 @@ def test_create_sms(
     else:
         assert (
             pno_to_send.message["To"]
-            == '"\'00 11 22 33 44 55"@test.sms, "44 44 44 44 44"@test.sms'
+            == '"\'00 11 22 33 44 55"@test.sms, "44 44 44 44 44"@test.sms, 0000000000@test.sms'
         )
 
     assert pno_to_send.message["Cc"] is None

--- a/datascience/tests/test_pipeline/test_flows/test_regulations_checkup.py
+++ b/datascience/tests/test_pipeline/test_flows/test_regulations_checkup.py
@@ -376,7 +376,12 @@ def test_make_html_hyperlinks():
 def test_extract_monitorfish_regulations(reset_test_data, monitorfish_regulations):
     regulations = extract_monitorfish_regulations.run()
 
-    pd.testing.assert_frame_equal(regulations, monitorfish_regulations)
+    pd.testing.assert_frame_equal(
+        regulations,
+        regulations.sort_values("reference", ascending=False)
+        .sort_values(["law_type", "zone"])
+        .reset_index(drop=True),
+    )
 
 
 def test_extract_legipeche_regulations(reset_test_data, legipeche_regulations):


### PR DESCRIPTION
## Linked issues

- Resolve #3894

## Présentation

- Ajout d'une table `pno_extra_subscriptions` qui permet d'ajouter des destinataires hors unités aux diffusions de PNO
- Chaque ligne de cette table comporte 
  - un `locode` de port
  - un `pno_type_name` (type de préavis)
  - le nom du destinataire
  - son  organisation
  - le mode de communication (`SMS` / `EMAIL`)
  - son email ou numéro de téléphone  
- Le flow `distribute_pnos` utilise ces abonnements pour assigner des destinataires supplémentaires, en plus des unités, aux préavis dont le port et le type de préavis correspondent à un abonnement
- Pour l'instant le besoin existant est de diffuser uniquement les préavis navires tiers à certains destinataires par email. Pour éviter de hard coder ceci j'ai préféré prévoir un système plus souple dans le quel on peut paramétrer des diffusions sur n'importe quel type de préavis et par n'importe quel moyen de communication (SMS ou EMAIL).

## Impacts
- L'administration de ces diffusions hors unité se fera en dur / via Metabase
- Les messages envoyés seront dans `prior_notification_sent_messages` au même titre que les messages envoyés aux unités
- Ils apparaitront donc aussi dans la liste de diffusion des préavis dans l'app
----