### PR TITLE
Résolution du problème de doublon de numéro de balise dans Poséidon

### DIFF
--- a/datascience/src/pipeline/queries/fmc/beacons.sql
+++ b/datascience/src/pipeline/queries/fmc/beacons.sql
@@ -1,3 +1,4 @@
+WITh t AS (
 SELECT
     n.id_nav_flotteur as vessel_id,
     b.numero as beacon_number,
@@ -5,7 +6,9 @@ SELECT
     b.id_fmc_operateur_satellite AS satellite_operator_id,
     bn.date_debut AS logging_datetime_utc,
     ctb.libelle AS beacon_type,
-    ctb.est_cotier AS is_coastal
+    ctb.est_cotier AS is_coastal,
+    ROW_NUMBER() OVER (PARTITION BY b.numero ORDER BY bn.date_debut DESC NULLS last) AS rk,
+    COUNT(*) OVER (PARTITION BY b.numero) AS nb
 FROM FMC2.FMC_BALISE b
 LEFT JOIN FMC2.FMC_BALISE_NAVIRE bn
 ON
@@ -19,3 +22,18 @@ LEFT JOIN FMC2.FMC_CODE_STATUT_BALISE cst
 ON cst.idc_fmc_statut_balise = st.idc_fmc_statut_balise
 LEFT JOIN FMC2.FMC_CODE_TYPE_BALISE ctb
 ON ctb.idc_fmc_type_balise = b.idc_fmc_type_balise
+)
+
+SELECT
+    vessel_id,
+    CASE
+        WHEN nb = 1 THEN beacon_number
+        ELSE beacon_number || ' (' || rk || '/' || nb || ')'
+    END AS beacon_number,
+    beacon_status,
+    satellite_operator_id,
+    logging_datetime_utc,
+    beacon_type,
+    is_coastal
+FROM t
+ORDER BY nb DESC, beacon_number


### PR DESCRIPTION
## Linked issues

- Resolve #3923

----
En cas de doublon (plusieurs balises avec le même numéro) dans Poséidon, on ajoute une numérotation (1/3, 2/3...) au numéro de balise pour les dédoublonner.