### PR TITLE
Tech - Correction du rafraichissement de l'application par le `polling` lorsque l'utilisateur est externe

### DIFF
--- a/frontend/src/api/APIWorker.tsx
+++ b/frontend/src/api/APIWorker.tsx
@@ -66,10 +66,12 @@ export function APIWorker() {
   const poll = useCallback(() => {
     dispatch(setIsUpdatingVessels())
     dispatch(updateVesselTracks())
-    dispatch(getAllBeaconMalfunctions())
+    if (isSuperUser) {
+      dispatch(getAllBeaconMalfunctions())
+    }
 
     setUpdateVesselSidebarTab(true)
-  }, [dispatch])
+  }, [dispatch, isSuperUser])
 
   useEffect(() => {
     if (isSuperUser === undefined) {


### PR DESCRIPTION
## Linked issues

----

- [ ] Tests E2E (Cypress)
