### PR TITLE
Fiche navire onglet identité – Ajustements d'ui modalités de contact

### DIFF
--- a/frontend/cypress/e2e/main_window/vessel_sidebar/identity.spec.ts
+++ b/frontend/cypress/e2e/main_window/vessel_sidebar/identity.spec.ts
@@ -49,7 +49,7 @@ context('Vessel sidebar identity tab', () => {
     cy.clickButton('Identité')
 
     // When creating a vessel contact
-    cy.fill("Modalité de contact avec le navire", 'Nouvelle modalité de contact')
+    cy.fill('Modalités de contact avec le navire', 'Nouvelle modalité de contact')
     cy.fill('Contact à mettre à jour', true)
     cy.clickButton('Valider')
 
@@ -67,14 +67,14 @@ context('Vessel sidebar identity tab', () => {
     })
 
     // When cancelling modifications
-    cy.fill("Modalité de contact avec le navire", 'Autre modalité de contact')
+    cy.fill('Modalités de contact avec le navire', 'Autre modalité de contact')
     cy.fill('Contact à mettre à jour', false)
     cy.clickButton('Annuler')
     // Then
     cy.get('#contactMethod').should('have.value', 'Nouvelle modalité de contact')
 
     // When updating a vessel contact method
-    cy.fill("Modalité de contact avec le navire", 'Autre modalité de contact')
+    cy.fill('Modalités de contact avec le navire', 'Autre modalité de contact')
     cy.fill('Contact à mettre à jour', false)
     cy.clickButton('Valider')
     // Then

--- a/frontend/src/features/Vessel/components/VesselSidebar/components/VesselContactToUpdateForm.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/components/VesselContactToUpdateForm.tsx
@@ -100,7 +100,7 @@ export function VesselContactToUpdateForm({ vesselId }: VesselContactToUpdateFor
 
 const StyledFormikTextarea = styled(FormikTextarea)`
   > textarea {
-    box-sizing: border-box; // ensures the textarea width matches the parent div
+    box-sizing: border-box; // ensures the textarea width matches the parent div. TODO: move this into monitorui, see https://github.com/MTES-MCT/monitor-ui/issues/1984
   }
 `
 

--- a/frontend/src/features/Vessel/components/VesselSidebar/components/VesselContactToUpdateForm.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/components/VesselContactToUpdateForm.tsx
@@ -73,7 +73,7 @@ export function VesselContactToUpdateForm({ vesselId }: VesselContactToUpdateFor
       {({ dirty, resetForm }) => (
         <ContactForm>
           <StyledFormikTextarea
-            label="Modalité de contact avec le navire"
+            label="Modalités de contact avec le navire"
             name="contactMethod"
             readOnly={!isSuperUser}
           />
@@ -98,7 +98,11 @@ export function VesselContactToUpdateForm({ vesselId }: VesselContactToUpdateFor
   )
 }
 
-const StyledFormikTextarea = styled(FormikTextarea)``
+const StyledFormikTextarea = styled(FormikTextarea)`
+  > textarea {
+    box-sizing: border-box; // ensures the textarea width matches the parent div
+  }
+`
 
 const ContactForm = styled(Form)`
   background-color: ${p => p.theme.color.white};


### PR DESCRIPTION
Fixes #4088

- [x] il faut le même padding de 24 px à gauche et à droite du champ "modalités de contact..."
- [x] rajouter un "s" à "modalité"

Depuis le commentaire d'@AdelineCelier : https://github.com/MTES-MCT/monitorfish/issues/4088#issuecomment-3664575773

Note: on pourrait probablement remonter le fix de "padding" sur monitorui

### Avant changements:
<img width="502" height="383" alt="Screenshot 2026-04-27 at 13 36 51" src="https://github.com/user-attachments/assets/8abc95b6-0ee5-4b11-85bd-30520c304dc3" />

### Après changements:
<img width="497" height="379" alt="Screenshot 2026-04-27 at 13 50 05" src="https://github.com/user-attachments/assets/e76f0fbb-8d85-43fa-afe5-750e158f6890" />
