### PR TITLE
JPE - Réduction de l'affichage de la piste VMS et du JPE depuis un contrôle à 2 jours

### DIFF
--- a/frontend/src/features/Vessel/components/VesselSidebar/components/Controls/Control.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/components/Controls/Control.tsx
@@ -44,8 +44,8 @@ export function Control({ control, isLastItem }: ControlProps) {
 
   const openTripForControl = async () => {
     const controlDate = customDayjs(control.actionDatetimeUtc)
-    const fromDate = controlDate.subtract(2, 'days')
-    const toDate = controlDate.add(2, 'days')
+    const fromDate = controlDate.subtract(1, 'day')
+    const toDate = controlDate.add(1, 'day')
     const trackRequest: TrackRequestCustom = {
       afterDateTime: fromDate.toDate(),
       beforeDateTime: toDate.toDate(),


### PR DESCRIPTION
## Linked issues

- Auparavant, la range de 4 jours remontait trop souvent plusieurs marées pour un navire contrôlé, surtout pour les petits métiers. 

----

- [ ] Tests E2E (Cypress)
