### PR TITLE
Remplacer le filtre "Date de contrôle" par deux filtres "Date de contrôle à quai" et "Date de contrôle en mer"

### DIFF
--- a/frontend/src/features/Vessel/components/VesselList/Row.tsx
+++ b/frontend/src/features/Vessel/components/VesselList/Row.tsx
@@ -6,6 +6,8 @@ import {
   displayOnboardFishingSpecies,
   getExpandableRowCellCustomStyle
 } from '@features/Vessel/components/VesselList/cells/utils'
+import { DEFAULT_VESSEL_LIST_FILTER_VALUES } from '@features/Vessel/components/VesselList/constants'
+import { getLastControlDateTimeAndControlType } from '@features/Vessel/components/VesselList/utils'
 import { ActivityOrigin, ActivityType } from '@features/Vessel/schemas/ActiveVesselSchema'
 import { Vessel } from '@features/Vessel/Vessel.types'
 import { useMainAppSelector } from '@hooks/useMainAppSelector'
@@ -30,9 +32,19 @@ type RowProps = Readonly<{
 }>
 export const Row = forwardRef<HTMLTableRowElement, RowProps>(({ hasWhiteBackground = false, index, row }, ref) => {
   const vessel = row.original
+  const listFilter = useMainAppSelector(store => store.vessel.listFilterValues)
   const gearsByCode = useMainAppSelector(state => state.gear.gearsByCode)
   const speciesByCode = useMainAppSelector(state => state.species.speciesByCode)
   const { data: fleetSegments } = useGetFleetSegmentsQuery()
+  const hasLastControlAtSeaFilter =
+    listFilter?.lastControlAtSeaPeriod !== DEFAULT_VESSEL_LIST_FILTER_VALUES.lastControlAtSeaPeriod
+  const hasLastControlAtQuayFilter =
+    listFilter?.lastControlAtQuayPeriod !== DEFAULT_VESSEL_LIST_FILTER_VALUES.lastControlAtQuayPeriod
+  const { lastControlDateTime } = getLastControlDateTimeAndControlType(
+    hasLastControlAtSeaFilter,
+    hasLastControlAtQuayFilter,
+    vessel
+  )
 
   const gears = (function () {
     if (!gearsByCode || !row.getIsExpanded()) {
@@ -153,10 +165,14 @@ export const Row = forwardRef<HTMLTableRowElement, RowProps>(({ hasWhiteBackgrou
             )}
           </ExpandedRowCell>
           <ExpandedRowCell>
-            <ExpandedRowLabel>
-              Résultat du contrôle {vessel.lastControlInfraction && <RedCircle $margin="2" />}
-            </ExpandedRowLabel>
-            {vessel.lastControlInfraction ? '1 infraction' : "Pas d'infraction"}
+            {lastControlDateTime && (
+              <>
+                <ExpandedRowLabel>
+                  Résultat du contrôle {vessel.lastControlInfraction && <RedCircle $margin="2" />}
+                </ExpandedRowLabel>
+                {vessel.lastControlInfraction ? '1 infraction' : "Pas d'infraction"}
+              </>
+            )}
           </ExpandedRowCell>
           <ExpandedRowCell />
           <ExpandedRowCell />

--- a/frontend/src/features/Vessel/components/VesselList/__tests__/utils.test.ts
+++ b/frontend/src/features/Vessel/components/VesselList/__tests__/utils.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from '@jest/globals'
+
+import { getLastControlDateTimeAndControlType } from '../utils'
+
+import type { Vessel } from '@features/Vessel/Vessel.types'
+
+describe('utils/getLastControlDateTimeAndControlType()', () => {
+  const mockVessel: Vessel.ActiveVessel = {
+    lastControlAtQuayDateTime: '2024-01-15T14:30:00Z',
+    lastControlAtSeaDateTime: '2024-01-20T10:00:00Z'
+  } as Vessel.ActiveVessel
+
+  describe('when no filters are active (both false)', () => {
+    it('should return the most recent control with correct type when sea is more recent', () => {
+      const vessel = {
+        ...mockVessel,
+        lastControlAtQuayDateTime: '2024-01-15T14:30:00Z',
+        lastControlAtSeaDateTime: '2024-01-20T10:00:00Z'
+      } as Vessel.ActiveVessel
+
+      const result = getLastControlDateTimeAndControlType(false, false, vessel)
+
+      expect(result.lastControlDateTime).toBe('2024-01-20T10:00:00Z')
+      expect(result.controlType).toBe('(mer)')
+    })
+
+    it('should return the most recent control with correct type when quay is more recent', () => {
+      const vessel = {
+        ...mockVessel,
+        lastControlAtQuayDateTime: '2024-01-15T14:30:00Z',
+        lastControlAtSeaDateTime: '2024-01-10T10:00:00Z'
+      } as Vessel.ActiveVessel
+
+      const result = getLastControlDateTimeAndControlType(false, false, vessel)
+
+      expect(result.lastControlDateTime).toBe('2024-01-15T14:30:00Z')
+      expect(result.controlType).toBe('(quai)')
+    })
+  })
+
+  describe('when only sea control filter is active', () => {
+    it('should return sea control date with sea type', () => {
+      const result = getLastControlDateTimeAndControlType(true, false, mockVessel)
+
+      expect(result.lastControlDateTime).toBe('2024-01-20T10:00:00Z')
+      expect(result.controlType).toBe('(mer)')
+    })
+
+    it('should return undefined when no sea control exists', () => {
+      const vessel = {
+        ...mockVessel,
+        lastControlAtSeaDateTime: undefined
+      } as Vessel.ActiveVessel
+
+      const result = getLastControlDateTimeAndControlType(true, false, vessel)
+
+      expect(result.lastControlDateTime).toBeUndefined()
+      expect(result.controlType).toBe('(mer)')
+    })
+  })
+
+  describe('when only quay control filter is active', () => {
+    it('should return quay control date with quay type', () => {
+      const result = getLastControlDateTimeAndControlType(false, true, mockVessel)
+
+      expect(result.lastControlDateTime).toBe('2024-01-15T14:30:00Z')
+      expect(result.controlType).toBe('(quai)')
+    })
+
+    it('should return undefined when no quay control exists', () => {
+      const vessel = {
+        ...mockVessel,
+        lastControlAtQuayDateTime: undefined
+      } as Vessel.ActiveVessel
+
+      const result = getLastControlDateTimeAndControlType(false, true, vessel)
+
+      expect(result.lastControlDateTime).toBeUndefined()
+      expect(result.controlType).toBe('(quai)')
+    })
+  })
+
+  describe('when both filters are active', () => {
+    it('should return the most recent control with correct type', () => {
+      const vessel = {
+        ...mockVessel,
+        lastControlAtQuayDateTime: '2024-01-15T14:30:00Z',
+        lastControlAtSeaDateTime: '2024-01-20T10:00:00Z'
+      } as Vessel.ActiveVessel
+
+      const result = getLastControlDateTimeAndControlType(true, true, vessel)
+
+      expect(result.lastControlDateTime).toBe('2024-01-20T10:00:00Z')
+      expect(result.controlType).toBe('(mer)')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle undefined vessel', () => {
+      const result = getLastControlDateTimeAndControlType(false, false, undefined)
+
+      expect(result.lastControlDateTime).toBeUndefined()
+      expect(result.controlType).toBeUndefined()
+    })
+
+    it('should prioritize specific filter when both control dates exist', () => {
+      const vessel = {
+        ...mockVessel,
+        lastControlAtQuayDateTime: '2024-01-25T14:30:00Z',
+        lastControlAtSeaDateTime: '2024-01-20T10:00:00Z' // Quay is more recent
+      } as Vessel.ActiveVessel
+
+      // When only sea filter is active, should return sea control regardless of which is more recent
+      const resultSeaFilter = getLastControlDateTimeAndControlType(true, false, vessel)
+      expect(resultSeaFilter.lastControlDateTime).toBe('2024-01-20T10:00:00Z')
+      expect(resultSeaFilter.controlType).toBe('(mer)')
+
+      // When only quay filter is active, should return quay control regardless of which is more recent
+      const resultQuayFilter = getLastControlDateTimeAndControlType(false, true, vessel)
+      expect(resultQuayFilter.lastControlDateTime).toBe('2024-01-25T14:30:00Z')
+      expect(resultQuayFilter.controlType).toBe('(quai)')
+    })
+  })
+})

--- a/frontend/src/features/Vessel/components/VesselList/columns.tsx
+++ b/frontend/src/features/Vessel/components/VesselList/columns.tsx
@@ -2,6 +2,7 @@ import { Ellipsised } from '@components/Ellipsised'
 import { Titled } from '@components/Titled'
 import { FLEET_SEGMENT_ORIGIN_LABEL, GEAR_ORIGIN_LABEL } from '@features/FleetSegment/constants'
 import { DEFAULT_VESSEL_LIST_FILTER_VALUES } from '@features/Vessel/components/VesselList/constants'
+import { getLastControlDateTimeAndControlType } from '@features/Vessel/components/VesselList/utils'
 import { ActivityOrigin } from '@features/Vessel/schemas/ActiveVesselSchema'
 import { getLastControlDateTime } from '@features/Vessel/utils'
 import { Vessel } from '@features/Vessel/Vessel.types'
@@ -179,30 +180,13 @@ export function getTableColumns(
           listFilter?.lastControlAtSeaPeriod !== DEFAULT_VESSEL_LIST_FILTER_VALUES.lastControlAtSeaPeriod
         const hasLastControlAtQuayFilter =
           listFilter?.lastControlAtQuayPeriod !== DEFAULT_VESSEL_LIST_FILTER_VALUES.lastControlAtQuayPeriod
-        const hasNoLastControlFilter = !hasLastControlAtSeaFilter && !hasLastControlAtQuayFilter
-        const hasTwoLastControlFilters = hasLastControlAtSeaFilter && hasLastControlAtQuayFilter
+        const { controlType, lastControlDateTime } = getLastControlDateTimeAndControlType(
+          hasLastControlAtSeaFilter,
+          hasLastControlAtQuayFilter,
+          vessel
+        )
 
-        let lastControlDateTime: string | undefined
-        let controlType = ''
-        if (hasLastControlAtSeaFilter || !hasLastControlAtQuayFilter) {
-          controlType = '(mer)'
-          lastControlDateTime = vessel.lastControlAtSeaDateTime
-        }
-
-        if (hasLastControlAtQuayFilter || !hasLastControlAtSeaFilter) {
-          controlType = '(quai)'
-          lastControlDateTime = vessel.lastControlAtQuayDateTime
-        }
-
-        if (hasNoLastControlFilter || hasTwoLastControlFilters) {
-          lastControlDateTime = getLastControlDateTime(
-            vessel.lastControlAtSeaDateTime,
-            vessel.lastControlAtQuayDateTime
-          )
-          controlType = lastControlDateTime === vessel.lastControlAtSeaDateTime ? '(mer)' : '(quai)'
-        }
-
-        return info.getValue() ? (
+        return lastControlDateTime ? (
           <>
             {customDayjs(lastControlDateTime).utc().format('[Le] DD/MM/YYYY')}{' '}
             <LastControlType>{controlType}</LastControlType>


### PR DESCRIPTION
## Linked issues

- Resolve #4341

----

- [ ] Tests E2E (Cypress)
