### PR TITLE
Préavis - Afficher la fiche navire depuis le fiche préavis & modification des coordonnées d'un contrôle

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -14,7 +14,7 @@ module.exports = {
   },
   rules: {
     curly: ['error', 'all'],
-    'func-names': ['error', 'always'],
+    'func-names': 'off',
     'newline-before-return': 'error',
     'no-console': ['error', { allow: ['info', 'warn', 'error'] }],
 

--- a/frontend/src/features/Draw/components/DrawModal.tsx
+++ b/frontend/src/features/Draw/components/DrawModal.tsx
@@ -23,6 +23,7 @@ import { addFeatureToDrawedFeature } from '../useCases/addFeatureToDrawedFeature
 import { closeDraw } from '../useCases/closeDraw'
 import { eraseDrawedGeometries } from '../useCases/eraseDrawedGeometries'
 
+import type { GeoJSON as GeoJSONNamespace } from '../../../domain/types/GeoJSON'
 import type { Coordinates } from '@mtes-mct/monitor-ui'
 import type { MultiPolygon } from 'ol/geom'
 
@@ -54,6 +55,26 @@ export function DrawLayerModal() {
       featureProjection: OPENLAYERS_PROJECTION
     }).readFeature(currentGeometry)
   }, [initialGeometry, drawedGeometry])
