### PR TITLE
Navires - Ajout d'un navire inactif `GB`

### DIFF
--- a/datascience/src/pipeline/queries/ocan/eu_vessels.sql
+++ b/datascience/src/pipeline/queries/ocan/eu_vessels.sql
@@ -53,5 +53,6 @@ WHERE ncp.est_actif = 1 AND
         'GBR000J10346',
         'GBR000J10070',
         'GBR000J10359',
-        'GBR000A10387'
+        'GBR000A10387',
+        'GBR000C17828'
     )

--- a/datascience/src/pipeline/queries/ocan/eu_vessels.sql
+++ b/datascience/src/pipeline/queries/ocan/eu_vessels.sql
@@ -52,5 +52,6 @@ WHERE ncp.est_actif = 1 AND
         'GBR000J10178',
         'GBR000J10346',
         'GBR000J10070',
-        'GBR000J10359'
+        'GBR000J10359',
+        'GBR000A10387'
     )


### PR DESCRIPTION
## Linked issues

- Car navire sans licence FR (donc statut RET sur NAVPRO)

----

- [ ] Tests E2E (Cypress)
