### PR TITLE
Modification de la migration de `positions`

### DIFF
--- a/backend/src/main/resources/db/migration/internal/V0.296__Update_positions_table.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.296__Update_positions_table.sql
@@ -1,5 +1,0 @@
-ALTER TABLE public.positions
-ALTER COLUMN time_since_previous_position TYPE DOUBLE PRECISION USING EXTRACT(epoch FROM time_since_previous_position) / 3600.0;
-
-ALTER TABLE public.positions
-ALTER COLUMN time_emitting_at_sea TYPE DOUBLE PRECISION USING EXTRACT(epoch FROM time_emitting_at_sea) / 3600.0;

--- a/backend/src/main/resources/db/migration/internal/V0.298__Update_positions_table.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.298__Update_positions_table.sql
@@ -1,0 +1,11 @@
+ALTER TABLE public.positions
+DROP COLUMN time_since_previous_position;
+
+ALTER TABLE public.positions
+ADD COLUMN time_since_previous_position DOUBLE PRECISION;
+
+ALTER TABLE public.positions
+DROP COLUMN time_emitting_at_sea;
+
+ALTER TABLE public.positions
+ADD COLUMN time_emitting_at_sea DOUBLE PRECISION;


### PR DESCRIPTION
Pour éviter le down della muerte.
Faire tourner enrich_positions ensuite.