### PR TITLE
Forcer la vérification des préavis de navires présentant un signalement actif

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/prior_notification/ManualPriorNotificationComputedValues.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/prior_notification/ManualPriorNotificationComputedValues.kt
@@ -2,6 +2,7 @@ package fr.gouv.cnsp.monitorfish.domain.entities.prior_notification
 
 import com.neovisionaries.i18n.CountryCode
 import fr.gouv.cnsp.monitorfish.domain.entities.fleet_segment.FleetSegment
+import fr.gouv.cnsp.monitorfish.domain.entities.reporting.Reporting
 
 val VESSEL_FLAG_COUNTRY_CODES_WITHOUT_SYSTEMATIC_VERIFICATION: List<CountryCode> = listOf(CountryCode.FR)
 const val VESSEL_RISK_FACTOR_VERIFICATION_THRESHOLD: Double = 2.3
@@ -16,13 +17,19 @@ data class ManualPriorNotificationComputedValues(
     val tripSegments: List<FleetSegment>,
     val types: List<PnoType>,
     val vesselRiskFactor: Double?,
+    val isInVerificationScope: Boolean,
 ) {
     companion object {
         fun isInVerificationScope(
             vesselFlagCountryCode: CountryCode?,
             vesselRiskFactor: Double?,
+            infractionSuspicions: List<Reporting>,
         ): Boolean {
             if (vesselFlagCountryCode == null || vesselRiskFactor == null) {
+                return true
+            }
+
+            if (infractionSuspicions.isNotEmpty()) {
                 return true
             }
 

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/repositories/ReportingRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/repositories/ReportingRepository.kt
@@ -39,6 +39,8 @@ interface ReportingRepository {
         fromDate: ZonedDateTime,
     ): List<Reporting>
 
+    fun findCurrentInfractionSuspicionsByVesselId(vesselId: Int): List<Reporting>
+
     fun findCurrentAndArchivedByVesselIdEquals(
         vesselId: Int,
         fromDate: ZonedDateTime,

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/ComputeManualPriorNotification.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/ComputeManualPriorNotification.kt
@@ -14,6 +14,7 @@ class ComputeManualPriorNotification(
     private val pnoFleetSegmentSubscriptionRepository: PnoFleetSegmentSubscriptionRepository,
     private val pnoVesselSubscriptionRepository: PnoVesselSubscriptionRepository,
     private val vesselRepository: VesselRepository,
+    private val reportingRepository: ReportingRepository,
     private val speciesRepository: SpeciesRepository,
     private val computeFleetSegments: ComputeFleetSegments,
     private val computePnoTypes: ComputePnoTypes,
@@ -33,6 +34,9 @@ class ComputeManualPriorNotification(
             "The vessel $vesselId is not found."
         }
 
+        // We select reportings only by NAVPRO vessel id as the vessel is FRA.
+        val infractionSuspicions = reportingRepository.findCurrentInfractionSuspicionsByVesselId(vesselId)
+
         val species = speciesRepository.findAll()
 
         val fishingCatchesWithFaoArea =
@@ -48,7 +52,7 @@ class ComputeManualPriorNotification(
 
         val isInVerificationScope =
             ManualPriorNotificationComputedValues
-                .isInVerificationScope(vesselFlagCountryCode, vesselRiskFactor)
+                .isInVerificationScope(vesselFlagCountryCode, vesselRiskFactor, infractionSuspicions)
         val isPartOfControlUnitSubscriptions =
             pnoPortSubscriptionRepository.has(portLocode) ||
                 pnoVesselSubscriptionRepository.has(vesselId) ||
@@ -61,6 +65,7 @@ class ComputeManualPriorNotification(
             tripSegments = tripSegments,
             types = types,
             vesselRiskFactor = vesselRiskFactor,
+            isInVerificationScope = isInVerificationScope,
         )
     }
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/CreateOrUpdateManualPriorNotification.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/CreateOrUpdateManualPriorNotification.kt
@@ -1,10 +1,8 @@
 package fr.gouv.cnsp.monitorfish.domain.use_cases.prior_notification
 
-import com.neovisionaries.i18n.CountryCode
 import fr.gouv.cnsp.monitorfish.config.UseCase
 import fr.gouv.cnsp.monitorfish.domain.entities.logbook.*
 import fr.gouv.cnsp.monitorfish.domain.entities.logbook.messages.PNO
-import fr.gouv.cnsp.monitorfish.domain.entities.prior_notification.ManualPriorNotificationComputedValues
 import fr.gouv.cnsp.monitorfish.domain.entities.prior_notification.PriorNotification
 import fr.gouv.cnsp.monitorfish.domain.entities.prior_notification.PriorNotificationType
 import fr.gouv.cnsp.monitorfish.domain.repositories.*
@@ -98,7 +96,7 @@ class CreateOrUpdateManualPriorNotification(
                 portLocode = portLocode,
                 purpose = purpose,
                 author = author,
-                computedVesselFlagCountryCode = vessel?.flagState,
+                isInVerificationScope = computedValues.isInVerificationScope,
                 computedVesselRiskFactor = computedValues.vesselRiskFactor,
                 isPartOfControlUnitSubscriptions = isPartOfControlUnitSubscriptions,
             )
@@ -188,17 +186,15 @@ class CreateOrUpdateManualPriorNotification(
         pnoTypes: List<PriorNotificationType>,
         portLocode: String,
         author: String?,
-        computedVesselFlagCountryCode: CountryCode?,
         computedVesselRiskFactor: Double?,
         isPartOfControlUnitSubscriptions: Boolean,
+        isInVerificationScope: Boolean,
     ): PNO {
         val allPorts = portRepository.findAll()
 
         val authorTrigram = existingMessageValue?.authorTrigram
         val createdBy = existingMessageValue?.createdBy ?: existingMessageValue?.authorTrigram ?: author
-        val isInVerificationScope =
-            ManualPriorNotificationComputedValues
-                .isInVerificationScope(computedVesselFlagCountryCode, computedVesselRiskFactor)
+
         // If the prior notification is not in verification scope,
         // we pass `isBeingSent` as `true` in order to ask the workflow to send it.
         val isBeingSent = !isInVerificationScope && isPartOfControlUnitSubscriptions

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/outputs/SelectedVesselDataOutput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/outputs/SelectedVesselDataOutput.kt
@@ -191,7 +191,7 @@ data class SelectedVesselDataOutput(
                 hasLogbookEsacapt = vessel.hasLogbookEsacapt,
                 hasVisioCaptures = vessel.hasVisioCaptures,
                 // TODO Unused in the frontend - to remove ?
-                riskFactor = RiskFactorDataOutput.fromVesselRiskFactor(VesselRiskFactor())
+                riskFactor = RiskFactorDataOutput.fromVesselRiskFactor(VesselRiskFactor()),
             )
     }
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaReportingRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaReportingRepository.kt
@@ -113,6 +113,13 @@ class JpaReportingRepository(
                 it.toReporting(mapper)
             }
 
+    override fun findCurrentInfractionSuspicionsByVesselId(vesselId: Int): List<Reporting> =
+        dbReportingRepository
+            .findCurrentInfractionSuspicionsByVesselId(vesselId)
+            .map {
+                it.toReporting(mapper)
+            }
+
     override fun findCurrentAndArchivedByVesselIdEquals(
         vesselId: Int,
         fromDate: ZonedDateTime,

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/interfaces/DBReportingRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/interfaces/DBReportingRepository.kt
@@ -64,6 +64,19 @@ interface DBReportingRepository : CrudRepository<ReportingEntity, Int> {
         fromDate: Instant,
     ): List<ReportingEntity>
 
+    @Query(
+        value = """
+        SELECT *
+        FROM reportings
+        WHERE
+            vessel_id = :vesselId AND
+            archived IS FALSE AND
+            deleted IS FALSE
+        """,
+        nativeQuery = true,
+    )
+    fun findCurrentInfractionSuspicionsByVesselId(vesselId: Int): List<ReportingEntity>
+
     @Modifying(clearAutomatically = true)
     @Query(
         value = """

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/interfaces/DBReportingRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/interfaces/DBReportingRepository.kt
@@ -70,6 +70,7 @@ interface DBReportingRepository : CrudRepository<ReportingEntity, Int> {
         FROM reportings
         WHERE
             vessel_id = :vesselId AND
+            type IN ('ALERT', 'INFRACTION_SUSPICION') AND
             archived IS FALSE AND
             deleted IS FALSE
         """,

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/ComputeManualPriorNotificationUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/ComputeManualPriorNotificationUTests.kt
@@ -1,0 +1,245 @@
+package fr.gouv.cnsp.monitorfish.domain.use_cases.prior_notification
+
+import com.neovisionaries.i18n.CountryCode
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.whenever
+import fr.gouv.cnsp.monitorfish.domain.entities.fleet_segment.ScipSpeciesType
+import fr.gouv.cnsp.monitorfish.domain.entities.logbook.LogbookFishingCatch
+import fr.gouv.cnsp.monitorfish.domain.entities.prior_notification.PriorNotificationState
+import fr.gouv.cnsp.monitorfish.domain.entities.species.Species
+import fr.gouv.cnsp.monitorfish.domain.entities.vessel.Vessel
+import fr.gouv.cnsp.monitorfish.domain.repositories.*
+import fr.gouv.cnsp.monitorfish.domain.use_cases.TestUtils.getDummyReportings
+import fr.gouv.cnsp.monitorfish.domain.use_cases.fleet_segment.ComputeFleetSegments
+import fr.gouv.cnsp.monitorfish.domain.use_cases.fleet_segment.TestUtils.getDummyFleetSegments
+import fr.gouv.cnsp.monitorfish.domain.use_cases.prior_notification.TestUtils.getDummyPnoTypes
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito.mock
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.time.ZonedDateTime
+
+@ExtendWith(SpringExtension::class)
+class ComputeManualPriorNotificationUTests {
+    private val pnoPortSubscriptionRepository: PnoPortSubscriptionRepository = mock()
+    private val pnoFleetSegmentSubscriptionRepository: PnoFleetSegmentSubscriptionRepository = mock()
+    private val pnoVesselSubscriptionRepository: PnoVesselSubscriptionRepository = mock()
+    private val vesselRepository: VesselRepository = mock()
+    private val reportingRepository: ReportingRepository = mock()
+    private val speciesRepository: SpeciesRepository = mock()
+    private val computeFleetSegments: ComputeFleetSegments = mock()
+    private val computePnoTypes: ComputePnoTypes = mock()
+    private val computeRiskFactor: ComputeRiskFactor = mock()
+
+    @Test
+    fun `execute should return isInVerificationScope as true When flag state is GBR`() {
+        // Given
+        val vesselId = 1
+        val vessel =
+            Vessel(
+                id = 1,
+                internalReferenceNumber = "GBR00022680",
+                vesselName = "MY AWESOME VESSEL",
+                flagState = CountryCode.GB,
+                declaredFishingGears = listOf("Trémails"),
+                vesselType = "Fishing",
+                districtCode = "AY",
+                hasLogbookEsacapt = false,
+                underCharter = true,
+            )
+
+        val catches = listOf(LogbookFishingCatch(species = "HKE", faoZone = "27.9.a", weight = 1500.0))
+
+        val speciesList =
+            listOf(
+                Species("BSS", "", null),
+                Species("HKE", "", ScipSpeciesType.DEMERSAL),
+                Species("NEP", "", null),
+                Species("SOL", "", ScipSpeciesType.DEMERSAL),
+                Species("SWO", "", ScipSpeciesType.TUNA),
+            )
+        val faoArea = "27.7.d"
+        val portLocode = "FRDUN"
+        val year = 2024
+        val tripGearCodes = listOf("OTB")
+
+        val segments = getDummyFleetSegments()
+        val types = getDummyPnoTypes()
+        val riskFactor = 0.75
+
+        whenever(vesselRepository.findVesselById(any())).thenReturn(vessel)
+        whenever(reportingRepository.findCurrentInfractionSuspicionsByVesselId(any())).thenReturn(listOf())
+        whenever(speciesRepository.findAll()).thenReturn(speciesList)
+        whenever(computeFleetSegments.execute(any(), any(), any())).thenReturn(segments)
+        whenever(computePnoTypes.execute(any(), any(), any())).thenReturn(types)
+        whenever(computeRiskFactor.execute(any(), any(), any())).thenReturn(riskFactor)
+
+        whenever(pnoPortSubscriptionRepository.has(portLocode)).thenReturn(true)
+        whenever(pnoVesselSubscriptionRepository.has(vesselId)).thenReturn(false)
+        whenever(pnoFleetSegmentSubscriptionRepository.has(any(), any())).thenReturn(false)
+
+        // When
+        val result =
+            ComputeManualPriorNotification(
+                pnoPortSubscriptionRepository = pnoPortSubscriptionRepository,
+                pnoFleetSegmentSubscriptionRepository = pnoFleetSegmentSubscriptionRepository,
+                pnoVesselSubscriptionRepository = pnoVesselSubscriptionRepository,
+                vesselRepository = vesselRepository,
+                reportingRepository = reportingRepository,
+                speciesRepository = speciesRepository,
+                computeFleetSegments = computeFleetSegments,
+                computePnoTypes = computePnoTypes,
+                computeRiskFactor = computeRiskFactor,
+            ).execute(catches, faoArea, portLocode, tripGearCodes, vesselId, year)
+
+        // Then
+        assertThat(result.isVesselUnderCharter).isTrue()
+        assertThat(result.vesselRiskFactor).isEqualTo(riskFactor)
+        assertThat(result.tripSegments).isEqualTo(segments)
+        assertThat(result.types).isEqualTo(types)
+        assertThat(result.isInVerificationScope).isTrue()
+        assertThat(result.nextState).isEqualTo(PriorNotificationState.PENDING_VERIFICATION)
+    }
+
+    @Test
+    fun `execute should return isInVerificationScope as true When vessel has active reportings`() {
+        // Given
+        val vesselId = 1
+        val vessel =
+            Vessel(
+                id = 1,
+                internalReferenceNumber = "FRA00022680",
+                vesselName = "MY AWESOME VESSEL",
+                flagState = CountryCode.FR,
+                declaredFishingGears = listOf("Trémails"),
+                vesselType = "Fishing",
+                districtCode = "AY",
+                hasLogbookEsacapt = false,
+                underCharter = true,
+            )
+
+        val catches = listOf(LogbookFishingCatch(species = "HKE", faoZone = "27.9.a", weight = 1500.0))
+
+        val speciesList =
+            listOf(
+                Species("BSS", "", null),
+                Species("HKE", "", ScipSpeciesType.DEMERSAL),
+                Species("NEP", "", null),
+                Species("SOL", "", ScipSpeciesType.DEMERSAL),
+                Species("SWO", "", ScipSpeciesType.TUNA),
+            )
+        val faoArea = "27.7.d"
+        val portLocode = "FRDUN"
+        val year = 2024
+        val tripGearCodes = listOf("OTB")
+
+        val segments = getDummyFleetSegments()
+        val types = getDummyPnoTypes()
+        val riskFactor = 0.75
+        val reportings = getDummyReportings(ZonedDateTime.now())
+
+        whenever(vesselRepository.findVesselById(any())).thenReturn(vessel)
+        whenever(reportingRepository.findCurrentInfractionSuspicionsByVesselId(any())).thenReturn(reportings)
+        whenever(speciesRepository.findAll()).thenReturn(speciesList)
+        whenever(computeFleetSegments.execute(any(), any(), any())).thenReturn(segments)
+        whenever(computePnoTypes.execute(any(), any(), any())).thenReturn(types)
+        whenever(computeRiskFactor.execute(any(), any(), any())).thenReturn(riskFactor)
+
+        whenever(pnoPortSubscriptionRepository.has(portLocode)).thenReturn(true)
+        whenever(pnoVesselSubscriptionRepository.has(vesselId)).thenReturn(false)
+        whenever(pnoFleetSegmentSubscriptionRepository.has(any(), any())).thenReturn(false)
+
+        // When
+        val result =
+            ComputeManualPriorNotification(
+                pnoPortSubscriptionRepository = pnoPortSubscriptionRepository,
+                pnoFleetSegmentSubscriptionRepository = pnoFleetSegmentSubscriptionRepository,
+                pnoVesselSubscriptionRepository = pnoVesselSubscriptionRepository,
+                vesselRepository = vesselRepository,
+                reportingRepository = reportingRepository,
+                speciesRepository = speciesRepository,
+                computeFleetSegments = computeFleetSegments,
+                computePnoTypes = computePnoTypes,
+                computeRiskFactor = computeRiskFactor,
+            ).execute(catches, faoArea, portLocode, tripGearCodes, vesselId, year)
+
+        // Then
+        assertThat(result.isVesselUnderCharter).isTrue()
+        assertThat(result.vesselRiskFactor).isEqualTo(riskFactor)
+        assertThat(result.tripSegments).isEqualTo(segments)
+        assertThat(result.types).isEqualTo(types)
+        assertThat(result.isInVerificationScope).isTrue()
+        assertThat(result.nextState).isEqualTo(PriorNotificationState.PENDING_VERIFICATION)
+    }
+
+    @Test
+    fun `execute should return isInVerificationScope as false When vessel has no active reportings`() {
+        // Given
+        val vesselId = 1
+        val vessel =
+            Vessel(
+                id = 1,
+                internalReferenceNumber = "FRA00022680",
+                vesselName = "MY AWESOME VESSEL",
+                flagState = CountryCode.FR,
+                declaredFishingGears = listOf("Trémails"),
+                vesselType = "Fishing",
+                districtCode = "AY",
+                hasLogbookEsacapt = false,
+                underCharter = true,
+            )
+
+        val catches = listOf(LogbookFishingCatch(species = "HKE", faoZone = "27.9.a", weight = 1500.0))
+
+        val speciesList =
+            listOf(
+                Species("BSS", "", null),
+                Species("HKE", "", ScipSpeciesType.DEMERSAL),
+                Species("NEP", "", null),
+                Species("SOL", "", ScipSpeciesType.DEMERSAL),
+                Species("SWO", "", ScipSpeciesType.TUNA),
+            )
+        val faoArea = "27.7.d"
+        val portLocode = "FRDUN"
+        val year = 2024
+        val tripGearCodes = listOf("OTB")
+
+        val segments = getDummyFleetSegments()
+        val types = getDummyPnoTypes()
+        val riskFactor = 0.75
+
+        whenever(vesselRepository.findVesselById(any())).thenReturn(vessel)
+        whenever(reportingRepository.findCurrentInfractionSuspicionsByVesselId(any())).thenReturn(listOf())
+        whenever(speciesRepository.findAll()).thenReturn(speciesList)
+        whenever(computeFleetSegments.execute(any(), any(), any())).thenReturn(segments)
+        whenever(computePnoTypes.execute(any(), any(), any())).thenReturn(types)
+        whenever(computeRiskFactor.execute(any(), any(), any())).thenReturn(riskFactor)
+
+        whenever(pnoPortSubscriptionRepository.has(portLocode)).thenReturn(true)
+        whenever(pnoVesselSubscriptionRepository.has(vesselId)).thenReturn(false)
+        whenever(pnoFleetSegmentSubscriptionRepository.has(any(), any())).thenReturn(false)
+
+        // When
+        val result =
+            ComputeManualPriorNotification(
+                pnoPortSubscriptionRepository = pnoPortSubscriptionRepository,
+                pnoFleetSegmentSubscriptionRepository = pnoFleetSegmentSubscriptionRepository,
+                pnoVesselSubscriptionRepository = pnoVesselSubscriptionRepository,
+                vesselRepository = vesselRepository,
+                reportingRepository = reportingRepository,
+                speciesRepository = speciesRepository,
+                computeFleetSegments = computeFleetSegments,
+                computePnoTypes = computePnoTypes,
+                computeRiskFactor = computeRiskFactor,
+            ).execute(catches, faoArea, portLocode, tripGearCodes, vesselId, year)
+
+        // Then
+        assertThat(result.isVesselUnderCharter).isTrue()
+        assertThat(result.vesselRiskFactor).isEqualTo(riskFactor)
+        assertThat(result.tripSegments).isEqualTo(segments)
+        assertThat(result.types).isEqualTo(types)
+        assertThat(result.isInVerificationScope).isFalse()
+        assertThat(result.nextState).isEqualTo(PriorNotificationState.AUTO_SEND_REQUESTED)
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/CreateOrUpdateManualPriorNotificationITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/CreateOrUpdateManualPriorNotificationITests.kt
@@ -349,6 +349,7 @@ class CreateOrUpdateManualPriorNotificationITests : AbstractDBTests() {
                     tripSegments = emptyList(),
                     types = emptyList(),
                     vesselRiskFactor = 0.0,
+                    isInVerificationScope = false,
                 ),
             )
 
@@ -398,6 +399,7 @@ class CreateOrUpdateManualPriorNotificationITests : AbstractDBTests() {
                     tripSegments = emptyList(),
                     types = emptyList(),
                     vesselRiskFactor = 5.0,
+                    isInVerificationScope = true,
                 ),
             )
 

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/CreateOrUpdateManualPriorNotificationUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/CreateOrUpdateManualPriorNotificationUTests.kt
@@ -60,6 +60,7 @@ class CreateOrUpdateManualPriorNotificationUTests {
                 tripSegments = emptyList(),
                 types = emptyList(),
                 vesselRiskFactor = null,
+                isInVerificationScope = false,
             ),
         )
         given(manualPriorNotificationRepository.save(any())).willReturn(newFakePriorNotification)
@@ -123,6 +124,7 @@ class CreateOrUpdateManualPriorNotificationUTests {
                 tripSegments = emptyList(),
                 types = emptyList(),
                 vesselRiskFactor = null,
+                isInVerificationScope = false,
             ),
         )
         given(manualPriorNotificationRepository.save(any())).willReturn(updatedFakePriorNotification)

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationControllerUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationControllerUTests.kt
@@ -176,6 +176,7 @@ class PriorNotificationControllerUTests {
                     tripSegments = emptyList(),
                     types = emptyList(),
                     vesselRiskFactor = 1.2,
+                    isInVerificationScope = false,
                 ),
             )
 

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaReportingRepositoryITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaReportingRepositoryITests.kt
@@ -218,6 +218,25 @@ class JpaReportingRepositoryITests : AbstractDBTests() {
 
     @Test
     @Transactional
+    fun `findCurrentInfractionSuspicionsByVesselId Should return current reportings`() {
+        // When
+        val reporting =
+            jpaReportingRepository.findCurrentInfractionSuspicionsByVesselId(
+                123456,
+            )
+
+        // Then
+        assertThat(reporting).hasSize(1)
+
+        assertThat(reporting.first().internalReferenceNumber).isEqualTo("ABC000180832")
+        assertThat(reporting.first().isArchived).isEqualTo(false)
+        assertThat(reporting.first().isDeleted).isEqualTo(false)
+        val alertTwo = reporting.first().value as ThreeMilesTrawlingAlert
+        assertThat(alertTwo.seaFront).isEqualTo("NAMO")
+    }
+
+    @Test
+    @Transactional
     fun `archive Should set the archived flag as true`() {
         // Given
         val reportingToArchive =

--- a/datascience/src/pipeline/flows/enrich_logbook.py
+++ b/datascience/src/pipeline/flows/enrich_logbook.py
@@ -57,7 +57,7 @@ def extract_control_anteriority() -> pd.DataFrame:
 def extract_vessels_with_active_reportings() -> set:
     vessels_with_active_reportings = extract(
         db_name="monitorfish_remote",
-        query_filepath="monitorfish/vessels_with_active_reportings.sql",
+        query_filepath="monitorfish/vessels_with_active_reportings_for_pnos.sql",
     )
 
     return set(vessels_with_active_reportings.internal_reference_number)

--- a/datascience/src/pipeline/flows/enrich_logbook.py
+++ b/datascience/src/pipeline/flows/enrich_logbook.py
@@ -54,6 +54,16 @@ def extract_control_anteriority() -> pd.DataFrame:
 
 
 @task(checkpoint=False)
+def extract_vessels_with_active_reportings() -> set:
+    vessels_with_active_reportings = extract(
+        db_name="monitorfish_remote",
+        query_filepath="monitorfish/vessels_with_active_reportings.sql",
+    )
+
+    return set(vessels_with_active_reportings.internal_reference_number)
+
+
+@task(checkpoint=False)
 def reset_pnos(period: Period):
     """
     Deletes enriched data from pnos in logbook table in the designated Period.
@@ -464,12 +474,15 @@ def flag_pnos_to_verify_and_send(
     pno_units_targeting_vessels: pd.DataFrame,
     pno_units_ports_and_segments_subscriptions: pd.DataFrame,
     predicted_arrival_threshold: datetime,
+    vessels_with_active_reportings: set,
 ):
     pnos = pnos.copy(deep=True)
 
     pnos["is_in_verification_scope"] = (
-        pnos.risk_factor >= RISK_FACTOR_VERIFICATION_THRESHOLD
-    ) | (~pnos.flag_state.isin(FLAG_STATES_WITHOUT_SYSTEMATIC_VERIFICATION))
+        (pnos.risk_factor >= RISK_FACTOR_VERIFICATION_THRESHOLD)
+        | (~pnos.flag_state.isin(FLAG_STATES_WITHOUT_SYSTEMATIC_VERIFICATION))
+        | (pnos.cfr.isin(vessels_with_active_reportings))
+    )
 
     pnos["is_verified"] = False
     pnos["is_sent"] = False
@@ -657,6 +670,7 @@ def extract_enrich_load_logbook(
     pno_units_targeting_vessels: pd.DataFrame,
     pno_units_ports_and_segments_subscriptions: pd.DataFrame,
     utcnow: datetime,
+    vessels_with_active_reportings: set,
 ):
     """Extract pnos for the given `Period`, enrich and update the `logbook` table.
 
@@ -706,6 +720,7 @@ def extract_enrich_load_logbook(
         pno_units_targeting_vessels=pno_units_targeting_vessels,
         pno_units_ports_and_segments_subscriptions=pno_units_ports_and_segments_subscriptions,
         predicted_arrival_threshold=utcnow,
+        vessels_with_active_reportings=vessels_with_active_reportings,
     )
 
     logger.info("Loading")
@@ -736,6 +751,7 @@ with Flow("Enrich Logbook") as flow:
         pno_units_ports_and_segments_subscriptions = (
             extract_pno_units_ports_and_segments_subscriptions()
         )
+        vessels_with_active_reportings = extract_vessels_with_active_reportings()
 
         with case(recompute_all, True):
             reset = reset_pnos.map(periods)
@@ -750,6 +766,7 @@ with Flow("Enrich Logbook") as flow:
                     pno_units_ports_and_segments_subscriptions
                 ),
                 utcnow=unmapped(utcnow),
+                vessels_with_active_reportings=unmapped(vessels_with_active_reportings),
                 upstream_tasks=[reset],
             )
 
@@ -765,6 +782,7 @@ with Flow("Enrich Logbook") as flow:
                     pno_units_ports_and_segments_subscriptions
                 ),
                 utcnow=unmapped(utcnow),
+                vessels_with_active_reportings=unmapped(vessels_with_active_reportings),
             )
 
 flow.file_name = Path(__file__).name

--- a/datascience/src/pipeline/queries/monitorfish/active_reportings.sql
+++ b/datascience/src/pipeline/queries/monitorfish/active_reportings.sql
@@ -5,4 +5,5 @@ SELECT DISTINCT
 FROM reportings
 WHERE
     NOT archived
+    AND NOT deleted
     AND value->>'type' = :alert_type

--- a/datascience/src/pipeline/queries/monitorfish/non_archived_reportings_of_type.sql
+++ b/datascience/src/pipeline/queries/monitorfish/non_archived_reportings_of_type.sql
@@ -1,3 +1,3 @@
 SELECT id
 FROM reportings
-WHERE value->>'type' = :reporting_type AND NOT archived
+WHERE value->>'type' = :reporting_type AND NOT archived AND NOT deleted

--- a/datascience/src/pipeline/queries/monitorfish/vessels_with_active_reportings.sql
+++ b/datascience/src/pipeline/queries/monitorfish/vessels_with_active_reportings.sql
@@ -1,0 +1,3 @@
+SELECT DISTINCT internal_reference_number
+FROM reportings
+WHERE NOT archived AND NOT deleted AND internal_reference_number IS NOT NULL

--- a/datascience/src/pipeline/queries/monitorfish/vessels_with_active_reportings.sql
+++ b/datascience/src/pipeline/queries/monitorfish/vessels_with_active_reportings.sql
@@ -1,3 +1,0 @@
-SELECT DISTINCT internal_reference_number
-FROM reportings
-WHERE NOT archived AND NOT deleted AND internal_reference_number IS NOT NULL

--- a/datascience/src/pipeline/queries/monitorfish/vessels_with_active_reportings_for_pnos.sql
+++ b/datascience/src/pipeline/queries/monitorfish/vessels_with_active_reportings_for_pnos.sql
@@ -1,0 +1,7 @@
+SELECT DISTINCT internal_reference_number
+FROM reportings
+WHERE
+    NOT archived AND
+    NOT deleted AND
+    type IN ('ALERT', 'INFRACTION_SUSPICION') AND
+    internal_reference_number IS NOT NULL

--- a/datascience/tests/test_data/remote_database/V666.20__Reset_test_reportings.sql
+++ b/datascience/tests/test_data/remote_database/V666.20__Reset_test_reportings.sql
@@ -1,5 +1,6 @@
 DELETE FROM reportings;
 
 INSERT INTO reportings (
-    id,    type, vessel_id, internal_reference_number, external_reference_number,       ircs,      vessel_name, vessel_identifier,               creation_date, validation_date, archived, deleted, flag_state,                                                                                                                              value) VALUES
-(    56, 'ALERT',         6,                      NULL,               'ZZTOPACDC', 'ZZ000000', 'I DO 4H REPORT',            'IRCS', NOW() - ('1 DAY')::interval,           NOW(),    false,   false, 'FR'      ,'{"seaFront": "NAMO", "riskFactor": 3.5647, "type": "THREE_MILES_TRAWLING_ALERT", "natinfCode": 7059}'::jsonb);
+     id,    type, vessel_id, internal_reference_number, external_reference_number,       ircs,      vessel_name,           vessel_identifier,                 creation_date, validation_date, archived, deleted, flag_state,                                                                                                                              value) VALUES
+(    56, 'ALERT',         6,                      NULL,               'ZZTOPACDC', 'ZZ000000', 'I DO 4H REPORT',                      'IRCS',   NOW() - ('1 DAY')::interval,           NOW(),    false,   false, 'FR'      ,'{"seaFront": "NAMO", "riskFactor": 3.5647, "type": "THREE_MILES_TRAWLING_ALERT", "natinfCode": 7059}'::jsonb),
+(    57, 'ALERT',      NULL,             'SOME_VESSEL',               'BLABLABLA',       NULL,      'ZEOINEZKN', 'INTERNAL_REFERENCE_NUMBER', NOW() - ('10 DAYs')::interval,           NOW(),    false,   false, 'FR'      ,'{"seaFront": "NAMO", "riskFactor": 3.5647, "type": "THREE_MILES_TRAWLING_ALERT", "natinfCode": 7059}'::jsonb);

--- a/datascience/tests/test_pipeline/test_flows/test_last_positions.py
+++ b/datascience/tests/test_pipeline/test_flows/test_last_positions.py
@@ -83,14 +83,19 @@ def test_extract_reportings(reset_test_data):
     reportings = extract_reportings.run()
     expected_reportings = pd.DataFrame(
         {
-            "vessel_id": [6],
-            "cfr": [None],
-            "ircs": ["ZZ000000"],
-            "external_immatriculation": ["ZZTOPACDC"],
-            "reportings": [["ALERT"]],
+            "vessel_id": [6, None],
+            "cfr": [None, "SOME_VESSEL"],
+            "ircs": ["ZZ000000", None],
+            "external_immatriculation": ["ZZTOPACDC", "BLABLABLA"],
+            "reportings": [["ALERT"], ["ALERT"]],
         }
     )
-    pd.testing.assert_frame_equal(reportings, expected_reportings)
+    pd.testing.assert_frame_equal(
+        reportings.sort_values("external_immatriculation", ascending=False).reset_index(
+            drop=True
+        ),
+        expected_reportings,
+    )
 
 
 def test_load_last_positions(reset_test_data):

--- a/datascience/tests/test_pipeline/test_shared_tasks/test_alerts.py
+++ b/datascience/tests/test_pipeline/test_shared_tasks/test_alerts.py
@@ -99,12 +99,17 @@ def test_extract_active_reportings(reset_test_data):
     )
     expected_active_reportings = pd.DataFrame(
         {
-            "internal_reference_number": [None],
-            "external_reference_number": ["ZZTOPACDC"],
-            "ircs": ["ZZ000000"],
+            "internal_reference_number": [None, "SOME_VESSEL"],
+            "external_reference_number": ["ZZTOPACDC", "BLABLABLA"],
+            "ircs": ["ZZ000000", None],
         }
     )
-    pd.testing.assert_frame_equal(active_reportings, expected_active_reportings)
+    pd.testing.assert_frame_equal(
+        active_reportings.sort_values(
+            "external_reference_number", ascending=False
+        ).reset_index(drop=True),
+        expected_active_reportings,
+    )
 
     active_reportings = extract_active_reportings.run(AlertType.MISSING_FAR_ALERT.value)
     pd.testing.assert_frame_equal(active_reportings, expected_active_reportings.head(0))
@@ -121,7 +126,7 @@ def test_extract_pending_alerts_ids_of_type(reset_test_data):
 def test_extract_non_archived_reportings_ids_of_type(reset_test_data):
     assert extract_non_archived_reportings_ids_of_type.run(
         reporting_type="THREE_MILES_TRAWLING_ALERT"
-    ) == [56]
+    ) == [56, 57]
 
     assert (
         extract_non_archived_reportings_ids_of_type.run(


### PR DESCRIPTION
## Linked issues

- Resolve #4237

## TODO
- [x] Data pipeline
- [x] Backend (modifier `isInVerificationScope`)

A checker : faut-il inclure uniquement les navires avec des signalements de type `ALERT` et  `INFRACTION_SUSPICION` ?