### PR TITLE
Fix - Dev - Race condition dans la fixture de db des tests de pipeline

### DIFF
--- a/pipeline/tests/conftest.py
+++ b/pipeline/tests/conftest.py
@@ -166,9 +166,10 @@ def start_remote_database_container(set_environment_variables, create_docker_cli
     while healthcheck_exit_code != 0 and elapsed_time < timeout:
         print(f"Waiting for database container to start ({elapsed_time}/{timeout})")
         sleep(stop_time)
+        # The `-h 127.0.0.1` is required due to this issue https://github.com/docker-library/postgres/issues/146
         healthcheck_exit_code = remote_database_container.exec_run(
             (
-                f"pg_isready -U {os.environ['MONITORFISH_REMOTE_DB_USER']} -d "
+                f"pg_isready -h 127.0.0.1 -U {os.environ['MONITORFISH_REMOTE_DB_USER']} -d "
                 f"{os.environ['MONITORFISH_REMOTE_DB_NAME']}"
             )
         ).exit_code


### PR DESCRIPTION
En faisant #4981 j'ai eu un autre problème avec les tests du pipeline. Les migrations de passaient pas avec comme erreur
```
Exception: Error running migration V0.0__Create_positions_table.sql. Error message is: b'CREATE SEQUENCE\nCREATE SEQUENCE\nSET\npsql:/opt/migrations/internal/V0.0__Create_positions_table.sql:6: FATAL:  terminating connection due to administrator command\npsql:/opt/migrations/internal/V0.0__Create_positions_table.sql:6: server closed the connection unexpectedly\n\tThis probably means the server terminated abnormally\n\tbefore or while processing the request.\npsql:/opt/migrations/internal/V0.0__Create_positions_table.sql:6: error: connection to server was lost\n'
```

Après investigation avec @VincentAntoine on a confirmé que c'était une race condition avec l'initialisation de la DB, puis vu cette issue https://github.com/docker-library/postgres/issues/146 qui semblait similaire.

En applicant le solution d'ajouter `-h 127.0.0.1` dans le healthcheck recommandé ici https://github.com/docker-library/postgres/issues/146#issuecomment-3553955164, le problème a été réglé.