### PR TITLE
Fiabilisation de la planification des `flows`

### DIFF
--- a/datascience/src/pipeline/flows/position_alerts.py
+++ b/datascience/src/pipeline/flows/position_alerts.py
@@ -503,7 +503,7 @@ with Flow("Position alert", executor=LocalDaskExecutor()) as flow:
     with case(flow_not_running, True):
         alert_type = Parameter("alert_type")
         alert_config_name = Parameter("alert_config_name")
-        zones = Parameter("zones")
+        zones = Parameter("zones", default=None)
         hours_from_now = Parameter("hours_from_now", default=8)
         only_fishing_positions = Parameter("only_fishing_positions", default=True)
         flag_states = Parameter("flag_states", default=None)

--- a/datascience/src/pipeline/flows_config.py
+++ b/datascience/src/pipeline/flows_config.py
@@ -322,7 +322,6 @@ position_alerts.flow.schedule = Schedule(
             parameter_defaults={
                 "alert_type": "NEAFC_FISHING_ALERT",
                 "alert_config_name": "NEAFC_FISHING_ALERT",
-                "zones": None,
                 "hours_from_now": 8,
                 "only_fishing_positions": True,
             },

--- a/datascience/tests/test_pipeline/test_flows_config.py
+++ b/datascience/tests/test_pipeline/test_flows_config.py
@@ -1,0 +1,24 @@
+import prefect
+
+from src.pipeline.flows_config import flows_to_register
+
+
+def test_flows_registration():
+    for flow in flows_to_register:
+        # Check that the flow and its params can be serialized and deserialized
+        serialized_flow = flow.serialize()
+        prefect.serialization.flow.FlowSchema().load(serialized_flow)
+
+        # Check that the default parameters include all required parameters
+        required_parameters = {p for p in flow.parameters() if p.required}
+        if flow.schedule is not None and required_parameters:
+            required_names = {p.name for p in required_parameters}
+            for c in flow.schedule.clocks:
+                try:
+                    assert required_names <= set(c.parameter_defaults.keys())
+                except AssertionError:
+                    raise ValueError(
+                        "Some of the flow's required parameters are missing from the "
+                        "clock's default parameters :"
+                        f"{required_names - set(c.parameter_defaults.keys())}"
+                    )


### PR DESCRIPTION
- Résout le bug qui apparait au moment du `register` sur le flow de `position_alerts` quand le paramètre `zones` est `None`.
- Ajoute un test sur la serialization / deserialisation des flows pour détecter ce genre de pb avant MEP.