### PR TITLE
APIs - Ajout d'une API publique pour récupérer tous les navires

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/vessel/GetVessels.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/vessel/GetVessels.kt
@@ -1,0 +1,12 @@
+package fr.gouv.cnsp.monitorfish.domain.use_cases.vessel
+
+import fr.gouv.cnsp.monitorfish.config.UseCase
+import fr.gouv.cnsp.monitorfish.domain.entities.vessel.Vessel
+import fr.gouv.cnsp.monitorfish.domain.repositories.VesselRepository
+
+@UseCase
+class GetVessels(
+    private val vesselRepository: VesselRepository,
+) {
+    fun execute(): List<Vessel> = vesselRepository.findAll()
+}

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/VesselController.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/VesselController.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
 
+import fr.gouv.cnsp.monitorfish.domain.use_cases.vessel.GetVessels
 import fr.gouv.cnsp.monitorfish.domain.use_cases.vessel.SearchVessels
 import fr.gouv.cnsp.monitorfish.infrastructure.api.outputs.VesselIdentityDataOutput
 import io.swagger.v3.oas.annotations.Operation
@@ -14,8 +15,13 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/vessels")
 @Tag(name = "APIs for Vessels")
 class PublicVesselController(
+    private val getVessels: GetVessels,
     private val searchVessels: SearchVessels,
 ) {
+    @GetMapping("")
+    @Operation(summary = "Get all vessels")
+    fun getAllVessels(): List<VesselIdentityDataOutput> = getVessels.execute().map(VesselIdentityDataOutput::fromVessel)
+
     @GetMapping("/search")
     @Operation(summary = "Search vessels")
     fun searchVessel(

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/vessel/GetVesselsUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/vessel/GetVesselsUTests.kt
@@ -1,0 +1,51 @@
+package fr.gouv.cnsp.monitorfish.domain.use_cases.vessel
+
+import com.neovisionaries.i18n.CountryCode
+import fr.gouv.cnsp.monitorfish.domain.entities.vessel.Vessel
+import fr.gouv.cnsp.monitorfish.domain.repositories.VesselRepository
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class GetVesselsUTests {
+    @MockBean
+    private lateinit var vesselRepository: VesselRepository
+
+    @Test
+    fun `execute should propagate exception when repository throws unexpectedly`() {
+        // Given
+        val runtimeException = RuntimeException("Unexpected DB error")
+        given(vesselRepository.findAll()).willThrow(runtimeException)
+
+        // When & Then
+        val exception =
+            assertThrows<RuntimeException> {
+                GetVessels(vesselRepository).execute()
+            }
+        assertThat(exception).isSameAs(runtimeException)
+    }
+
+    @Test
+    fun `execute Should return vessels `() {
+        // Given
+        given(vesselRepository.findAll()).willReturn(
+            listOf(
+                Vessel(1, internalReferenceNumber = "1234", flagState = CountryCode.FR, hasLogbookEsacapt = false),
+                Vessel(2, internalReferenceNumber = "5789", flagState = CountryCode.FR, hasLogbookEsacapt = false),
+            ),
+        )
+
+        // When
+        val vessels = GetVessels(vesselRepository).execute()
+
+        // Then
+        assertThat(vessels).hasSize(2)
+        assertThat(vessels.first().id).isEqualTo(1)
+        assertThat(vessels.last().id).isEqualTo(2)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicVesselControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicVesselControllerITests.kt
@@ -30,6 +30,57 @@ class PublicVesselControllerITests {
     @MockBean
     private lateinit var searchVessels: SearchVessels
 
+    @MockBean
+    private lateinit var getVessels: GetVessels
+
+    @Test
+    fun `Should return all vessels`() {
+        // Given
+        given(getVessels.execute()).willReturn(
+            listOf(
+                Vessel(
+                    id = 1,
+                    vesselName = "BLUE WHALE",
+                    flagState = CountryCode.FR,
+                    internalReferenceNumber = "FR999999",
+                    imo = "IMO1234567",
+                    mmsi = "111222333",
+                    ircs = "FRCODE",
+                    externalReferenceNumber = "EXT123",
+                    districtCode = "DC01",
+                    hasLogbookEsacapt = false,
+                ),
+                Vessel(
+                    id = 2,
+                    vesselName = "RED FISH",
+                    flagState = CountryCode.ES,
+                    internalReferenceNumber = "ES888888",
+                    imo = null,
+                    mmsi = null,
+                    ircs = null,
+                    externalReferenceNumber = null,
+                    districtCode = null,
+                    hasLogbookEsacapt = true,
+                ),
+            ),
+        )
+
+        // When
+        api
+            .perform(get("/api/v1/vessels"))
+            // Then
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()", equalTo(2)))
+            .andExpect(jsonPath("$[0].vesselName", equalTo("BLUE WHALE")))
+            .andExpect(jsonPath("$[0].flagState", equalTo("FR")))
+            .andExpect(jsonPath("$[0].internalReferenceNumber", equalTo("FR999999")))
+            .andExpect(jsonPath("$[1].vesselName", equalTo("RED FISH")))
+            .andExpect(jsonPath("$[1].flagState", equalTo("ES")))
+            .andExpect(jsonPath("$[1].internalReferenceNumber", equalTo("ES888888")))
+
+        Mockito.verify(getVessels).execute()
+    }
+
     @Test
     fun `Should search for a vessel`() {
         // Given


### PR DESCRIPTION
## Description

Ajout d'un endpoint pour avoir accès à tous les Vessels. 

A la base, le /search nous suffisait mais vu qu'on bosse sur le offline, il faut que l'on pré-download les référentiels statiques côté frontend, d'où la nécessité de cet endpoint pour RapportNav

----

- [ ] Tests E2E (Cypress)
