### PR TITLE
UI - Retours design suite aux changements de composants

### DIFF
--- a/frontend/src/features/BeaconMalfunction/components/BeaconMalfunctionBoard/VesselStatusSelect.tsx
+++ b/frontend/src/features/BeaconMalfunction/components/BeaconMalfunctionBoard/VesselStatusSelect.tsx
@@ -25,7 +25,6 @@ export function VesselStatusSelect({
       cleanable={isCleanable}
       isLabelHidden
       label="Status"
-      menuStyle={{ width: '180px' }}
       name="vesselStatus"
       onChange={status => updateVesselStatus(beaconMalfunction, status as string)}
       options={VESSEL_STATUS}
@@ -34,6 +33,7 @@ export function VesselStatusSelect({
         <VesselStatusSelectValue item={item} textColor={vesselStatus?.textColor ?? THEME.color.charcoal} />
       )}
       searchable={false}
+      style={{ width: '180px' }}
       value={vesselStatus?.value ?? undefined}
     />
   )

--- a/frontend/src/features/BeaconMalfunction/components/BeaconMalfunctionBoard/index.tsx
+++ b/frontend/src/features/BeaconMalfunction/components/BeaconMalfunctionBoard/index.tsx
@@ -13,7 +13,7 @@ import { useMainAppDispatch } from '@hooks/useMainAppDispatch'
 import { useMainAppSelector } from '@hooks/useMainAppSelector'
 import { THEME } from '@mtes-mct/monitor-ui'
 import { createSelector } from '@reduxjs/toolkit'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import { BeaconMalfunctionCard } from './BeaconMalfunctionCard'
@@ -34,7 +34,7 @@ import type {
   BeaconMalfunctionStatusValue
 } from '@features/BeaconMalfunction/types'
 import type { MainRootState } from '@store'
-import type { CSSProperties, MutableRefObject } from 'react'
+import type { CSSProperties } from 'react'
 
 const getMemoizedBeaconMalfunctionsByStage = createSelector(
   (state: MainRootState) => state.beaconMalfunction.beaconMalfunctions,
@@ -52,7 +52,6 @@ export function BeaconMalfunctionBoard() {
   const [searchedVessel, setSearchedVessel] = useState<string>('')
   const [activeBeaconMalfunction, setActiveBeaconMalfunction] = useState(null)
   const [filteredVesselStatus, setFilteredVesselStatus] = useState<BeaconMalfunctionStatusValue | undefined>()
-  const vesselStatusSelectRef = useRef() as MutableRefObject<HTMLDivElement>
   const mouseSensor = useSensor(MouseSensor, {
     activationConstraint: {
       distance: 10
@@ -230,15 +229,13 @@ export function BeaconMalfunctionBoard() {
           type="text"
           value={searchedVessel}
         />
-        <VesselStatusSelectWrapper ref={vesselStatusSelectRef}>
-          <VesselStatusSelect
-            isCleanable
-            updateVesselStatus={(_, status) =>
-              setFilteredVesselStatus(VESSEL_STATUS.find(statusObject => statusObject.value === status))
-            }
-            vesselStatus={filteredVesselStatus}
-          />
-        </VesselStatusSelectWrapper>
+        <VesselStatusSelect
+          isCleanable
+          updateVesselStatus={(_, status) =>
+            setFilteredVesselStatus(VESSEL_STATUS.find(statusObject => statusObject.value === status))
+          }
+          vesselStatus={filteredVesselStatus}
+        />
       </Header>
       <DndContext
         autoScroll
@@ -347,22 +344,6 @@ const Wrapper = styled(LegacyRsuiteComponentsWrapper)`
     margin-right: 5px;
     margin-left: 5px;
   }
-
-  .rs-picker {
-    width: 180px !important;
-
-    > .rs-picker-toggle {
-      padding: 3px 8px 5px;
-
-      > .rs-stack {
-        > .rs-picker-toggle-indicator {
-          > svg {
-            top: 4px;
-          }
-        }
-      }
-    }
-  }
 `
 const wrapperStyle: CSSProperties = {
   height: 'calc(100vh - 20px)',
@@ -371,8 +352,6 @@ const wrapperStyle: CSSProperties = {
   padding: '20px 0 0 10px',
   width: 'calc(100vw - 90px)'
 }
-
-const VesselStatusSelectWrapper = styled.div``
 
 const Header = styled.div`
   display: flex;

--- a/frontend/src/features/Regulation/components/RegulationForm/FishingPeriod/index.tsx
+++ b/frontend/src/features/Regulation/components/RegulationForm/FishingPeriod/index.tsx
@@ -1,10 +1,10 @@
 import { useBackofficeAppDispatch } from '@hooks/useBackofficeAppDispatch'
 import { useBackofficeAppSelector } from '@hooks/useBackofficeAppSelector'
+import { Textarea } from '@mtes-mct/monitor-ui'
 import { useState } from 'react'
 
 import { FishingPeriodForm } from './FishingPeriodForm'
 import { OtherRemark, Section } from '../../../../commonStyles/Backoffice.style'
-import { CustomInput, Label } from '../../../../commonStyles/Input.style'
 import { regulationActions } from '../../../slice'
 import { SectionTitle } from '../../RegulationTables/SectionTitle'
 
@@ -14,8 +14,8 @@ export function FishingPeriodSection() {
 
   const [show, setShow] = useState(false)
 
-  const onChange = value => {
-    dispatch(regulationActions.setFishingPeriodOtherInfo(value))
+  const onChange = (value: string | undefined) => {
+    dispatch(regulationActions.setFishingPeriodOtherInfo(value ?? ''))
   }
 
   return (
@@ -23,15 +23,13 @@ export function FishingPeriodSection() {
       <SectionTitle isOpen={show} setIsOpen={setShow} title="Périodes de pêche" />
       <FishingPeriodForm show={show} />
       <OtherRemark $show={show}>
-        <Label>Remarques</Label>
-        <CustomInput
-          $isGray={processingRegulation.fishingPeriod?.otherInfo !== ''}
-          as="textarea"
-          onChange={event => onChange(event.target.value)}
-          placeholder=""
+        <Textarea
+          label="Remarques"
+          name="fishingPeriodOtherInfo"
+          onChange={onChange}
           rows={2}
+          style={{ width: '500px' }}
           value={processingRegulation.fishingPeriod?.otherInfo ?? ''}
-          width="500px"
         />
       </OtherRemark>
     </Section>

--- a/frontend/src/features/Regulation/components/RegulationForm/GearRegulation/RegulatedGear.tsx
+++ b/frontend/src/features/Regulation/components/RegulationForm/GearRegulation/RegulatedGear.tsx
@@ -79,7 +79,7 @@ export function RegulatedGear({
             width={170}
           />
           <StyledCustomInput
-            $isGray={mesh && mesh[0] !== ''}
+            $isGray
             onChange={intervalValue => {
               const nextIntervalValue = mesh ? [...mesh] : []
               nextIntervalValue[0] = intervalValue
@@ -92,7 +92,7 @@ export function RegulatedGear({
             <>
               et
               <SecondCustomInput
-                $isGray={mesh && mesh.length === 2 && mesh[1] !== ''}
+                $isGray
                 onChange={value => {
                   if (!mesh) {
                     return
@@ -112,7 +112,7 @@ export function RegulatedGear({
       <ContentLine $alignedToTop>
         <Label>Remarques</Label>
         <CustomInput
-          $isGray={remarks}
+          $isGray
           as="textarea"
           data-cy="regulatory-gears-remarks"
           onChange={event => onChange('remarks', event.target.value)}

--- a/frontend/src/features/Regulation/components/RegulationForm/GearRegulation/RegulatedGears.tsx
+++ b/frontend/src/features/Regulation/components/RegulationForm/GearRegulation/RegulatedGears.tsx
@@ -1,5 +1,6 @@
+import { Label } from '@features/commonStyles/Input.style'
 import { useBackofficeAppSelector } from '@hooks/useBackofficeAppSelector'
-import { Checkbox, MultiRadio, MultiCascader, Label } from '@mtes-mct/monitor-ui'
+import { Checkbox, MultiRadio, MultiCascader } from '@mtes-mct/monitor-ui'
 import { isEqual } from 'lodash-es'
 import { useCallback, useEffect } from 'react'
 import styled from 'styled-components'
@@ -358,5 +359,4 @@ const GearCheckBox = styled(Checkbox)`
 
 const DerogationRadioWrapper = styled.div`
   display: flex;
-  gap: 16px;
 `

--- a/frontend/src/features/Regulation/components/RegulationForm/GearRegulation/index.tsx
+++ b/frontend/src/features/Regulation/components/RegulationForm/GearRegulation/index.tsx
@@ -6,6 +6,7 @@ import {
 } from '@features/Regulation/utils'
 import { useBackofficeAppDispatch } from '@hooks/useBackofficeAppDispatch'
 import { useBackofficeAppSelector } from '@hooks/useBackofficeAppSelector'
+import { Textarea } from '@mtes-mct/monitor-ui'
 import { GEAR_REGULATION_KEYS, prepareCategoriesAndGearsToDisplay } from 'domain/entities/backoffice'
 import { getAllGearCodes } from 'domain/use_cases/gearCode/getAllGearCodes'
 import { useEffect, useState } from 'react'
@@ -13,7 +14,6 @@ import styled from 'styled-components'
 
 import { RegulatedGears } from './RegulatedGears'
 import { Section, OtherRemark, VerticalLine } from '../../../../commonStyles/Backoffice.style'
-import { Label, CustomInput } from '../../../../commonStyles/Input.style'
 import { SectionTitle } from '../../RegulationTables/SectionTitle'
 
 import type { BackofficeAppPromiseThunk } from '@store'
@@ -60,7 +60,7 @@ export function GearRegulation() {
     setGearRegulation(property, regulatedGears)
   }
 
-  const setOtherInfo = value => {
+  const setOtherInfo = (value: string | undefined) => {
     setGearRegulation(GEAR_REGULATION_KEYS.OTHER_INFO, value)
   }
 
@@ -87,15 +87,13 @@ export function GearRegulation() {
         />
       </RegulatedGearsForms>
       <OtherRemark $show={show}>
-        <Label>Remarques</Label>
-        <CustomInput
-          $isGray={!!processingRegulation.gearRegulation?.otherInfo}
-          as="textarea"
-          onChange={event => setOtherInfo(event.target.value)}
-          placeholder=""
+        <Textarea
+          label="Remarques"
+          name="gearRegulationOtherInfo"
+          onChange={setOtherInfo}
           rows={2}
+          style={{ width: '500px' }}
           value={processingRegulation.gearRegulation?.otherInfo ?? ''}
-          width="500px"
         />
       </OtherRemark>
     </Section>

--- a/frontend/src/features/Regulation/components/RegulationForm/index.tsx
+++ b/frontend/src/features/Regulation/components/RegulationForm/index.tsx
@@ -29,6 +29,7 @@ import {
 } from '@features/Regulation/utils'
 import { useBackofficeAppDispatch } from '@hooks/useBackofficeAppDispatch'
 import { useBackofficeAppSelector } from '@hooks/useBackofficeAppSelector'
+import { Textarea } from '@mtes-mct/monitor-ui'
 import { setError } from 'domain/shared_slices/Global'
 import { getAllSpecies } from 'domain/use_cases/species/getAllSpecies'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -37,7 +38,6 @@ import styled from 'styled-components'
 
 import { Footer, FooterButton, OtherRemark, Section, Title } from '../../../commonStyles/Backoffice.style'
 import { CancelButton, ValidateButton } from '../../../commonStyles/Buttons.style'
-import { CustomInput, Label } from '../../../commonStyles/Input.style'
 import ChevronIconSVG from '../../../icons/Chevron_simple_gris.svg?react'
 import { STATUS } from '../RegulationTables/constants'
 
@@ -216,7 +216,7 @@ export function RegulationForm({ isEdition, title }: RegulationFormProps) {
     }
   }, [dispatch, geometriesMap, isEdition, processingRegulation, selectedRegulatoryZoneId, isRegulatoryPreviewDisplayed])
 
-  const setOtherInfo = value => {
+  const setOtherInfo = (value: string | undefined) => {
     dispatch(
       regulationActions.updateProcessingRegulationByKey({
         key: REGULATORY_REFERENCE_KEYS.OTHER_INFO,
@@ -260,17 +260,14 @@ export function RegulationForm({ isEdition, title }: RegulationFormProps) {
               <GearRegulation />
               {/* @ts-ignore */}
               <OtherRemark $show>
-                <Label>Remarques générales</Label>
-                {/* @ts-ignore */}
-                <CustomInput
-                  $isGray={otherInfo && otherInfo !== ''}
-                  as="textarea"
+                <Textarea
                   data-cy="regulatory-general-other-info"
-                  onChange={event => setOtherInfo(event.target.value)}
-                  placeholder=""
+                  label="Remarques générales"
+                  name="otherInfo"
+                  onChange={setOtherInfo}
                   rows={2}
+                  style={{ width: '500px' }}
                   value={otherInfo ?? ''}
-                  width="500px"
                 />
               </OtherRemark>
             </ContentWrapper>

--- a/frontend/src/features/Regulation/components/RegulationForm/species_regulation/RegulatedSpecies.tsx
+++ b/frontend/src/features/Regulation/components/RegulationForm/species_regulation/RegulatedSpecies.tsx
@@ -179,7 +179,7 @@ export function RegulatedSpecies({
             searchable
             value={DEFAULT_SPECIES_CATEGORY_VALUE}
             virtualized
-            width={280}
+            width={300}
           />
         </ContentLine>
         <ContentLine>
@@ -203,7 +203,7 @@ export function RegulatedSpecies({
               searchable
               value={DEFAULT_SPECIES_VALUE}
               virtualized
-              width={280}
+              width={300}
             />
           ) : null}
         </ContentLine>
@@ -227,7 +227,7 @@ export function RegulatedSpecies({
                 <SpeciesDetail>
                   <Label>Remarques</Label>
                   <CustomInput
-                    $isGray={species.find(_species => _species.code === speciesValue.code)?.remarks}
+                    $isGray
                     as="textarea"
                     data-cy={`${dataCyTarget}-regulatory-species-remarks`}
                     onChange={event =>

--- a/frontend/src/features/Regulation/components/RegulationForm/species_regulation/SpeciesRegulation.tsx
+++ b/frontend/src/features/Regulation/components/RegulationForm/species_regulation/SpeciesRegulation.tsx
@@ -1,18 +1,17 @@
 import { useBackofficeAppDispatch } from '@hooks/useBackofficeAppDispatch'
 import { useBackofficeAppSelector } from '@hooks/useBackofficeAppSelector'
+import { Textarea, type Option } from '@mtes-mct/monitor-ui'
 import { SPECIES_REGULATION_KEYS } from 'domain/entities/backoffice'
-import { useCallback, useEffect, useState, type ChangeEvent } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import { RegulatedSpecies } from './RegulatedSpecies'
 import { OtherRemark, Section, VerticalLine } from '../../../../commonStyles/Backoffice.style'
-import { CustomInput, Label } from '../../../../commonStyles/Input.style'
 import { regulationActions } from '../../../slice'
 import { REGULATORY_REFERENCE_KEYS } from '../../../utils'
 import { SectionTitle } from '../../RegulationTables/SectionTitle'
 
 import type { RegulatedSpecies as RegulatedSpeciesType } from '@features/Regulation/types'
-import type { Option } from '@mtes-mct/monitor-ui'
 
 export function SpeciesRegulation() {
   const dispatch = useBackofficeAppDispatch()
@@ -72,8 +71,8 @@ export function SpeciesRegulation() {
     [setSpeciesRegulation]
   )
 
-  const setOtherInfo = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    setSpeciesRegulation(SPECIES_REGULATION_KEYS.OTHER_INFO, event.target.value)
+  const setOtherInfo = (value: string | undefined) => {
+    setSpeciesRegulation(SPECIES_REGULATION_KEYS.OTHER_INFO, value)
   }
 
   return (
@@ -101,19 +100,14 @@ export function SpeciesRegulation() {
         />
       </RegulatedSpeciesForms>
       <OtherRemark $show={show}>
-        <Label>Remarques</Label>
-        <CustomInput
-          $isGray={
-            processingRegulation.speciesRegulation?.otherInfo &&
-            processingRegulation.speciesRegulation?.otherInfo !== ''
-          }
-          as="textarea"
+        <Textarea
           data-cy="regulatory-species-other-info"
+          label="Remarques"
+          name="speciesRegulationOtherInfo"
           onChange={setOtherInfo}
-          placeholder=""
           rows={2}
+          style={{ width: '500px' }}
           value={processingRegulation.speciesRegulation?.otherInfo ?? ''}
-          width="500px"
         />
       </OtherRemark>
     </Section>

--- a/frontend/src/ui/LegacyRsuiteComponentsWrapper.tsx
+++ b/frontend/src/ui/LegacyRsuiteComponentsWrapper.tsx
@@ -305,34 +305,4 @@ export const LegacyRsuiteComponentsWrapper = styled.div`
   .rs-btn-primary:hover {
     color: inherit;
   }
-
-  /*****************************************************************************
-    Fixes following mointor-ui v12 upgrade (including Rsuite breaking changes)
-  */
-
-  .rs-picker {
-    border-radius: 0;
-    font-size: 13px;
-    width: 100%;
-
-    * {
-      font-size: 13px;
-    }
-
-    [role='combobox'] {
-      width: 100%;
-    }
-
-    .rs-picker-toggle-placeholder {
-      font-size: 11px;
-    }
-  }
-
-  .rs-picker {
-    width: auto;
-  }
-
-  .rs-picker-popup {
-    z-index: 9999;
-  }
 `


### PR DESCRIPTION
## Linked issues

- Resolve #3737 
<img width="1262" height="799" alt="Capture d’écran 2025-09-16 à 17 15 21" src="https://github.com/user-attachments/assets/ed4b621e-50be-4b0d-afa8-f1dbea95f6b5" />

----

- [ ] Tests E2E (Cypress)
