### PR TITLE
Tech - Fix keycloak ssl required during dev

### DIFF
--- a/infra/dev/keycloak/realm-monitor-dev.json
+++ b/infra/dev/keycloak/realm-monitor-dev.json
@@ -1,6 +1,7 @@
 {
   "realm": "monitor",
   "enabled": true,
+  "sslRequired": "none",
   "clients": [
     {
       "clientId": "monitorfish",


### PR DESCRIPTION
J'ai eu une erreur `HTTPS required`après un click sur le bouton login.

<img width="1463" height="317" alt="Screenshot 2026-03-30 at 14 24 12" src="https://github.com/user-attachments/assets/2ffa3021-42c8-4a93-a0a4-cd9bfb5851f4" />

@louptheron a recommandé de set `"sslRequired": "none"` dans le fichier de config du realm `infra/dev/keycloak/realm-monitor-dev.json` et ça a effectivement réglé le problème
