### PR TITLE
Fix marge blanche au dessus d'Ajouter une infraction dans l'éditeur de mission

### DIFF
--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/FormikMultiInfractionPicker/index.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/FormikMultiInfractionPicker/index.tsx
@@ -182,6 +182,9 @@ const Wrapper = styled(FieldsetGroup)`
     > .Element-Fieldset:not(:first-child) {
       margin-top: 16px;
     }
+    > button:not(:first-child) {
+      margin-top: 0; // Nécessaire pour empêcher une marge blanche au dessus du bouton "Ajouter une infraction"
+    }
   }
 `
 


### PR DESCRIPTION
Resolves #4111

Règle le problème de marge blanche au dessus du bouton "Ajouter une infraction" soulevé par [ce commentaire](https://github.com/MTES-MCT/monitorfish/issues/4111#issuecomment-3891758922)

Avant:
<img width="618" height="464" alt="Screenshot 2026-03-30 at 14 45 36" src="https://github.com/user-attachments/assets/4a89b461-9541-4c8b-a05d-47979636e6d7" />

Après:
<img width="548" height="366" alt="Screenshot 2026-03-30 at 14 45 47" src="https://github.com/user-attachments/assets/0b334976-3aa4-4de2-882a-8f2cc96192d0" />