### PR TITLE
JPE - Le LAN de la marée précédente fait sélectionner la mauvaise marée

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaLogbookReportRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaLogbookReportRepository.kt
@@ -145,14 +145,19 @@ class JpaLogbookReportRepository(
                             beforeDateTime = beforeDateTime.toInstant(),
                             afterDateTime = afterDateTime.toInstant(),
                         )
-                val firstTrip = trips.first()
+                val tripsBetweenDatesWithoutLAN =
+                    trips.filter {
+                        it.startDate.atZone(UTC).isBefore(beforeDateTime) &&
+                            it.endDateWithoutLAN?.atZone(UTC)?.isAfter(afterDateTime) ?: false
+                    }
+                val firstTrip = tripsBetweenDatesWithoutLAN.first()
 
                 return VoyageDatesAndTripNumber(
                     tripNumber = firstTrip.tripNumber,
                     startDate = firstTrip.startDate.atZone(UTC),
                     endDate = firstTrip.endDate.atZone(UTC),
                     endDateWithoutLAN = firstTrip.endDateWithoutLAN?.atZone(UTC),
-                    totalTripsFoundForDates = trips.size,
+                    totalTripsFoundForDates = tripsBetweenDatesWithoutLAN.size,
                 )
             }
 

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaLogbookReportRepositoryITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaLogbookReportRepositoryITests.kt
@@ -1199,7 +1199,7 @@ class JpaLogbookReportRepositoryITests : AbstractDBTests() {
         assertThat(trip.tripNumber).isEqualTo("9463715")
         assertThat(trip.startDate.toString()).isEqualTo("2019-10-11T01:06Z")
         assertThat(trip.endDate.toString()).isEqualTo("2019-10-22T11:06Z")
-        assertThat(trip.totalTripsFoundForDates).isEqualTo(4)
+        assertThat(trip.totalTripsFoundForDates).isEqualTo(3)
     }
 
     @Test


### PR DESCRIPTION
## Linked issues

- Resolve #4332

----

- [ ] Tests E2E (Cypress)
