### PR TITLE
Préavis - Filtrer par "préavis 0" (dans les types de préavis)

### DIFF
--- a/frontend/src/features/PriorNotification/components/PriorNotificationList/FilterBar.tsx
+++ b/frontend/src/features/PriorNotification/components/PriorNotificationList/FilterBar.tsx
@@ -267,7 +267,7 @@ export function FilterBar() {
           searchable
           value={listFilterValues.portLocodes}
         />
-        <CheckPicker
+        <TypeCheckPicker
           disabled={!priorNotificationTypesAsOptions}
           isLabelHidden
           isTransparent
@@ -283,7 +283,7 @@ export function FilterBar() {
           searchable
           value={listFilterValues.priorNotificationTypes}
         />
-        <StatusCheckPicker
+        <CheckPicker<FilterStatus>
           isLabelHidden
           isTransparent
           label="Statuts de diffusion"
@@ -358,7 +358,7 @@ const Row = styled.div`
   }
 `
 
-const StatusCheckPicker = styled(CheckPicker<FilterStatus>)`
+const TypeCheckPicker = styled(CheckPicker)`
   [role='listbox'] {
     > [role='option']:last-child {
       border-top: 2px solid ${({ theme }) => theme.color.lightGray};

--- a/frontend/src/features/PriorNotification/components/PriorNotificationList/constants.ts
+++ b/frontend/src/features/PriorNotification/components/PriorNotificationList/constants.ts
@@ -92,6 +92,5 @@ export const FILTER_STATUSES_AS_OPTIONS: Option<FilterStatus>[] = [
   { label: IS_INVALIDATED_LABEL, value: IS_INVALIDATED },
   { label: 'Envoi auto. demandé', value: PriorNotification.State.AUTO_SEND_REQUESTED },
   { label: 'Envoi auto. fait', value: PriorNotification.State.AUTO_SEND_DONE },
-  { label: 'Échec de diffusion', value: PriorNotification.State.FAILED_SEND },
-  { label: IS_PRIOR_NOTIFICATION_ZERO_LABEL, value: IS_PRIOR_NOTIFICATION_ZERO }
+  { label: 'Échec de diffusion', value: PriorNotification.State.FAILED_SEND }
 ]

--- a/frontend/src/features/PriorNotification/components/PriorNotificationList/types.ts
+++ b/frontend/src/features/PriorNotification/components/PriorNotificationList/types.ts
@@ -1,9 +1,4 @@
-import {
-  type LastControlPeriod,
-  type ExpectedArrivalPeriod,
-  type IS_INVALIDATED,
-  IS_PRIOR_NOTIFICATION_ZERO
-} from './constants'
+import { type LastControlPeriod, type ExpectedArrivalPeriod, type IS_INVALIDATED } from './constants'
 
 import type { AllSeafrontGroup, SeafrontGroup } from '@constants/seafront'
 import type { PriorNotification } from '@features/PriorNotification/PriorNotification.types'
@@ -31,4 +26,4 @@ export type ListFilter = UndefineExcept<
   'expectedArrivalPeriod' | 'seafrontGroup'
 >
 
-export type FilterStatus = PriorNotification.State | typeof IS_INVALIDATED | typeof IS_PRIOR_NOTIFICATION_ZERO
+export type FilterStatus = PriorNotification.State | typeof IS_INVALIDATED

--- a/frontend/src/features/PriorNotification/components/PriorNotificationList/utils.tsx
+++ b/frontend/src/features/PriorNotification/components/PriorNotificationList/utils.tsx
@@ -240,13 +240,22 @@ function getStatesFromFilterStatuses(statuses: FilterStatus[] | undefined): Prio
     return undefined
   }
 
-  const states = statuses.filter(status => status !== IS_INVALIDATED && status !== IS_PRIOR_NOTIFICATION_ZERO)
+  const states = statuses.filter(status => status !== IS_INVALIDATED)
 
   return [
     ...states,
     ...(states.includes(PriorNotification.State.VERIFIED_AND_SENT) ? [PriorNotification.State.PENDING_SEND] : []),
     ...(states.includes(PriorNotification.State.AUTO_SEND_DONE) ? [PriorNotification.State.PENDING_AUTO_SEND] : [])
   ]
+}
+
+function getTypesFromFilterTypes(priorNotificationTypes: string[] | undefined): string[] | undefined {
+  const withoutZero = priorNotificationTypes?.filter(val => val !== IS_PRIOR_NOTIFICATION_ZERO)
+  if (!withoutZero?.length) {
+    return undefined
+  }
+
+  return withoutZero
 }
 
 export function getStaticApiFilterFromListFilter(listFilter: ListFilter): Logbook.ApiFilter {
@@ -257,9 +266,9 @@ export function getStaticApiFilterFromListFilter(listFilter: ListFilter): Logboo
     isInvalidated: listFilter.statuses?.includes(IS_INVALIDATED) ? true : undefined,
     isLessThanTwelveMetersVessel: getMaybeBooleanFromRichBoolean(listFilter.isLessThanTwelveMetersVessel),
     // We don't want to send `false` when it's unchecked because it would exclude "Préavis Zéro" prior notifications
-    isPriorNotificationZero: listFilter.statuses?.includes(IS_PRIOR_NOTIFICATION_ZERO) ? true : undefined,
+    isPriorNotificationZero: listFilter.priorNotificationTypes?.includes(IS_PRIOR_NOTIFICATION_ZERO) ? true : undefined,
     portLocodes: listFilter.portLocodes,
-    priorNotificationTypes: listFilter.priorNotificationTypes,
+    priorNotificationTypes: getTypesFromFilterTypes(listFilter.priorNotificationTypes),
     seafrontGroup: listFilter.seafrontGroup,
     searchQuery: listFilter.searchQuery,
     specyCodes: listFilter.specyCodes,
@@ -275,9 +284,6 @@ export function getStatusTagLabel(status: FilterStatus): string {
   switch (status) {
     case IS_INVALIDATED:
       return IS_INVALIDATED_LABEL
-
-    case IS_PRIOR_NOTIFICATION_ZERO:
-      return 'Préavis Zéro'
 
     default:
       return PriorNotification.STATE_LABEL[status]

--- a/frontend/src/features/PriorNotification/hooks/useGetPriorNotificationTypesAsOptions.ts
+++ b/frontend/src/features/PriorNotification/hooks/useGetPriorNotificationTypesAsOptions.ts
@@ -19,14 +19,14 @@ export function useGetPriorNotificationTypesAsOptions() {
       return undefined
     }
 
-    const opts = types.map(type => ({
+    const options = types.map(type => ({
       label: type,
       value: type
     }))
 
-    opts.push({ label: IS_PRIOR_NOTIFICATION_ZERO_LABEL, value: IS_PRIOR_NOTIFICATION_ZERO })
+    options.push({ label: IS_PRIOR_NOTIFICATION_ZERO_LABEL, value: IS_PRIOR_NOTIFICATION_ZERO })
 
-    return opts
+    return options
   }, [types])
 
   return {

--- a/frontend/src/features/PriorNotification/hooks/useGetPriorNotificationTypesAsOptions.ts
+++ b/frontend/src/features/PriorNotification/hooks/useGetPriorNotificationTypesAsOptions.ts
@@ -1,5 +1,9 @@
 import { useMemo } from 'react'
 
+import {
+  IS_PRIOR_NOTIFICATION_ZERO,
+  IS_PRIOR_NOTIFICATION_ZERO_LABEL
+} from '../components/PriorNotificationList/constants'
 import { useGetPriorNotificationTypesQuery } from '../priorNotificationApi'
 
 import type { Option } from '@mtes-mct/monitor-ui'
@@ -15,10 +19,14 @@ export function useGetPriorNotificationTypesAsOptions() {
       return undefined
     }
 
-    return types.map(type => ({
+    const opts = types.map(type => ({
       label: type,
       value: type
     }))
+
+    opts.push({ label: IS_PRIOR_NOTIFICATION_ZERO_LABEL, value: IS_PRIOR_NOTIFICATION_ZERO })
+
+    return opts
   }, [types])
 
   return {


### PR DESCRIPTION
Fixes #4374

- [x] basculer le préavis 0 du filtre statut de diffusion vers le filtre type de préavis
- [x] vérifier si le filtre fonctionne bien (cf. dans [ce commentaire](https://github.com/MTES-MCT/monitorfish/issues/4374#issuecomment-3522033039) le pb avec le navire néerlandais)

Comportement après changements (cc @AdelineCelier):

<img width="1260" height="670" alt="Screenshot 2026-04-27 at 13 09 27" src="https://github.com/user-attachments/assets/7c026ee8-3904-4a2f-8702-19933289a3ce" />
<img width="1259" height="615" alt="Screenshot 2026-04-27 at 13 10 14" src="https://github.com/user-attachments/assets/1f8fbb61-dc37-41b2-a041-a2e1ed83e191" />
<img width="1259" height="593" alt="Screenshot 2026-04-27 at 13 10 36" src="https://github.com/user-attachments/assets/8387b924-f668-4ead-986f-a8fb895f09b5" />
<img width="540" height="394" alt="Screenshot 2026-04-27 at 13 11 01" src="https://github.com/user-attachments/assets/009824a3-8ac2-4e24-9a13-9d48df29ca91" />
