### PR TITLE
Préavis - Les données de captures dans les préavis manuels BFT sont incohérentes

### DIFF
--- a/frontend/cypress/e2e/side_window/manual_prior_notification_form/behavior.spec.ts
+++ b/frontend/cypress/e2e/side_window/manual_prior_notification_form/behavior.spec.ts
@@ -565,7 +565,7 @@ context('Side Window > Manual Prior Notification Form > Behavior', () => {
 
   // Non-regression test
   // https://github.com/MTES-MCT/monitorfish/issues/3683
-  it('Should create a manual prior notification Zero, remove a specy and calculate BFT total weight', () => {
+  it('Should create a manual prior notification Zero, remove a specy and calculate BFT total weight and quantity', () => {
     const { utcDateTupleWithTime: arrivalDateTupleWithTime } = getUtcDateInMultipleFormats(
       customDayjs().add(2, 'hours').startOf('minute').toISOString()
     )
@@ -586,6 +586,9 @@ context('Side Window > Manual Prior Notification Form > Behavior', () => {
     cy.fill('Espèces à bord et à débarquer', 'SWO')
 
     cy.fill('Engins utilisés', ['OTP'], { index: 1 })
+    cy.fill('Quantité (BF1)', 2)
+    cy.fill('Quantité (BF2)', 3)
+    cy.get('[id="fishingCatches[0].quantity"]').should('have.value', '5')
 
     cy.clickButton('Créer le préavis')
 

--- a/frontend/cypress/e2e/side_window/manual_prior_notification_form/form.spec.ts
+++ b/frontend/cypress/e2e/side_window/manual_prior_notification_form/form.spec.ts
@@ -67,7 +67,7 @@ context('Side Window > Manual Prior Notification Form > Form', () => {
       })
       assert.deepInclude(createdPriorNotification.fishingCatches, {
         faoArea: null,
-        quantity: null,
+        quantity: 15,
         specyCode: 'BFT',
         specyName: 'THON ROUGE',
         weight: 150.0

--- a/frontend/src/features/PriorNotification/components/ManualPriorNotificationForm/fields/FormikFishingCatchesMultiSelect/FormikExtraField.tsx
+++ b/frontend/src/features/PriorNotification/components/ManualPriorNotificationForm/fields/FormikFishingCatchesMultiSelect/FormikExtraField.tsx
@@ -33,8 +33,14 @@ export function FormikExtraField({ fishingCatchIndex, isReadOnly }: FormikExtraF
         (fishinCatch.$bluefinTunaExtendedCatch.BF2.weight ?? 0) +
         (fishinCatch.$bluefinTunaExtendedCatch.BF3.weight ?? 0)
 
+      const totalQuantity =
+        (fishinCatch.$bluefinTunaExtendedCatch.BF1.quantity ?? 0) +
+        (fishinCatch.$bluefinTunaExtendedCatch.BF2.quantity ?? 0) +
+        (fishinCatch.$bluefinTunaExtendedCatch.BF3.quantity ?? 0)
+
       const nextFishingCatch: PriorNotification.FormDataFishingCatch = {
         ...fishinCatch,
+        quantity: totalQuantity,
         weight: totalWeight
       }
 

--- a/frontend/src/features/PriorNotification/components/ManualPriorNotificationForm/fields/FormikFishingCatchesMultiSelect/FormikMainField.tsx
+++ b/frontend/src/features/PriorNotification/components/ManualPriorNotificationForm/fields/FormikFishingCatchesMultiSelect/FormikMainField.tsx
@@ -95,6 +95,19 @@ export function FormikMainField({
                 </StyledSubRow>
               )}
 
+              {fishingCatch.specyCode === BLUEFIN_TUNA_SPECY_CODE && (
+                <FormikNumberInput
+                  areArrowsHidden
+                  isErrorMessageHidden
+                  isLabelHidden
+                  label={`Pièces (${fishingCatch.specyCode})`}
+                  name={`fishingCatches[${index}].quantity`}
+                  readOnly
+                  title="Le nombre de pièces est calculé à partir des pièces saisies dans les cases BF1, BF2, BF3"
+                  unit="pc"
+                />
+              )}
+
               <FormikNumberInput
                 areArrowsHidden
                 isErrorMessageHidden


### PR DESCRIPTION
## Linked issues

- Resolve #3889
- [x] Faire la modif dans le front pour que les nombres de pièces soient sommés et reportésé dans BFT à partir des infos BF1, BF2, BF3 saisies par l'utilisateur (en plus du poids pour lequel c'est déjà fait)
- [ ] Passer la requête ci-dessus en prod pour corriger les incohérences dans les données
- [x] filtrer la ligne BFT dans le cas où il y a BF1, BF2, BF3 dans le PDF

----

- [x] Tests E2E (Cypress)
