### PR TITLE
CR de contrôle - Le champ actionEndDatetimeUtc est écrasé lors d'un update

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission/mission_actions/UpdateMissionAction.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission/mission_actions/UpdateMissionAction.kt
@@ -16,18 +16,22 @@ class UpdateMissionAction(
         actionId: Int,
         action: MissionAction,
     ): MissionAction {
+        val previousMissionAction = missionActionsRepository.findById(actionId)
+
         logger.info("Updating mission action $actionId")
         action.verify()
 
         // We store the `storedValue` of the enum and not the enum uppercase value
         val facade = getMissionActionFacade.execute(action)?.toString()
 
-        val actionWithId =
+        val actionWithFixedFieldsAndId =
             action.copy(
+                actionEndDatetimeUtc = previousMissionAction.actionEndDatetimeUtc,
+                observationsByUnit = previousMissionAction.observationsByUnit,
                 id = actionId,
                 facade = facade,
             )
 
-        return missionActionsRepository.save(actionWithId)
+        return missionActionsRepository.save(actionWithFixedFieldsAndId)
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission/mission_actions/UpdateMissionActionUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission/mission_actions/UpdateMissionActionUTests.kt
@@ -1,6 +1,9 @@
 package fr.gouv.cnsp.monitorfish.domain.use_cases.mission.mission_actions
 
 import com.neovisionaries.i18n.CountryCode
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.given
+import com.nhaarman.mockitokotlin2.verify
 import fr.gouv.cnsp.monitorfish.domain.entities.mission.mission_actions.Completion
 import fr.gouv.cnsp.monitorfish.domain.entities.mission.mission_actions.MissionAction
 import fr.gouv.cnsp.monitorfish.domain.entities.mission.mission_actions.MissionActionType
@@ -52,5 +55,36 @@ class UpdateMissionActionUTests {
         // Then
         assertThat(throwable).isNotNull()
         assertThat(throwable.message).isEqualTo("A control must specify a vessel: the `vesselId` must be given.")
+    }
+
+    @Test
+    fun `execute Should get the previous action`() {
+        // Given
+        val action =
+            MissionAction(
+                id = 123,
+                vesselId = 156,
+                missionId = 1,
+                actionDatetimeUtc = ZonedDateTime.now(),
+                portLocode = "AEFAT",
+                actionType = MissionActionType.LAND_CONTROL,
+                gearOnboard = listOf(),
+                seizureAndDiversion = true,
+                isDeleted = false,
+                hasSomeGearsSeized = false,
+                hasSomeSpeciesSeized = false,
+                isFromPoseidon = false,
+                flagState = CountryCode.FR,
+                userTrigram = "LTH",
+                completion = Completion.TO_COMPLETE,
+            )
+        val endDate = ZonedDateTime.now()
+        given(missionActionsRepository.findById(any())).willReturn(action.copy(actionEndDatetimeUtc = endDate))
+
+        // When
+        UpdateMissionAction(missionActionsRepository, getMissionActionFacade).execute(123, action)
+
+        // Then
+        verify(missionActionsRepository).save(action.copy(actionEndDatetimeUtc = endDate))
     }
 }


### PR DESCRIPTION
## Linked issues

- Resolve #4197

----

- [ ] Tests E2E (Cypress)
