### PR TITLE
Act-Rep - Utiliser le marquage externe pour le champ `OBJECT_NATIONAL_ID`

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/vessel/Vessel.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/vessel/Vessel.kt
@@ -74,20 +74,11 @@ data class Vessel(
         "VESSELS:${this.internalReferenceNumber ?: "UNKNOWN"}/${this.ircs ?: "UNKNOWN"}/${this.externalReferenceNumber ?: "UNKNOWN"}"
 
     fun getNationalIdentifier(): String {
-        if (districtCode.isNullOrEmpty()) {
+        if (externalReferenceNumber.isNullOrEmpty()) {
             return ""
         }
 
-        val internalReferenceNumberCountryCode =
-            LIKELY_CONTROLLED_COUNTRY_CODES.find { countryAlpha3 ->
-                internalReferenceNumber?.contains(
-                    countryAlpha3,
-                ) == true
-            }
-        val zeros = if (internalReferenceNumberCountryCode == CountryCode.BE.alpha3) "0" else "000" // The BEL state have a higher CFR
-        val identifier = internalReferenceNumber?.replace("${internalReferenceNumberCountryCode}$zeros", "") ?: ""
-
-        return "$districtCode$identifier"
+        return externalReferenceNumber
     }
 
     fun isFrench(): Boolean = FRENCH_COUNTRY_CODES.contains(flagState.alpha2)
@@ -128,51 +119,5 @@ data class Vessel(
                 mmsi.isNullOrEmpty()
         )
 }
-
-val LIKELY_CONTROLLED_COUNTRY_CODES =
-    listOf(
-        CountryCode.FR.alpha3,
-        CountryCode.RU.alpha3,
-        CountryCode.KR.alpha3,
-        CountryCode.JP.alpha3,
-        CountryCode.LY.alpha3,
-        CountryCode.VE.alpha3,
-        CountryCode.SC.alpha3,
-        CountryCode.AU.alpha3,
-        CountryCode.CN.alpha3,
-        CountryCode.MG.alpha3,
-        CountryCode.BR.alpha3,
-        CountryCode.PL.alpha3,
-        CountryCode.VU.alpha3,
-        CountryCode.KM.alpha3,
-        CountryCode.MC.alpha3,
-        CountryCode.BW.alpha3,
-        CountryCode.AI.alpha3,
-        CountryCode.LK.alpha3,
-        CountryCode.TW.alpha3,
-        CountryCode.TT.alpha3,
-        CountryCode.FO.alpha3,
-        CountryCode.GY.alpha3,
-        CountryCode.PA.alpha3,
-        CountryCode.SX.alpha3,
-        CountryCode.TN.alpha3,
-        CountryCode.TR.alpha3,
-        CountryCode.AL.alpha3,
-        CountryCode.GD.alpha3,
-        CountryCode.DZ.alpha3,
-        CountryCode.SX.alpha3,
-        CountryCode.BE.alpha3,
-        CountryCode.DK.alpha3,
-        CountryCode.DE.alpha3,
-        CountryCode.EE.alpha3,
-        CountryCode.IE.alpha3,
-        CountryCode.ES.alpha3,
-        CountryCode.IT.alpha3,
-        CountryCode.NL.alpha3,
-        CountryCode.NO.alpha3,
-        CountryCode.PT.alpha3,
-        CountryCode.SE.alpha3,
-        CountryCode.GB.alpha3,
-    )
 
 val UNKNOWN_VESSEL = Vessel(id = -1, flagState = CountryCode.UNDEFINED, hasLogbookEsacapt = false)

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/vessel/VesselUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/vessel/VesselUTests.kt
@@ -16,74 +16,9 @@ class VesselUTests {
             Vessel(
                 id = 1,
                 internalReferenceNumber = "FRA00022680",
+                externalReferenceNumber = "AY22680",
                 vesselName = "MY AWESOME VESSEL",
                 flagState = CountryCode.FR,
-                declaredFishingGears = listOf("Trémails"),
-                vesselType = "Fishing",
-                districtCode = "AY",
-                hasLogbookEsacapt = false,
-            )
-
-        // When
-        val nationalIdentifier = vessel.getNationalIdentifier()
-
-        // Then
-        assertThat(nationalIdentifier).isEqualTo("AY22680")
-    }
-
-    @Test
-    fun `getNationalIdentifier should return the identifier for a BE vessel`() {
-        // Given
-        val vessel =
-            Vessel(
-                id = 1,
-                internalReferenceNumber = "BEL01022680",
-                vesselName = "MY AWESOME VESSEL",
-                flagState = CountryCode.FR,
-                declaredFishingGears = listOf("Trémails"),
-                vesselType = "Fishing",
-                districtCode = "AY",
-                hasLogbookEsacapt = false,
-            )
-
-        // When
-        val nationalIdentifier = vessel.getNationalIdentifier()
-
-        // Then
-        assertThat(nationalIdentifier).isEqualTo("AY1022680")
-    }
-
-    @Test
-    fun `getNationalIdentifier should return no identifier for a FR vessel When district code is null`() {
-        // Given
-        val vessel =
-            Vessel(
-                id = 1,
-                internalReferenceNumber = "FRA00022680",
-                vesselName = "MY AWESOME VESSEL",
-                flagState = CountryCode.FR,
-                declaredFishingGears = listOf("Trémails"),
-                vesselType = "Fishing",
-                districtCode = "",
-                hasLogbookEsacapt = false,
-            )
-
-        // When
-        val nationalIdentifier = vessel.getNationalIdentifier()
-
-        // Then
-        assertThat(nationalIdentifier).isEqualTo("")
-    }
-
-    @Test
-    fun `getNationalIdentifier should return the identifier for a GB vessel`() {
-        // Given
-        val vessel =
-            Vessel(
-                id = 1,
-                internalReferenceNumber = "GBR00022680",
-                vesselName = "MY AWESOME VESSEL",
-                flagState = CountryCode.GB,
                 declaredFishingGears = listOf("Trémails"),
                 vesselType = "Fishing",
                 districtCode = "AY",

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission/mission_actions/GetActivityReportsUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission/mission_actions/GetActivityReportsUTests.kt
@@ -290,6 +290,7 @@ class GetActivityReportsUTests {
                 Vessel(
                     id = 1,
                     internalReferenceNumber = "FR00022680",
+                    externalReferenceNumber = "AY22680",
                     vesselName = "MY AWESOME VESSEL",
                     flagState = CountryCode.FR,
                     declaredFishingGears = listOf("Trémails"),
@@ -300,6 +301,7 @@ class GetActivityReportsUTests {
                 Vessel(
                     id = 2,
                     internalReferenceNumber = "FR00065455",
+                    externalReferenceNumber = "LO65455",
                     vesselName = "MY SECOND AWESOME VESSEL",
                     flagState = CountryCode.FR,
                     declaredFishingGears = listOf("Trémails"),
@@ -366,13 +368,13 @@ class GetActivityReportsUTests {
 
         activityReports.activityReports.first().let { landReport ->
             assertThat(landReport.activityCode).isEqualTo(ActivityCode.LAN)
-            assertThat(landReport.vesselNationalIdentifier).isEqualTo("AYFR00022680")
+            assertThat(landReport.vesselNationalIdentifier).isEqualTo("AY22680")
             assertThat(landReport.faoArea).isEqualTo("27.4.c")
             assertThat(landReport.segment).isEqualTo("NWW01")
         }
         activityReports.activityReports.last().let { seaReport ->
             assertThat(seaReport.activityCode).isEqualTo(ActivityCode.FIS)
-            assertThat(seaReport.vesselNationalIdentifier).isEqualTo("AYFR00022680")
+            assertThat(seaReport.vesselNationalIdentifier).isEqualTo("AY22680")
             assertThat(seaReport.faoArea).isEqualTo("27.4.c")
             assertThat(seaReport.segment).isNull()
         }

--- a/frontend/cypress/e2e/side_window/mission_list/export_activity_reports.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_list/export_activity_reports.spec.ts
@@ -33,7 +33,7 @@ context('Side Window > Mission List > Export Activity Reports', () => {
         )
         .should(
           'contains',
-          '"LCross Etel","L","Cross Etel","","INSPECTION","20200118","07:19","07:19","FRA","FRA","","","","Vessel","FRA","AYFAK000999999"'
+          '"LCross Etel","L","Cross Etel","","INSPECTION","20200118","07:19","07:19","FRA","FRA","","","","Vessel","FRA","DONTSINK"'
         )
         .should(
           'contains',


### PR DESCRIPTION
## Linked issues

- Resolve #4473

----

- [ ] Tests E2E (Cypress)
