### PR TITLE
Tech - Suppression du stockage des couches REG dans le backoffice

### DIFF
--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -84,7 +84,7 @@ const persistedBackofficeReducerConfig: PersistConfig<typeof backofficeReducer> 
   stateReconciler: autoMergeLevel2,
   storage,
   transforms: [SetRegulationStateTransform],
-  whitelist: ['regulation']
+  whitelist: []
 }
 const persistedBackofficeReducer = persistReducer(
   persistedBackofficeReducerConfig,

--- a/frontend/src/store/reducers.ts
+++ b/frontend/src/store/reducers.ts
@@ -17,7 +17,7 @@ import { priorNotificationReducer, type PriorNotificationState } from '@features
 import { backofficePriorNotificationReducer } from '@features/PriorNotification/slice.backoffice'
 import { backofficeProducerOrganizationMembershipReducer } from '@features/ProducerOrganizationMembership/slice.backoffice'
 import { regulatoryLayerSearchReducer } from '@features/Regulation/components/RegulationSearch/slice'
-import { regulationReducer } from '@features/Regulation/slice'
+import { regulationReducer, type RegulationState } from '@features/Regulation/slice'
 import { reportingTableFiltersReducer } from '@features/Reporting/components/ReportingTable/Filters/slice'
 import { reportingReducer } from '@features/Reporting/slice'
 import { sideWindowReducer } from '@features/SideWindow/slice'
@@ -63,7 +63,10 @@ const commonReducerList = {
   gear: gearReducer,
   global: globalSliceReducer,
   map: mapReducer,
-  regulation: regulationReducer,
+  regulation: persistReducerTyped(
+    { ...getCommonPersistReducerConfig<RegulationState>('backofficePersistorRegulation', ['processingRegulation']) },
+    regulationReducer
+  ),
   species: speciesReducer
 }
 


### PR DESCRIPTION
## Linked issues

- Le sotckage dans le `localstorage` ne permettait pas d'avoir la vue à date des dernières modifications.

----

- [ ] Tests E2E (Cypress)
