### PR TITLE
Correction d'un bug dans l'enrichissement des préavis

### DIFF
--- a/datascience/src/pipeline/flows/enrich_logbook.py
+++ b/datascience/src/pipeline/flows/enrich_logbook.py
@@ -135,14 +135,6 @@ def extract_pno_catches(
             "min_trip_date": trips_period.start,
             "max_trip_date": trips_period.end,
         },
-        dtypes={
-            "species": str,
-            "fao_area": str,
-            "weight": float,
-            "facade": str,
-            "vessel_type": str,
-            "scip_species_type": str,
-        },
     )
 
 
@@ -287,7 +279,6 @@ def compute_pno_types(
           - weight `float` `150.5`
           - flag_state `str` `'FRA'`
           - locode `str` `CCXXX`
-          - facade `str` `NAMO`
 
         pno_types (pd.DataFrame): DataFrame of pno_types definitions. 1 line = 1 rule.
           Must have columns :

--- a/datascience/src/pipeline/flows/enrich_logbook.py
+++ b/datascience/src/pipeline/flows/enrich_logbook.py
@@ -135,6 +135,14 @@ def extract_pno_catches(
             "min_trip_date": trips_period.start,
             "max_trip_date": trips_period.end,
         },
+        dtypes={
+            "species": str,
+            "fao_area": str,
+            "weight": float,
+            "facade": str,
+            "vessel_type": str,
+            "scip_species_type": str,
+        },
     )
 
 
@@ -156,6 +164,7 @@ def compute_pno_segments(
           - species `str` `'COD'`
           - fao_area `str` `'27.7.d'`
           - year `int` `2022`
+          - facade `str` `'MED'`
           - weight `float` `230.2`
           - vessel_type `str` `Fishing vessel`
           - scip_species_type `str` `DEMERSAL`

--- a/datascience/src/pipeline/queries/monitorfish/pno_catches.sql
+++ b/datascience/src/pipeline/queries/monitorfish/pno_catches.sql
@@ -116,7 +116,7 @@ SELECT
     s.weight,
     s.flag_state,
     s.locode,
-    s.facade,
+    COALESCE(s.facade, 'Hors façade') AS facade,
     v.vessel_type,
     species.scip_species_type
 FROM pno_species s

--- a/datascience/src/pipeline/queries/monitorfish/pno_catches.sql
+++ b/datascience/src/pipeline/queries/monitorfish/pno_catches.sql
@@ -22,7 +22,7 @@ pno_species AS (
         trip_number,
         trip_number_was_computed,
         report_datetime_utc,
-        p.locode,
+        r.value->>'port' AS locode,
         p.facade,
         (r.value->>'tripStartDate')::TIMESTAMPTZ AS trip_start_date,
         (r.value->>'predictedArrivalDatetimeUtc')::TIMESTAMPTZ AS predicted_arrival_datetime_utc,

--- a/datascience/tests/test_pipeline/test_flows/test_enrich_logbook.py
+++ b/datascience/tests/test_pipeline/test_flows/test_enrich_logbook.py
@@ -321,8 +321,8 @@ def expected_pno_catches() -> pd.DataFrame:
             "fao_area": ["27.7.a", None],
             "weight": [1500.0, None],
             "flag_state": ["CYP", "CYP"],
-            "locode": ["GBPHD", None],
-            "facade": ["MEMN", None],
+            "locode": ["GBPHD", "NOFAC"],
+            "facade": ["MEMN", "Hors façade"],
             "vessel_type": [None, None],
             "scip_species_type": ["DEMERSAL", None],
         }


### PR DESCRIPTION
## Linked issues

- Resolve #4269

Plantage dû à un échec de la jointure DuckDB dans `enrich_logbook` > `compute_pno_segments` sur la clef `facade`, en raison d'un mismatch de type (en absence de donnée, pandas convertit la colonne en `float`).
Corrigé en remplaçant les NULL par la value 'Hors façade' en cas de port inconnu ou avec une façade NULL.