+
+  const controlPointCoordinates = useMemo(() => {
+    if (listener !== InteractionListener.CONTROL_POINT) {
+      return undefined
+    }
+
+    if (drawedGeometry) {
+      const drawedCoordinates = (drawedGeometry as GeoJSONNamespace.Point).coordinates
+
+      return [drawedCoordinates[1], drawedCoordinates[0]]
+    }
+
+    if (initialGeometry) {
+      const initialCoordinates = (initialGeometry as GeoJSONNamespace.Point)?.coordinates
+
+      return [initialCoordinates[1], initialCoordinates[0]]
+    }
+
+    return undefined
+  }, [listener, initialGeometry, drawedGeometry])
 
   useEffect(() => {
     if (initialFeatureNumberRef.current !== undefined) {
@@ -152,7 +173,7 @@ export function DrawLayerModal() {
         <CoordinatesInputWrapper>
           <CoordinatesInput
             coordinatesFormat={coordinatesFormat}
-            defaultValue={undefined}
+            defaultValue={controlPointCoordinates}
             isLabelHidden
             label="Coordonnées"
             name="coordinates"

--- a/frontend/src/features/Logbook/components/VesselLogbook/LogbookMessages/messages/FARMessage/Haul.tsx
+++ b/frontend/src/features/Logbook/components/VesselLogbook/LogbookMessages/messages/FARMessage/Haul.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import styled from 'styled-components'
 
 import { buildCatchArray } from '../../../../../utils'
@@ -9,13 +8,13 @@ import { CatchMessageZone } from '../common/CatchMessageZone'
 import { SpecyCatch } from '../common/SpecyCatch'
 
 export function Haul({ hasManyHauls, haul, haulNumber }) {
-  const catchesWithProperties = useMemo(() => {
+  const catchesWithProperties = (function () {
     if (!haul?.catches) {
       return []
     }
 
     return buildCatchArray(haul.catches)
-  }, [haul])
+  })()
 
   return (
     <>

--- a/frontend/src/features/Logbook/components/VesselLogbook/LogbookMessages/messages/LogbookMessage.tsx
+++ b/frontend/src/features/Logbook/components/VesselLogbook/LogbookMessages/messages/LogbookMessage.tsx
@@ -2,7 +2,6 @@ import { Ellipsised } from '@components/Ellipsised'
 import { useMainAppDispatch } from '@hooks/useMainAppDispatch'
 import { useMainAppSelector } from '@hooks/useMainAppSelector'
 import { Icon, THEME } from '@mtes-mct/monitor-ui'
-import { useMemo } from 'react'
 import styled from 'styled-components'
 
 import { getComponentFromMessageType } from './constants'
@@ -31,7 +30,7 @@ export function LogbookMessage({
   const dispatch = useMainAppDispatch()
   const fishingActivitiesShowedOnMap = useMainAppSelector(state => state.fishingActivities.fishingActivitiesShowedOnMap)
 
-  const logbookHeaderTitle = useMemo(() => {
+  const logbookHeaderTitle = (function () {
     switch (logbookMessage.messageType) {
       case LogbookMessageTypeEnum.DEP.code.toString(): {
         const depMessage = logbookMessage as Logbook.DepMessage
@@ -59,7 +58,7 @@ export function LogbookMessage({
         return LogbookMessageTypeEnum[logbookMessage.messageType].fullName
       }
     }
-  }, [logbookMessage, isManuallyCreated])
+  })()
 
   const openXML = (xml: string) => {
     const blob = new Blob([xml], { type: 'text/xml' })
@@ -68,10 +67,7 @@ export function LogbookMessage({
     URL.revokeObjectURL(url)
   }
 
-  const logbookMessageComponent = useMemo(
-    () => getComponentFromMessageType(logbookMessage, isManuallyCreated),
-    [logbookMessage, isManuallyCreated]
-  )
+  const logbookMessageComponent = getComponentFromMessageType(logbookMessage, isManuallyCreated)
 
   return (
     <Wrapper $isFirst={isFirst} data-cy="LogbookMessage" id={logbookMessage.operationNumber}>

--- a/frontend/src/features/Logbook/components/VesselLogbook/LogbookMessages/messages/common/CatchDetails.tsx
+++ b/frontend/src/features/Logbook/components/VesselLogbook/LogbookMessages/messages/common/CatchDetails.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import styled from 'styled-components'
 
 import { LogbookSpeciesPresentation, LogbookSpeciesPreservationState } from '../../../../../constants'
@@ -24,7 +23,7 @@ export function CatchDetails({
   },
   weightType
 }: CatchDetailsProps) {
-  const presentationFullName = useMemo(() => {
+  const presentationFullName = (function () {
     if (!presentation) {
       return undefined
     }
@@ -34,9 +33,9 @@ export function CatchDetails({
     }
 
     return presentation
-  }, [presentation])
+  })()
 
-  const preservationFullName = useMemo(() => {
+  const preservationFullName = (function () {
     if (!preservationState) {
       return undefined
     }
@@ -46,7 +45,7 @@ export function CatchDetails({
     }
 
     return preservationState
-  }, [preservationState])
+  })()
 
   return (
     <Wrapper key={`${faoZone}${weight}${statisticalRectangle}${economicZone}${presentation}`}>

--- a/frontend/src/features/Logbook/components/VesselLogbook/LogbookMessages/messages/common/SpecyCatch.tsx
+++ b/frontend/src/features/Logbook/components/VesselLogbook/LogbookMessages/messages/common/SpecyCatch.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@mtes-mct/monitor-ui'
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import styled from 'styled-components'
 
 import { WeightType } from '../../constants'
@@ -23,13 +23,13 @@ export function SpecyCatch({
 }: SpecyCatchProps) {
   const [isOpen, setIsOpen] = useState(false)
 
-  const specyFullName = useMemo(() => {
+  const specyFullName = (function () {
     if (specyCatch.speciesName && specyCatch.species) {
       return `${specyCatch.speciesName} (${specyCatch.species})`
     }
 
     return specyCatch.species
-  }, [specyCatch])
+  })()
 
   return (
     <Species>

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/VesselField.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/VesselField.tsx
@@ -5,7 +5,6 @@ import { Checkbox, useNewWindow } from '@mtes-mct/monitor-ui'
 import { skipToken } from '@reduxjs/toolkit/query'
 import { UNKNOWN_VESSEL } from 'domain/entities/vessel/vessel'
 import { useFormikContext } from 'formik'
-import { useMemo } from 'react'
 import styled from 'styled-components'
 
 import { useGetMissionActionFormikUsecases } from '../../hooks/useGetMissionActionFormikUsecases'
@@ -21,7 +20,7 @@ export function VesselField() {
 
   const { data: vessel, isFetching } = useGetVesselQuery(values.vesselId ?? skipToken)
 
-  const defaultValue = useMemo(() => {
+  const defaultValue = (function () {
     if (!values.vesselId || !values.flagState) {
       return undefined
     }
@@ -43,15 +42,7 @@ export function VesselField() {
       vesselLength: undefined,
       vesselName: values.vesselName
     }
-  }, [
-    values.flagState,
-    values.vesselName,
-    values.districtCode,
-    values.externalReferenceNumber,
-    values.internalReferenceNumber,
-    values.vesselId,
-    values.ircs
-  ])
+  })()
 
   const handleVesselSearchChange = (nextVessel: Partial<Vessel.VesselIdentity> | undefined) => {
     if (!nextVessel) {

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/VesselFleetSegmentsField.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/VesselFleetSegmentsField.tsx
@@ -43,15 +43,11 @@ export function VesselFleetSegmentsField({ label }: VesselFleetSegmentsFieldProp
     ))
   }
 
-  const fleetSegmentTags = useMemo(
-    () =>
-      values.segments
-        ? values.segments.map(({ segment, segmentName }) => (
-            <Tag key={segment} accent={Accent.PRIMARY}>{`${segment} - ${segmentName}`}</Tag>
-          ))
-        : [],
-    [values.segments]
-  )
+  const fleetSegmentTags = values.segments
+    ? values.segments.map(({ segment, segmentName }) => (
+        <Tag key={segment} accent={Accent.PRIMARY}>{`${segment} - ${segmentName}`}</Tag>
+      ))
+    : []
 
   if (isLoading) {
     return <FieldsetGroupSpinner isLight legend={label} />

--- a/frontend/src/features/Mission/components/MissionForm/MainForm/FormikLocationPicker.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/MainForm/FormikLocationPicker.tsx
@@ -14,7 +14,7 @@ import { useFormikContext } from 'formik'
 import { boundingExtent } from 'ol/extent'
 import { transformExtent } from 'ol/proj'
 import { remove } from 'ramda'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect } from 'react'
 import styled from 'styled-components'
 
 import { useGetMainFormFormikUsecases } from '../hooks/useGetMainFormFormikUsecases'
@@ -31,13 +31,13 @@ export function FormikLocationPicker() {
   const { updateMissionLocation } = useGetMainFormFormikUsecases()
   const dispatch = useMainAppDispatch()
 
-  const polygons = useMemo(() => {
+  const polygons = (function () {
     if (!values.geom) {
       return []
     }
 
     return values.geom.coordinates || []
-  }, [values.geom])
+  })()
 
   const addZone = useCallback(async () => {
     dispatch(addOrEditMissionZone(undefined))

--- a/frontend/src/features/PriorNotification/components/PriorNotificationList/index.tsx
+++ b/frontend/src/features/PriorNotification/components/PriorNotificationList/index.tsx
@@ -8,6 +8,7 @@ import { Body } from '@features/SideWindow/components/Body'
 import { Header } from '@features/SideWindow/components/Header'
 import { Page } from '@features/SideWindow/components/Page'
 import { SubMenu } from '@features/SideWindow/SubMenu'
+import { useForceUpdate } from '@hooks/useForceUpdate'
 import { useHandleFrontendApiError } from '@hooks/useHandleFrontendApiError'
 import { useListPagination } from '@hooks/useListPagination'
 import { useListSorting } from '@hooks/useListSorting'
@@ -45,6 +46,7 @@ type PriorNotificationListProps = Readonly<{
 }>
 export function PriorNotificationList({ isFromUrl }: PriorNotificationListProps) {
   const lastFetchStartDateRef = useRef<number | undefined>(undefined)
+  const { forceUpdate } = useForceUpdate()
 
   const dispatch = useMainAppDispatch()
   const listFilter = useMainAppSelector(state => state.priorNotification.listFilterValues)
@@ -102,6 +104,14 @@ export function PriorNotificationList({ isFromUrl }: PriorNotificationListProps)
   const isBodyEmptyDataVisible = !isBodyLoaderVisible && !!priorNotifications && priorNotifications.length === 0
   const previousListFilter = usePrevious(listFilter)
   const title = getTitle(listFilter.seafrontGroup)
+
+  useEffect(() => {
+    /**
+     * We need this force update for the side window to re-render
+     * 95% of all transactions are done under 2 seconds (from duration percentiles in sentry)
+     * */
+    forceUpdate(2000)
+  }, [loadingState, forceUpdate])
 
   const handleSubMenuChange = useCallback(
     (nextSeafrontGroup: SeafrontGroup | AllSeafrontGroup | NoSeafrontGroup) => {

--- a/frontend/src/features/PriorNotification/components/shared/CardBodyHead/index.tsx
+++ b/frontend/src/features/PriorNotification/components/shared/CardBodyHead/index.tsx
@@ -1,4 +1,5 @@
 import { PriorNotification } from '@features/PriorNotification/PriorNotification.types'
+import { useForceUpdate } from '@hooks/useForceUpdate'
 import { LinkButton, type Undefine } from '@mtes-mct/monitor-ui'
 import { useState } from 'react'
 import styled from 'styled-components'
@@ -33,7 +34,7 @@ export function CardBodyHead({
   types
 }: CardBodyHeadProps) {
   const [isSentMessageListExpanded, setIsSentMessageListExpanded] = useState(false)
-
+  const { forceUpdate } = useForceUpdate()
   const hasDesignatedPorts = detail?.logbookMessage.message.pnoTypes?.find(type => type.hasDesignatedPorts)
   const isInvalidated = detail?.logbookMessage.message.isInvalidated
   const isPendingVerification = detail?.state === PriorNotification.State.PENDING_VERIFICATION
@@ -44,6 +45,7 @@ export function CardBodyHead({
 
   const expandSentMessageList = () => {
     setIsSentMessageListExpanded(true)
+    forceUpdate() // We need this force update for the side window to re-render
   }
 
   return (

--- a/frontend/src/features/PriorNotification/components/shared/CardHeader.tsx
+++ b/frontend/src/features/PriorNotification/components/shared/CardHeader.tsx
@@ -1,6 +1,9 @@
 import { CountryFlag } from '@components/CountryFlag'
+import { useMainAppDispatch } from '@hooks/useMainAppDispatch'
 import { Accent, Icon, IconButton } from '@mtes-mct/monitor-ui'
 import styled, { keyframes } from 'styled-components'
+
+import { showVessel } from '../../../../domain/use_cases/vessel/showVessel'
 
 import type { Vessel } from '@features/Vessel/Vessel.types'
 import type { ReactNode } from 'react'
@@ -21,6 +24,14 @@ export function CardHeader({
   withCloseButton = false,
   withFirstTitleRow = false
 }: CardHeaderProps) {
+  const dispatch = useMainAppDispatch()
+
+  function triggerShowVessel() {
+    if (selectedVesselIdentity) {
+      dispatch(showVessel(selectedVesselIdentity, false, true))
+    }
+  }
+
   return (
     <Wrapper>
       <Title>
@@ -53,10 +64,10 @@ export function CardHeader({
             </TitleRowIconBox>
 
             {selectedVesselIdentity ? (
-              <span>
+              <button onClick={triggerShowVessel} title="Voir la fiche navire" type="button">
                 <VesselName>{selectedVesselIdentity.vesselName ?? '...'}</VesselName> (
                 {selectedVesselIdentity.internalReferenceNumber ?? '...'})
-              </span>
+              </button>
             ) : (
               <Loader $height={22} />
             )}
@@ -104,6 +115,8 @@ const Title = styled.div`
     &:nth-child(2) {
       color: ${p => p.theme.color.gunMetal};
       margin-top: 8px;
+      cursor: pointer;
+      text-decoration: underline;
     }
   }
 `

--- a/frontend/src/features/Vessel/components/VesselSidebar/Controls/Control.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/Controls/Control.tsx
@@ -7,10 +7,11 @@ import styled from 'styled-components'
 import { GearOnboard } from './GearOnboard'
 import { Infraction } from './Infraction'
 import { useIsSuperUser } from '../../../../../auth/hooks/useIsSuperUser'
-import { getNumberOfInfractions } from '../../../../../domain/entities/controls'
+import {
+  getNumberOfInfractionsWithoutRecord,
+  getNumberOfInfractionsWithRecord
+} from '../../../../../domain/entities/controls'
 import { getDate } from '../../../../../utils'
-import GyroRedSVG from '../../../../icons/Gyrophare_controles_rouge.svg?react'
-import GyroGreenSVG from '../../../../icons/Gyrophare_controles_vert.svg?react'
 
 type ControlProps = Readonly<{
   control: MissionAction.MissionAction
@@ -19,7 +20,9 @@ type ControlProps = Readonly<{
 export function Control({ control, isLastItem }: ControlProps) {
   const isSuperUser = useIsSuperUser()
   const dispatch = useMainAppDispatch()
-  const numberOfInfractions = getNumberOfInfractions(control)
+  const numberOfInfractionsWithRecord = getNumberOfInfractionsWithRecord(control)
+  const numberOfInfractionsWithoutRecord = getNumberOfInfractionsWithoutRecord(control)
+  const numberOfInfractions = numberOfInfractionsWithRecord + numberOfInfractionsWithoutRecord
   const gearAndSpeciesInfractionsLength = control.gearInfractions.length + control.speciesInfractions.length
   const gearSpeciesAndLogbookInfractionsLength =
     control.gearInfractions.length + control.speciesInfractions.length + control.logbookInfractions.length
@@ -54,7 +57,13 @@ export function Control({ control, isLastItem }: ControlProps) {
 
   return (
     <Wrapper isLastItem={isLastItem}>
-      <GyroColumn>{numberOfInfractions ? <GyroRed /> : <GyroGreen />}</GyroColumn>
+      <GyroColumn>
+        {numberOfInfractionsWithRecord > 0 && <StyledControlUnitFilled color={THEME.color.maximumRed} />}
+        {numberOfInfractionsWithoutRecord > 0 && !numberOfInfractionsWithRecord && (
+          <StyledControlUnitFilled color={THEME.color.goldenPoppy} />
+        )}
+        {!numberOfInfractions && <StyledControlUnitFilled color={THEME.color.mediumSeaGreen} />}
+      </GyroColumn>
       <ContentColumn data-cy="vessel-control">
         <Title data-cy="vessel-control-title" title={`${controlTitle} ${controlPort}`}>
           {controlTitle}
@@ -193,16 +202,8 @@ const ContentColumn = styled.div`
   box-sizing: border-box;
 `
 
-const GyroGreen = styled(GyroGreenSVG)`
-  width: 16px;
-  margin: 0px 12px 0 2px;
-  vertical-align: sub;
-`
-
-const GyroRed = styled(GyroRedSVG)`
-  width: 16px;
-  margin: 0px 12px 0 2px;
-  vertical-align: sub;
+const StyledControlUnitFilled = styled(Icon.ControlUnitFilled)`
+  margin-right: 8px;
 `
 
 const StyledTagGroup = styled(TagGroup)`

--- a/frontend/src/features/Vessel/components/VesselSidebar/Controls/Control.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/Controls/Control.tsx
@@ -1,18 +1,16 @@
+import { MissionAction } from '@features/Mission/missionAction.types'
+import { editMission } from '@features/Mission/useCases/editMission'
+import { useMainAppDispatch } from '@hooks/useMainAppDispatch'
 import { Accent, Button, Icon, Tag, TagGroup, THEME } from '@mtes-mct/monitor-ui'
-import { useCallback, useMemo } from 'react'
 import styled from 'styled-components'
 
 import { GearOnboard } from './GearOnboard'
 import { Infraction } from './Infraction'
 import { useIsSuperUser } from '../../../../../auth/hooks/useIsSuperUser'
-import { COLORS } from '../../../../../constants/constants'
 import { getNumberOfInfractions } from '../../../../../domain/entities/controls'
-import { useMainAppDispatch } from '../../../../../hooks/useMainAppDispatch'
 import { getDate } from '../../../../../utils'
 import GyroRedSVG from '../../../../icons/Gyrophare_controles_rouge.svg?react'
 import GyroGreenSVG from '../../../../icons/Gyrophare_controles_vert.svg?react'
-import { MissionAction } from '../../../../Mission/missionAction.types'
-import { editMission } from '../../../../Mission/useCases/editMission'
 
 type ControlProps = Readonly<{
   control: MissionAction.MissionAction
@@ -21,21 +19,16 @@ type ControlProps = Readonly<{
 export function Control({ control, isLastItem }: ControlProps) {
   const isSuperUser = useIsSuperUser()
   const dispatch = useMainAppDispatch()
-  const numberOfInfractions = useMemo(() => getNumberOfInfractions(control), [control])
-  const gearAndSpeciesInfractionsLength = useMemo(
-    () => control.gearInfractions.length + control.speciesInfractions.length,
-    [control]
-  )
-  const gearSpeciesAndLogbookInfractionsLength = useMemo(
-    () => control.gearInfractions.length + control.speciesInfractions.length + control.logbookInfractions.length,
-    [control]
-  )
+  const numberOfInfractions = getNumberOfInfractions(control)
+  const gearAndSpeciesInfractionsLength = control.gearInfractions.length + control.speciesInfractions.length
+  const gearSpeciesAndLogbookInfractionsLength =
+    control.gearInfractions.length + control.speciesInfractions.length + control.logbookInfractions.length
 
-  const openMission = useCallback(async () => {
+  const openMission = () => {
     dispatch(editMission(control.missionId))
-  }, [dispatch, control.missionId])
+  }
 
-  const controlType = useMemo(() => {
+  const controlType = (function () {
     switch (control.actionType) {
       case MissionAction.MissionActionType.AIR_CONTROL:
         return 'AÉRIEN'
@@ -46,21 +39,18 @@ export function Control({ control, isLastItem }: ControlProps) {
       default:
         return ''
     }
-  }, [control])
+  })()
 
-  const controlPort = useMemo(() => {
+  const controlPort = (function () {
     switch (control.actionType) {
       case MissionAction.MissionActionType.LAND_CONTROL:
         return `${control.portName?.toUpperCase()} (${control.portLocode?.toUpperCase()})`
       default:
         return ''
     }
-  }, [control])
+  })()
 
-  const controlTitle = useMemo(
-    () => `CONTRÔLE ${controlType} DU ${getDate(control.actionDatetimeUtc)}`,
-    [control, controlType]
-  )
+  const controlTitle = `CONTRÔLE ${controlType} DU ${getDate(control.actionDatetimeUtc)}`
 
   return (
     <Wrapper isLastItem={isLastItem}>
@@ -192,7 +182,7 @@ const Wrapper = styled.div<{
   width: -webkit-fill-available;
   margin: 16px;
   padding: 12px 24px 16px 12px;
-  color: ${COLORS.gunMetal};
+  color: ${p => p.theme.color.gunMetal};
   display: flex;
   white-space: initial;
 `

--- a/frontend/src/features/Vessel/components/VesselSidebar/Controls/Infraction.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/Controls/Infraction.tsx
@@ -1,6 +1,5 @@
 import { useGetNatinfsAsOptions } from '@features/Mission/components/MissionForm/hooks/useGetNatinfsAsOptions'
 import { find } from 'lodash'
-import { useMemo } from 'react'
 import styled from 'styled-components'
 
 import { COLORS } from '../../../../../constants/constants'
@@ -14,13 +13,13 @@ type InfractionProps = {
 export function Infraction({ index, infraction, infractionDomain }: InfractionProps) {
   const natinfsAsOptions = useGetNatinfsAsOptions()
 
-  const infractionWithLabel = useMemo(() => {
+  const infractionWithLabel = (function () {
     const infractionLabel = find(natinfsAsOptions, { value: infraction.natinf })?.label
 
     return { ...infraction, infractionLabel }
-  }, [natinfsAsOptions, infraction])
+  })()
 
-  const infractionDomainText = useMemo(() => {
+  const infractionDomainText = (function () {
     switch (infractionDomain) {
       case MissionAction.InfractionDomain.GEAR:
         return 'engin'
@@ -37,7 +36,7 @@ export function Infraction({ index, infraction, infractionDomain }: InfractionPr
       default:
         return ''
     }
-  }, [infractionDomain])
+  })()
 
   return (
     <Wrapper isFirstInfraction={index === 1}>

--- a/frontend/src/features/Vessel/components/VesselSidebar/Controls/LastControl.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/Controls/LastControl.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import styled from 'styled-components'
 
 import { Green, Red } from './Controls.style'
@@ -17,7 +16,7 @@ export function LastControl({ field }: LastControlProps) {
       ? control.controlUnits.map(controlUnit => controlUnit.name.replace('(historique)', '')).join(', ')
       : 'Unité manquante'
 
-  const numberOfInfractions = useMemo(() => getNumberOfInfractions(control), [control])
+  const numberOfInfractions = getNumberOfInfractions(control)
 
   return (
     <Fields data-cy="vessel-controls-summary-last-control">

--- a/frontend/src/features/Vessel/components/VesselSidebar/Controls/YearControls.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/Controls/YearControls.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import styled from 'styled-components'
 
 import { Control } from './Control'
@@ -20,7 +20,7 @@ export function YearControls({ year, yearControls }: YearControlsProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const isEmpty = yearControls.length === 0
 
-  const numberOfInfractionsText = useMemo(() => {
+  const numberOfInfractionsText = (function () {
     const numberOfInfractions = yearControls.reduce(
       (accumulator, control) => accumulator + getNumberOfInfractions(control),
       0
@@ -71,14 +71,10 @@ export function YearControls({ year, yearControls }: YearControlsProps) {
         , {numberOfInfractions} {pluralize('infraction', numberOfInfractions)} <Red />
       </>
     )
-  }, [yearControls, isEmpty])
+  })()
 
-  const sortedControls = useMemo(
-    () =>
-      yearControls.sort((a, b) =>
-        a.actionDatetimeUtc && b.actionDatetimeUtc && a.actionDatetimeUtc > b.actionDatetimeUtc ? -1 : 1
-      ),
-    [yearControls]
+  const sortedControls = yearControls.sort((a, b) =>
+    a.actionDatetimeUtc && b.actionDatetimeUtc && a.actionDatetimeUtc > b.actionDatetimeUtc ? -1 : 1
   )
 
   return (

--- a/frontend/src/features/Vessel/components/VesselSidebar/Controls/YearsToControlList.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/Controls/YearsToControlList.tsx
@@ -1,5 +1,4 @@
 import { customDayjs } from '@mtes-mct/monitor-ui'
-import { useMemo } from 'react'
 import styled from 'styled-components'
 
 import { YearControls } from './YearControls'
@@ -13,13 +12,9 @@ type YearsToControlListProps = {
   yearsToControls: Record<number, MissionAction.MissionAction[]>
 }
 export function YearsToControlList({ controlsFromDate, yearsToControls }: YearsToControlListProps) {
-  const sortedYears = useMemo(
-    () =>
-      Object.keys(yearsToControls)
-        .sort((a, b) => Number(b) - Number(a))
-        .map(value => Number(value)),
-    [yearsToControls]
-  )
+  const sortedYears = Object.keys(yearsToControls)
+    .sort((a, b) => Number(b) - Number(a))
+    .map(value => Number(value))
 
   return (
     <SidebarZone>

--- a/frontend/src/features/Vessel/components/VesselSidebar/Equipment/resume/YearBeaconMalfunctions.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/Equipment/resume/YearBeaconMalfunctions.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import styled from 'styled-components'
 
 import { BeaconMalfunctionCard } from './BeaconMalfunctionCard'
@@ -25,19 +25,12 @@ export function YearBeaconMalfunctions({
 }: YearBeaconMalfunctionsProps) {
   const [isOpen, setIsOpen] = useState(false)
   const isEmpty = yearBeaconMalfunctions.length === 0
-  const numberOfMalfunctions = useMemo(
-    () => getNumberOfSeaAndLandBeaconMalfunctions(yearBeaconMalfunctions),
-    [yearBeaconMalfunctions]
-  )
+  const numberOfMalfunctions = getNumberOfSeaAndLandBeaconMalfunctions(yearBeaconMalfunctions)
 
-  const sortedMalfunctions = useMemo(
-    () =>
-      yearBeaconMalfunctions.sort(
-        (a, b) =>
-          new Date(b.beaconMalfunction.malfunctionStartDateTime).getTime() -
-          new Date(a.beaconMalfunction.malfunctionStartDateTime).getTime()
-      ),
-    [yearBeaconMalfunctions]
+  const sortedMalfunctions = yearBeaconMalfunctions.sort(
+    (a, b) =>
+      new Date(b.beaconMalfunction.malfunctionStartDateTime).getTime() -
+      new Date(a.beaconMalfunction.malfunctionStartDateTime).getTime()
   )
 
   return (

--- a/frontend/src/features/Vessel/components/VesselSidebar/Equipment/resume/YearsToBeaconMalfunctionList.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/Equipment/resume/YearsToBeaconMalfunctionList.tsx
@@ -1,5 +1,4 @@
 import { SidebarZone } from '@features/Vessel/components/VesselSidebar/common_styles/common.style'
-import { useMemo } from 'react'
 import styled from 'styled-components'
 
 import { YearBeaconMalfunctions } from './YearBeaconMalfunctions'
@@ -17,13 +16,9 @@ export function YearsToBeaconMalfunctionList({
   vesselBeaconMalfunctionsFromDate,
   yearsToBeaconMalfunctions
 }: YearsToBeaconMalfunctionListProps) {
-  const sortedYears = useMemo(
-    () =>
-      Object.keys(yearsToBeaconMalfunctions)
-        .sort((a, b) => Number(b) - Number(a))
-        .map(value => Number(value)),
-    [yearsToBeaconMalfunctions]
-  )
+  const sortedYears = Object.keys(yearsToBeaconMalfunctions)
+    .sort((a, b) => Number(b) - Number(a))
+    .map(value => Number(value))
 
   return (
     <SidebarZone>

--- a/frontend/src/features/Vessel/components/VesselSidebar/VesselSidebarHeader/VesselName.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/VesselSidebarHeader/VesselName.tsx
@@ -5,7 +5,7 @@ import { useMainAppSelector } from '@hooks/useMainAppSelector'
 import { addVesselToFavorites, removeVesselFromFavorites } from 'domain/shared_slices/FavoriteVessel'
 import { unselectVessel } from 'domain/use_cases/vessel/unselectVessel'
 import countries from 'i18n-iso-countries'
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 import styled from 'styled-components'
 
 import CloseIconSVG from '../../../../icons/Croix_grise.svg?react'
@@ -26,27 +26,21 @@ export function VesselName({ focusOnVesselSearchInput }) {
     [selectedVesselIdentity, favorites]
   )
 
-  const addOrRemoveToFavorites = useCallback(
-    e => {
-      e.stopPropagation()
+  const addOrRemoveToFavorites = function (e) {
+    e.stopPropagation()
 
-      if (isFavorite) {
-        dispatch(removeVesselFromFavorites(getVesselCompositeIdentifier(selectedVesselIdentity)))
-      } else {
-        dispatch(addVesselToFavorites(selectedVesselIdentity))
-      }
-    },
-    [dispatch, selectedVesselIdentity, isFavorite]
-  )
+    if (isFavorite) {
+      dispatch(removeVesselFromFavorites(getVesselCompositeIdentifier(selectedVesselIdentity)))
+    } else {
+      dispatch(addVesselToFavorites(selectedVesselIdentity))
+    }
+  }
 
-  const close = useCallback(
-    e => {
-      e.stopPropagation()
+  const close = function (e) {
+    e.stopPropagation()
 
-      dispatch(unselectVessel())
-    },
-    [dispatch]
-  )
+    dispatch(unselectVessel())
+  }
 
   return (
     <Wrapper
@@ -64,10 +58,15 @@ export function VesselName({ focusOnVesselSearchInput }) {
         $isFavorite={!!isFavorite}
         $isFlagShown={!!selectedVesselIdentity?.flagState}
         data-cy="sidebar-add-vessel-to-favorites"
+        /* eslint-disable-next-line react/jsx-no-bind */
         onClick={addOrRemoveToFavorites}
       />
       <Name title={selectedVesselIdentity?.vesselName ?? undefined}>{getVesselName(selectedVesselIdentity)}</Name>
-      <CloseIcon data-cy="vessel-search-selected-vessel-close-title" onClick={close} />
+      <CloseIcon
+        data-cy="vessel-search-selected-vessel-close-title"
+        /* eslint-disable-next-line react/jsx-no-bind */
+        onClick={close}
+      />
     </Wrapper>
   )
 }

--- a/frontend/src/features/Vessel/components/VesselSidebar/actions/TrackRequest/ExportTrack.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/actions/TrackRequest/ExportTrack.tsx
@@ -6,7 +6,7 @@ import { downloadAsCsv } from '@utils/downloadAsCsv'
 import { getCoordinates } from 'coordinates'
 import dayjs from 'dayjs'
 import countries from 'i18n-iso-countries'
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 import styled from 'styled-components'
 import { getDate } from 'utils'
 
@@ -26,29 +26,22 @@ export function ExportTrack() {
   const { selectedVesselPositions } = useMainAppSelector(state => state.vessel)
   const { trackEvent } = useTracking()
 
-  const exportedPositions: VesselPositionWithId[] = useMemo(
-    () =>
-      selectedVesselPositions
-        ?.map(position => {
-          const coordinates = getCoordinates(
-            [position.longitude, position.latitude],
-            WSG84_PROJECTION,
-            coordinatesFormat
-          )
-          if (!coordinates[0] || !coordinates[1]) {
-            return undefined
-          }
+  const exportedPositions: VesselPositionWithId[] =
+    selectedVesselPositions
+      ?.map(position => {
+        const coordinates = getCoordinates([position.longitude, position.latitude], WSG84_PROJECTION, coordinatesFormat)
+        if (!coordinates[0] || !coordinates[1]) {
+          return undefined
+        }
 
-          return {
-            ...position,
-            id: position.dateTime,
-            latitude: coordinates[0],
-            longitude: coordinates[1]
-          }
-        })
-        ?.filter((position): position is VesselPositionWithId => position !== undefined) ?? [],
-    [selectedVesselPositions, coordinatesFormat]
-  )
+        return {
+          ...position,
+          id: position.dateTime,
+          latitude: coordinates[0],
+          longitude: coordinates[1]
+        }
+      })
+      ?.filter((position): position is VesselPositionWithId => position !== undefined) ?? []
 
   const downloadCSV = useCallback(
     positions => {

--- a/frontend/src/features/Vessel/components/VesselSidebar/actions/TrackRequest/TrackDepthSelection.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/actions/TrackRequest/TrackDepthSelection.tsx
@@ -1,6 +1,5 @@
 import { SELECT_TRACK_DEPTH_OPTIONS } from '@features/Vessel/components/VesselSidebar/actions/TrackRequest/constants'
 import { Select } from '@mtes-mct/monitor-ui'
-import { useMemo } from 'react'
 import styled from 'styled-components'
 
 import { VesselTrackDepth } from '../../../../../../domain/entities/vesselTrackDepth'
@@ -16,10 +15,7 @@ type DateRangeRadioProps = {
   onChange: (nextTrackDepth: SelectableVesselTrackDepth | undefined) => Promisable<void>
 }
 export function TrackDepthSelection({ defaultValue, label, name, onChange }: DateRangeRadioProps) {
-  const normalizedDefaultValue = useMemo(
-    () => (defaultValue !== VesselTrackDepth.CUSTOM ? defaultValue : undefined),
-    [defaultValue]
-  )
+  const normalizedDefaultValue = defaultValue !== VesselTrackDepth.CUSTOM ? defaultValue : undefined
 
   return (
     <ColumnsBox>

--- a/frontend/src/features/Vessel/components/VesselSidebar/actions/TrackRequest/index.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/actions/TrackRequest/index.tsx
@@ -3,7 +3,7 @@ import { useMainAppSelector } from '@hooks/useMainAppSelector'
 import { DateRangePicker, THEME } from '@mtes-mct/monitor-ui'
 import { getTrackRequestFromTrackDepth, VesselTrackDepth } from 'domain/entities/vesselTrackDepth'
 import { updateSelectedVesselTrackRequest } from 'domain/use_cases/vessel/updateSelectedVesselTrackRequest'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useState } from 'react'
 import styled from 'styled-components'
 
 import { ExportTrack } from './ExportTrack'
@@ -28,14 +28,11 @@ export function TrackRequest({ isSidebarOpen }: TrackRequestProps) {
   const { selectedVesselIdentity } = useMainAppSelector(state => state.vessel)
   const [isOpenedFromClick, setIsOpenedFromClick] = useState(false)
 
-  const dateRangePickerDefaultValue = useMemo(
-    () =>
-      selectedVesselTrackRequest && selectedVesselTrackRequest.trackDepth === VesselTrackDepth.CUSTOM
-        ? ([selectedVesselTrackRequest.afterDateTime, selectedVesselTrackRequest.beforeDateTime] as DateRange)
-        : undefined,
-    [selectedVesselTrackRequest]
-  )
-  const isOpen = useMemo(() => isSidebarOpen && isOpenedFromClick, [isSidebarOpen, isOpenedFromClick])
+  const dateRangePickerDefaultValue =
+    selectedVesselTrackRequest && selectedVesselTrackRequest.trackDepth === VesselTrackDepth.CUSTOM
+      ? ([selectedVesselTrackRequest.afterDateTime, selectedVesselTrackRequest.beforeDateTime] as DateRange)
+      : undefined
+  const isOpen = isSidebarOpen && isOpenedFromClick
 
   const handleDateRangeRadioChange = useCallback(
     (nextTrackDepth: SelectableVesselTrackDepth | undefined) => {

--- a/frontend/src/features/Vessel/components/VesselSidebar/actions/show_fishing_activities/index.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/actions/show_fishing_activities/index.tsx
@@ -1,7 +1,7 @@
 import { useMainAppDispatch } from '@hooks/useMainAppDispatch'
 import { useMainAppSelector } from '@hooks/useMainAppSelector'
 import { THEME } from '@mtes-mct/monitor-ui'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useEffect } from 'react'
 import styled from 'styled-components'
 
 import ShowFishingActivitiesSVG from '../../../../../icons/Bouton_afficher_messages_JPE_sur_piste.svg?react'
@@ -17,10 +17,7 @@ export function ShowFishingActivitiesOnMap({ isSidebarOpen }) {
     state => state.fishingActivities
   )
   const getVesselLogbook = useGetLogbookUseCase()
-  const areFishingActivitiesReallyShowedOnMap = useMemo(
-    () => areFishingActivitiesShowedOnMap || fishingActivitiesShowedOnMap?.length,
-    [areFishingActivitiesShowedOnMap, fishingActivitiesShowedOnMap]
-  )
+  const areFishingActivitiesReallyShowedOnMap = areFishingActivitiesShowedOnMap || fishingActivitiesShowedOnMap?.length
 
   useEffect(() => {
     if (!isSidebarOpen) {
@@ -28,20 +25,18 @@ export function ShowFishingActivitiesOnMap({ isSidebarOpen }) {
     }
   }, [dispatch, isSidebarOpen])
 
-  const showOrHideFishingActivities = useCallback(() => {
-    ;(async () => {
-      if (areFishingActivitiesReallyShowedOnMap) {
-        dispatch(logbookActions.hideAllOnMap())
+  const showOrHideFishingActivities = async function () {
+    if (areFishingActivitiesReallyShowedOnMap) {
+      dispatch(logbookActions.hideAllOnMap())
 
-        return
-      }
+      return
+    }
 
-      if (!fishingActivities) {
-        await dispatch(getVesselLogbook(selectedVesselIdentity, undefined, true))
-      }
-      dispatch(logbookActions.showAllOnMap())
-    })()
-  }, [fishingActivities, getVesselLogbook, selectedVesselIdentity, areFishingActivitiesReallyShowedOnMap, dispatch])
+    if (!fishingActivities) {
+      await dispatch(getVesselLogbook(selectedVesselIdentity, undefined, true))
+    }
+    dispatch(logbookActions.showAllOnMap())
+  }
 
   return (
     <VesselSidebarActionButton
@@ -52,6 +47,7 @@ export function ShowFishingActivitiesOnMap({ isSidebarOpen }) {
       data-cy="show-all-fishing-activities-on-map"
       disabled={!selectedVesselPositions?.length}
       isHidden={false}
+      /* eslint-disable-next-line react/jsx-no-bind */
       onClick={showOrHideFishingActivities}
       title={`${areFishingActivitiesReallyShowedOnMap ? 'Cacher' : 'Afficher'} les messages du JPE sur la piste`}
     >

--- a/frontend/src/hooks/useForceUpdate.ts
+++ b/frontend/src/hooks/useForceUpdate.ts
@@ -12,5 +12,10 @@ export function useForceUpdate() {
 
   const forceDebouncedUpdate = useMemo(() => throttle(forceUpdate, 250), [forceUpdate])
 
-  return { forceDebouncedUpdate, forceUpdate }
+  return {
+    forceDebouncedUpdate,
+    forceUpdate: (timeout = 0) => {
+      setTimeout(() => forceUpdate(), timeout)
+    }
+  }
 }


### PR DESCRIPTION
## Linked issues

- Resolve #4035
- Corrections de re-render de la side-window avec un `forceRender`:
  - Dans la liste des destinataires du PNO
  - Lors du chargement de la liste des PNOs
- Suppression de `useMemo` et `useCallback` inutiles
- Resolve #4086
-  Resolve #4085
   - https://github.com/MTES-MCT/monitor-ui/pull/1572 
 
----

- [ ] Tests E2E (Cypress)
