### PR TITLE
Signalements – Pouvoir supprimer un signalement archivé

### DIFF
--- a/frontend/cypress/e2e/favorite_vessel.spec.ts
+++ b/frontend/cypress/e2e/favorite_vessel.spec.ts
@@ -7,7 +7,10 @@ context('Favorite Vessel', () => {
     cy.wait(3000)
   })
 
-  it('Opening the box Should close other boxes', () => {
+  it('A favorite vessel Should be added to the list from the map', () => {
+    /**
+     * Opening the box Should close other boxes
+     */
     cy.get('*[data-cy="favorite-vessels"]').click()
     cy.get('*[data-cy="layers-sidebar-box"]').should('be.not.visible')
 
@@ -18,11 +21,11 @@ context('Favorite Vessel', () => {
     // Re-open the favorite vessels box
     cy.get('*[data-cy="favorite-vessels"]').click()
     cy.get('*[data-cy="layers-sidebar-box"]').should('be.not.visible')
-  })
 
-  it('A favorite vessel Should be added to the list from the map', () => {
+    /**
+     * A favorite vessel Should be added to the list from the map
+     */
     // Given
-    cy.get('*[data-cy="favorite-vessels"]').click()
     cy.get('*[data-cy="favorite-vessels-number"]').contains(0)
     cy.get('*[data-cy="favorite-vessel-name"]').should('not.exist')
 
@@ -39,9 +42,10 @@ context('Favorite Vessel', () => {
     cy.get('*[data-cy="favorite-vessels-number"]').contains(0)
     cy.get('*[data-cy="favorite-vessel-name"]').should('not.exist')
     cy.get('*[data-cy="favorite-vessels"]').click()
-  })
 
-  it('A favorite vessel Should be added to the list from the vessel sidebar', () => {
+    /**
+     * A favorite vessel Should be added to the list from the vessel sidebar
+     */
     // Given
     cy.get('*[data-cy="favorite-vessels"]').click()
     cy.get('*[data-cy="favorite-vessels-number"]').contains(0)

--- a/frontend/cypress/e2e/main_window/vessel_sidebar/logbook.spec.ts
+++ b/frontend/cypress/e2e/main_window/vessel_sidebar/logbook.spec.ts
@@ -143,6 +143,7 @@ context('Vessel sidebar logbook tab', () => {
     cy.get('*[data-cy^="fishing-activity-name"]').should('exist').should('have.length', 4)
     cy.get('*[data-cy^="vessel-menu-fishing"]').click({ timeout: 10000 })
     cy.intercept('GET', '/bff/v1/vessels/positions*').as('previousTripPositions')
+    cy.wait(200)
     cy.get('*[data-cy^="vessel-fishing-previous-trip"]').click({ timeout: 10000 })
 
     // Then
@@ -174,10 +175,7 @@ context('Vessel sidebar logbook tab', () => {
           '&trackDepth=TWELVE_HOURS&afterDateTime=&beforeDateTime='
       )
     cy.get('*[data-cy^="fishing-activity-name"]').should('not.exist')
-    cy.get('*[data-cy="custom-dates-showed-text"]').contains('Piste affichée du 10/10/19 au 22/10/19')
-
     // Go back to the default track depth
-    cy.get('*[data-cy="custom-dates-show-last-positions"]').click()
     cy.get('*[data-cy="custom-dates-showed-text"]').should('not.exist')
     cy.get('*[data-cy^="vessel-track-depth-selection"]').click({ force: true, timeout: 10000 })
     cy.get('[name="vessel-track-depth"]').should('have.value', 'TWELVE_HOURS')

--- a/frontend/cypress/e2e/main_window/vessel_sidebar/logbook.spec.ts
+++ b/frontend/cypress/e2e/main_window/vessel_sidebar/logbook.spec.ts
@@ -170,8 +170,8 @@ context('Vessel sidebar logbook tab', () => {
       .should(
         'have.string',
         '/bff/v1/vessels/positions?internalReferenceNumber=FAK000999999' +
-          '&externalReferenceNumber=DONTSINK&IRCS=CALLME&vesselIdentifier=INTERNAL_REFERENCE_NUMBER&trackDepth=CUSTOM' +
-          '&afterDateTime=2019-10-10T21:06:00.000Z&beforeDateTime=2019-10-22T12:06:00.000Z'
+          '&externalReferenceNumber=DONTSINK&IRCS=CALLME&vesselIdentifier=INTERNAL_REFERENCE_NUMBER' +
+          '&trackDepth=TWELVE_HOURS&afterDateTime=&beforeDateTime='
       )
     cy.get('*[data-cy^="fishing-activity-name"]').should('not.exist')
     cy.get('*[data-cy="custom-dates-showed-text"]').contains('Piste affichée du 10/10/19 au 22/10/19')

--- a/frontend/cypress/e2e/measurement.spec.ts
+++ b/frontend/cypress/e2e/measurement.spec.ts
@@ -5,7 +5,10 @@ context('Measurement', () => {
     cy.wait(1000)
   })
 
-  it('A circle range measurement Should be created When clicking on the map', () => {
+  it('A circle range measurement Should be created', () => {
+    /**
+     * A circle range measurement Should be created When clicking on the map
+     */
     // When
     cy.get('*[data-cy="measurement"]').click({ timeout: 10000 })
     cy.get('*[data-cy="measurement-circle-range"]').click({ timeout: 10000 })
@@ -16,9 +19,10 @@ context('Measurement', () => {
     cy.get('*[data-cy="measurement-value"]').contains('r = 5.', { timeout: 10000 })
     cy.get('*[data-cy="close-measurement"]').click({ timeout: 10000 })
     cy.get('*[data-cy="measurement-value"]').should('not.exist')
-  })
 
-  it('A circle range measurement Should be created When the radius in entered in input', () => {
+    /**
+     * A circle range measurement Should be created When the radius in entered in input
+     */
     // When
     cy.get('*[data-cy="measurement"]').click({ timeout: 10000 })
     cy.get('*[data-cy="measurement-circle-range"]').click({ timeout: 10000 })
@@ -32,9 +36,10 @@ context('Measurement', () => {
     cy.get('*[data-cy="measurement-value"]').contains('r = 35 nm', { timeout: 10000 })
     cy.get('*[data-cy="close-measurement"]').click({ force: true, timeout: 10000 })
     cy.get('*[data-cy="measurement-value"]').should('not.exist')
-  })
 
-  it('A circle range measurement Should be created When the coordinates and radius are entered in input', () => {
+    /**
+     * A circle range measurement Should be created When the coordinates and radius are entered in input
+     */
     // When
     cy.get('*[data-cy="measurement"]').click({ timeout: 10000 })
     cy.get('*[data-cy="measurement-circle-range"]').click({ timeout: 10000 })

--- a/frontend/cypress/e2e/side_window/beacon_malfunction/board.spec.ts
+++ b/frontend/cypress/e2e/side_window/beacon_malfunction/board.spec.ts
@@ -310,7 +310,10 @@ context('Side Window > Beacon Malfunction Board', () => {
       .contains('I just added a new comment')
   })
 
-  it('Beacon malfunction archived reason Should be showed', () => {
+  it('Notification messages feedback should be showed in beacon follow up', () => {
+    /**
+     * Beacon malfunction archived reason Should be showed
+     */
     // In the board
     cy.get('*[data-cy="side-window-beacon-malfunctions-columns-ARCHIVED"]')
       .children()
@@ -318,9 +321,7 @@ context('Side Window > Beacon Malfunction Board', () => {
       .first()
       .find('*[data-cy="side-window-beacon-malfunctions-end-of-malfunction"]')
       .contains('Reprise des émissions')
-  })
 
-  it('Notification messages feedback should be showed in beacon follow up', () => {
     // In the board
     cy.get('*[data-cy="side-window-beacon-malfunctions-columns-ARCHIVED"]')
       .children()

--- a/frontend/cypress/e2e/sidebars/regulatory_layers.spec.ts
+++ b/frontend/cypress/e2e/sidebars/regulatory_layers.spec.ts
@@ -9,13 +9,6 @@ context('Sidebars > Regulatory Layers', () => {
     cy.visit('/#@-224002.65,6302673.54,8.70')
     cy.wait(1000)
 
-    cy.request(
-      'GET',
-      `http://0.0.0.0:8081/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=monitorfish:regulations&outputFormat=application/json&propertyName=id,law_type,topic,gears,species,regulatory_references,zone,region,next_id`
-    ).then(response => {
-      cy.log(response.body)
-    })
-
     /**
      * The number of zones searched and total zones in law type should be displayed
      */
@@ -49,7 +42,7 @@ context('Sidebars > Regulatory Layers', () => {
     cy.log('Show a zone with the zone button')
     // This intercept only works in the CI, as localhost in used in local
     cy.intercept(
-      'http://0.0.0.0:8081/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=monitorfish:regulations&outputFormat=application/json&CQL_FILTER=topic=%27Ouest%20Cotentin%20Bivalves%27%20AND%20zone=%27Praires%20Ouest%20cotentin%27'
+      'http://*:8081/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=monitorfish:regulations&outputFormat=application/json&CQL_FILTER=topic=%27Ouest%20Cotentin%20Bivalves%27%20AND%20zone=%27Praires%20Ouest%20cotentin%27'
     ).as('getRegulation')
     cy.get('[title=\'Afficher la zone "Praires Ouest cotentin"\']').click()
     cy.wait('@getRegulation').then(({ response }) => expect(response && response.statusCode).equal(200))
@@ -79,9 +72,6 @@ context('Sidebars > Regulatory Layers', () => {
     /**
      * A regulation Should be searched and the result Should be kept When we go to My Zones section
      */
-    // When
-    cy.get('[title="Arbre des couches"]').click()
-
     // Add the layer to My Zones
     cy.get('*[name="Rechercher une zone réglementaire"]').type('Cotentin biva')
     cy.get('*[data-cy="regulatory-layer-topic"]').should('have.length', 1)
@@ -101,13 +91,6 @@ context('Sidebars > Regulatory Layers', () => {
   it('A regulation Should be searched, added to My Zones and showed on the map with the Topic button', () => {
     cy.visit('/#@-224002.65,6302673.54,8.70')
     cy.wait(1000)
-
-    cy.request(
-      'GET',
-      `http://0.0.0.0:8081/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=monitorfish:regulations&outputFormat=application/json&propertyName=id,law_type,topic,gears,species,regulatory_references,zone,region,next_id`
-    ).then(response => {
-      cy.log(response.body)
-    })
 
     // When
     cy.get('[title="Arbre des couches"]').click()
@@ -147,13 +130,6 @@ context('Sidebars > Regulatory Layers', () => {
   it('The Cotentin regulation metadata Should be opened', () => {
     cy.visit('/#@-224002.65,6302673.54,8.70')
     cy.wait(1000)
-
-    cy.request(
-      'GET',
-      `http://0.0.0.0:8081/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=monitorfish:regulations&outputFormat=application/json&propertyName=id,law_type,topic,gears,species,regulatory_references,zone,region,next_id`
-    ).then(response => {
-      cy.log(response.body)
-    })
 
     // When
     cy.get('[title="Arbre des couches"]').click()
@@ -210,13 +186,6 @@ context('Sidebars > Regulatory Layers', () => {
     cy.visit('/#@-224002.65,6302673.54,8.70')
     cy.wait(1000)
 
-    cy.request(
-      'GET',
-      `http://0.0.0.0:8081/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=monitorfish:regulations&outputFormat=application/json&propertyName=id,law_type,topic,gears,species,regulatory_references,zone,region,next_id`
-    ).then(response => {
-      cy.log(response.body)
-    })
-
     // When
     cy.get('[title="Arbre des couches"]').click()
 
@@ -262,17 +231,10 @@ context('Sidebars > Regulatory Layers', () => {
     cy.visit('/#@-224002.65,6302673.54,8.70')
     cy.wait(1000)
 
-    cy.request(
-      'GET',
-      `http://0.0.0.0:8081/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=monitorfish:regulations&outputFormat=application/json&propertyName=id,law_type,topic,gears,species,regulatory_references,zone,region,next_id`
-    ).then(response => {
-      cy.log(response.body)
-    })
-
     // When
     cy.intercept(
       'GET',
-      `http://0.0.0.0:8081/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=monitorfish:regulations&outputFormat=application/json&srsname=EPSG:4326&bbox=-378334.88336741074,6256373.869989776,-280465.66220758925,6275194.874058974,EPSG:3857&propertyName=id,law_type,topic,gears,species,regulatory_references,zone,region`
+      `http://*:8081/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=monitorfish:regulations&outputFormat=application/json&srsname=EPSG:4326&bbox=-378334.88336741074,6256373.869989776,-280465.66220758925,6275194.874058974,EPSG:3857&propertyName=id,law_type,topic,gears,species,regulatory_references,zone,region`
     ).as('getFeature')
     cy.get('[title="Arbre des couches"]').click()
 
@@ -306,13 +268,6 @@ context('Sidebars > Regulatory Layers', () => {
     cy.visit('/#@-224002.65,6302673.54,8.70')
     cy.wait(1000)
 
-    cy.request(
-      'GET',
-      `http://0.0.0.0:8081/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=monitorfish:regulations&outputFormat=application/json&propertyName=id,law_type,topic,gears,species,regulatory_references,zone,region,next_id`
-    ).then(response => {
-      cy.log(response.body)
-    })
-
     // When
     cy.get('[title="Arbre des couches"]').click()
 
@@ -342,13 +297,6 @@ context('Sidebars > Regulatory Layers', () => {
 
     cy.visit('/#@-224002.65,6302673.54,8.70')
     cy.wait(1000)
-
-    cy.request(
-      'GET',
-      `http://0.0.0.0:8081/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=monitorfish:regulations&outputFormat=application/json&propertyName=id,law_type,topic,gears,species,regulatory_references,zone,region,next_id`
-    ).then(response => {
-      cy.log(response.body)
-    })
 
     // TODO Investigate why there is white space in the Cypress iframe when hiding vessels which breaks the entire test.
     // cy.clickButton('Affichage des dernières positions')

--- a/frontend/cypress/e2e/sidebars/regulatory_layers.spec.ts
+++ b/frontend/cypress/e2e/sidebars/regulatory_layers.spec.ts
@@ -1,8 +1,11 @@
 // import { encodeUriObject } from '../../src/utils/encodeUriObject'
 
 context('Sidebars > Regulatory Layers', () => {
-  it('The number of zones searched and total zones in law type should be displayed', () => {
+  beforeEach(() => {
     cy.login('superuser')
+  })
+
+  it('A regulation Should be searched, added to My Zones and showed on the map with the Zone button', () => {
     cy.visit('/#@-224002.65,6302673.54,8.70')
     cy.wait(1000)
 
@@ -13,28 +16,21 @@ context('Sidebars > Regulatory Layers', () => {
       cy.log(response.body)
     })
 
+    /**
+     * The number of zones searched and total zones in law type should be displayed
+     */
     // When
     cy.get('[title="Arbre des couches"]').click()
     cy.get('*[name="Rechercher une zone réglementaire"]').type('interdiction')
 
     // Then, 2 zones are showed
     cy.get('*[data-cy="regulatory-layer-topic-count"]').contains('2/4')
-  })
 
-  it('A regulation Should be searched, added to My Zones and showed on the map with the Zone button', () => {
-    cy.login('superuser')
-    cy.visit('/#@-224002.65,6302673.54,8.70')
-    cy.wait(1000)
-
-    cy.request(
-      'GET',
-      `http://0.0.0.0:8081/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=monitorfish:regulations&outputFormat=application/json&propertyName=id,law_type,topic,gears,species,regulatory_references,zone,region,next_id`
-    ).then(response => {
-      cy.log(response.body)
-    })
-
+    /**
+     * A regulation Should be searched, added to My Zones and showed on the map with the Zone button
+     */
     // When
-    cy.get('[title="Arbre des couches"]').click()
+    cleanRegulationSearchInput()
 
     // Add the layer to My Zones
     cy.get('*[name="Rechercher une zone réglementaire"]').type('Cotentin biva')
@@ -43,6 +39,7 @@ context('Sidebars > Regulatory Layers', () => {
     cy.get('[title=\'Sélectionner "Praires Ouest cotentin"\']').click()
 
     // Then it is in "My Zones"
+    cleanRegulationSearchInput()
     cy.get('*[data-cy="regulatory-layers-my-zones"]').click()
     cy.get('*[data-cy="regulatory-layers-my-zones-topic"]').contains('Ouest Cotentin Bivalves')
     cy.get('*[data-cy="regulatory-layers-my-zones-topic"]').click()
@@ -54,23 +51,6 @@ context('Sidebars > Regulatory Layers', () => {
     cy.intercept(
       'http://0.0.0.0:8081/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=monitorfish:regulations&outputFormat=application/json&CQL_FILTER=topic=%27Ouest%20Cotentin%20Bivalves%27%20AND%20zone=%27Praires%20Ouest%20cotentin%27'
     ).as('getRegulation')
-    // TODO Integrate `utils/encodeUriObject()` in `frontend/src/api/geoserver.js` once it's migrated to TS.
-    // cy.intercept(
-    //   encodeUriObject(
-    //     `http://0.0.0.0:8081/geoserver/wfs`,
-    //     /* eslint-disable sort-keys-fix/sort-keys-fix */
-    //     {
-    //       service: 'WFS',
-    //       version: '1.1.0',
-    //       request: 'GetFeature',
-    //       typename: 'monitorfish:regulations',
-    //       outputFormat: 'application/json',
-    //       CQL_FILTER: `topic='Ouest Cotentin Bivalves' AND zone='Praires Ouest cotentin'`
-    //     },
-    //     /* eslint-enable sort-keys-fix/sort-keys-fix */
-    //     true
-    //   )
-    // ).as('getRegulation')
     cy.get('[title=\'Afficher la zone "Praires Ouest cotentin"\']').click()
     cy.wait('@getRegulation').then(({ response }) => expect(response && response.statusCode).equal(200))
     cy.wait(200)
@@ -95,20 +75,10 @@ context('Sidebars > Regulatory Layers', () => {
     // The layer is hidden, the metadata modal should not be opened
     cy.get('.regulatory', { timeout: 10000 }).should('not.exist')
     cy.get('*[data-cy="regulatory-layers-metadata-lawtype"]', { timeout: 10000 }).should('not.exist')
-  })
 
-  it('A regulation Should be searched and the result Should be kept When we go to My Zones section', () => {
-    cy.login('superuser')
-    cy.visit('/#@-224002.65,6302673.54,8.70')
-    cy.wait(1000)
-
-    cy.request(
-      'GET',
-      `http://0.0.0.0:8081/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=monitorfish:regulations&outputFormat=application/json&propertyName=id,law_type,topic,gears,species,regulatory_references,zone,region,next_id`
-    ).then(response => {
-      cy.log(response.body)
-    })
-
+    /**
+     * A regulation Should be searched and the result Should be kept When we go to My Zones section
+     */
     // When
     cy.get('[title="Arbre des couches"]').click()
 
@@ -126,13 +96,9 @@ context('Sidebars > Regulatory Layers', () => {
 
     // Back to My Zones
     cy.get('*[data-cy="regulatory-layers-my-zones"]').click()
-
-    // Clean the search input
-    cleanSearchInput()
   })
 
   it('A regulation Should be searched, added to My Zones and showed on the map with the Topic button', () => {
-    cy.login('superuser')
     cy.visit('/#@-224002.65,6302673.54,8.70')
     cy.wait(1000)
 
@@ -179,7 +145,6 @@ context('Sidebars > Regulatory Layers', () => {
   })
 
   it('The Cotentin regulation metadata Should be opened', () => {
-    cy.login('superuser')
     cy.visit('/#@-224002.65,6302673.54,8.70')
     cy.wait(1000)
 
@@ -242,7 +207,6 @@ context('Sidebars > Regulatory Layers', () => {
   })
 
   it('The Armor regulation metadata Should be opened', () => {
-    cy.login('superuser')
     cy.visit('/#@-224002.65,6302673.54,8.70')
     cy.wait(1000)
 
@@ -295,7 +259,6 @@ context('Sidebars > Regulatory Layers', () => {
   })
 
   it('A regulation Should be searched with a rectangle', () => {
-    cy.login('superuser')
     cy.visit('/#@-224002.65,6302673.54,8.70')
     cy.wait(1000)
 
@@ -340,7 +303,6 @@ context('Sidebars > Regulatory Layers', () => {
   })
 
   it('A regulation Should be searched with a polygon', () => {
-    cy.login('superuser')
     cy.visit('/#@-224002.65,6302673.54,8.70')
     cy.wait(1000)
 
@@ -378,7 +340,6 @@ context('Sidebars > Regulatory Layers', () => {
       throw new Error('`baseUrl` is not defined')
     }
 
-    cy.login('superuser')
     cy.visit('/#@-224002.65,6302673.54,8.70')
     cy.wait(1000)
 
@@ -448,7 +409,6 @@ context('Sidebars > Regulatory Layers', () => {
 
   it('Should unselect one of the selected topic zone layers', () => {
     // Focus the map on Corsica
-    cy.login('superuser')
     cy.visit('/#@997505.75,5180266.24,8.70')
     cy.wait(500)
 
@@ -490,7 +450,6 @@ context('Sidebars > Regulatory Layers', () => {
 
   it('Should toggle the selected topic zone layers', () => {
     // Focus the map on Corsica
-    cy.login('superuser')
     cy.visit('/#@997505.75,5180266.24,8.70')
     cy.wait(500)
 
@@ -514,12 +473,12 @@ context('Sidebars > Regulatory Layers', () => {
 
     // Select all the "Armor CSJ Dragues" regulation zones (there is only 1)
     // Clean input
-    cleanSearchInput()
+    cleanRegulationSearchInput()
     cy.get('*[name="Rechercher une zone réglementaire"]').type('Armor')
     cy.get('[title=\'Sélectionner "Armor CSJ Dragues"\']').click()
 
     // Show metadata the only "Armor CSJ Dragues" regulation zone
-    cleanSearchInput()
+    cleanRegulationSearchInput()
     cy.contains('Mes zones réglementaires').click()
     cy.contains('Mes zones réglementaires').parent().contains('Armor CSJ Dragues').click()
     cy.get('[title=\'Afficher la réglementation "Secteur 3"\']').click()
@@ -530,7 +489,7 @@ context('Sidebars > Regulatory Layers', () => {
     cy.contains('Création de zone').should('be.visible')
   })
 
-  function cleanSearchInput() {
+  function cleanRegulationSearchInput() {
     cy.get('*[name="Rechercher une zone réglementaire"]').parent().find('.Element-IconButton').click()
   }
 })

--- a/frontend/src/features/FleetSegment/useCases/computeFleetSegments.ts
+++ b/frontend/src/features/FleetSegment/useCases/computeFleetSegments.ts
@@ -1,3 +1,4 @@
+import { RTK_FORCE_REFETCH_QUERY_OPTIONS } from '@api/constants'
 import { fleetSegmentApi } from '@features/FleetSegment/apis'
 
 import type { FleetSegment } from '@features/FleetSegment/types'
@@ -18,11 +19,14 @@ export const computeFleetSegments =
     const species = speciesOnboard?.map(specy => specy.speciesCode)
 
     const { data: fleetSegments } = await dispatch(
-      fleetSegmentApi.endpoints.computeFleetSegments.initiate({
-        faoAreas: faoAreas ?? [],
-        gears: gears ?? [],
-        species: species ?? []
-      })
+      fleetSegmentApi.endpoints.computeFleetSegments.initiate(
+        {
+          faoAreas: faoAreas ?? [],
+          gears: gears ?? [],
+          species: species ?? []
+        },
+        RTK_FORCE_REFETCH_QUERY_OPTIONS
+      )
     )
 
     return fleetSegments

--- a/frontend/src/features/Mission/components/MissionForm/useCases/updateActionFAOAreas.ts
+++ b/frontend/src/features/Mission/components/MissionForm/useCases/updateActionFAOAreas.ts
@@ -1,3 +1,4 @@
+import { RTK_FORCE_REFETCH_QUERY_OPTIONS } from '@api/constants'
 import { faoAreasApi } from '@api/faoAreas'
 
 import type { MissionActionFormValues } from '@features/Mission/components/MissionForm/types'
@@ -6,12 +7,15 @@ export const updateActionFAOAreas =
   (dispatch, setFieldValue: (field: string, value: any) => void) =>
   async (missionAction: MissionActionFormValues): Promise<string[]> => {
     const { data: computedVesselFaoAreas } = await dispatch(
-      faoAreasApi.endpoints.computeVesselFaoAreas.initiate({
-        internalReferenceNumber: missionAction.internalReferenceNumber,
-        latitude: missionAction.latitude,
-        longitude: missionAction.longitude,
-        portLocode: missionAction.portLocode
-      })
+      faoAreasApi.endpoints.computeVesselFaoAreas.initiate(
+        {
+          internalReferenceNumber: missionAction.internalReferenceNumber,
+          latitude: missionAction.latitude,
+          longitude: missionAction.longitude,
+          portLocode: missionAction.portLocode
+        },
+        RTK_FORCE_REFETCH_QUERY_OPTIONS
+      )
     )
 
     setFieldValue('faoAreas', computedVesselFaoAreas)

--- a/frontend/src/features/Reporting/components/ReportingCard/index.tsx
+++ b/frontend/src/features/Reporting/components/ReportingCard/index.tsx
@@ -179,6 +179,19 @@ export function ReportingCard({
             />
           </Actions>
         )}
+        {isArchived && (
+          <Actions $hasOccurrences={otherOccurrencesOfSameAlert.length > 0}>
+            <StyledIconButton
+              accent={Accent.TERTIARY}
+              color={THEME.color.charcoal}
+              data-cy="delete-reporting-card"
+              Icon={Icon.Delete}
+              iconSize={20}
+              onClick={askForDeletionConfirmation}
+              title="Supprimer ce signalement"
+            />
+          </Actions>
+        )}
       </Wrapper>
 
       {isDeletionConfirmationModalOpen && (

--- a/frontend/src/features/Reporting/components/ReportingTable/index.tsx
+++ b/frontend/src/features/Reporting/components/ReportingTable/index.tsx
@@ -92,7 +92,9 @@ export function ReportingTable({ isFromUrl, selectedSeafrontGroup }: ReportingTa
   })
 
   const { rows } = table.getRowModel()
-  const rowVirtualizer = useTableVirtualizer({ estimateSize: 42, ref: tableContainerRef, rows })
+
+  const overscan = useMemo(() => (reportings.length > 500 ? 500 : 50), [reportings])
+  const rowVirtualizer = useTableVirtualizer({ estimateSize: 42, overscan, ref: tableContainerRef, rows })
   const virtualRows = rowVirtualizer.getVirtualItems()
 
   return (
@@ -138,7 +140,7 @@ export function ReportingTable({ isFromUrl, selectedSeafrontGroup }: ReportingTa
               {!!rows.length && (
                 <tbody>
                   {virtualRows.map(virtualRow => {
-                    const row = rows[virtualRow.index]
+                    const row = rows[virtualRow?.index]
 
                     return (
                       <TableWithSelectableRows.BodyTr key={virtualRow.key} data-cy="ReportingList-reporting">

--- a/frontend/src/features/Reporting/useCases/deleteReporting.ts
+++ b/frontend/src/features/Reporting/useCases/deleteReporting.ts
@@ -1,4 +1,6 @@
+import { RtkCacheTagType } from '@api/constants'
 import { renderVesselFeatures } from '@features/Vessel/useCases/renderVesselFeatures'
+import { vesselApi } from '@features/Vessel/vesselApi'
 import { DisplayedErrorKey } from '@libs/DisplayedError/constants'
 
 import { Vessel } from '../../../domain/entities/vessel/vessel'
@@ -16,6 +18,8 @@ export const deleteReporting =
 
     try {
       await dispatch(reportingApi.endpoints.deleteReporting.initiate(id)).unwrap()
+
+      dispatch(vesselApi.util.invalidateTags([RtkCacheTagType.Reportings]))
 
       dispatch(
         removeVesselReporting({

--- a/frontend/src/hooks/useTableVirtualizer.ts
+++ b/frontend/src/hooks/useTableVirtualizer.ts
@@ -1,13 +1,19 @@
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { useCallback } from 'react'
+import { type MutableRefObject, useCallback } from 'react'
 
-export function useTableVirtualizer({ estimateSize, ref, rows }) {
+type UseTableVirtualizerProps = {
+  estimateSize: number
+  overscan: number
+  ref: MutableRefObject<HTMLDivElement | null>
+  rows: any
+}
+export function useTableVirtualizer({ estimateSize, overscan, ref, rows }: UseTableVirtualizerProps) {
   return useVirtualizer({
     count: rows.length,
     estimateSize: () => estimateSize,
     getItemKey: useCallback((index: number) => `${rows[index]?.id}`, [rows]),
     getScrollElement: () => ref.current,
-    overscan: rows.length > 500 ? rows.length / 10 : 50,
+    overscan,
     scrollPaddingEnd: 50,
     scrollPaddingStart: 40
   })


### PR DESCRIPTION
## Linked issues

- Resolve #3784
- Correction : 
> Quand on navigue dans les marées et qu'on revient à la dernière, ça reste en trackDepth=CUSTOM et ça s'arrête au dernier message au lieu d'allez jusqu'à NOW
- Correction : forçage du `refetch` pour le calcul des segments et fao dans le CR de contrôle
- Correction : du `useTableVirtualizer`

----

- [ ] Tests E2E (Cypress)
