### PR TITLE
OP - Afficher une bannière d'erreur quand l'upload est un échec

### DIFF
--- a/frontend/src/features/ProducerOrganizationMembership/components/ProducerOrganizationMembershipTable/FilterBar.tsx
+++ b/frontend/src/features/ProducerOrganizationMembership/components/ProducerOrganizationMembershipTable/FilterBar.tsx
@@ -21,16 +21,19 @@ export function FilterBar() {
       return
     }
 
-    await dispatch(updateProducerOrganizationMemberships(fileType.blobFile as File))
-    dispatch(
-      addMainWindowBanner({
-        children: 'Mise à jour des données effectuée',
-        closingDelay: 6000,
-        isClosable: true,
-        level: Level.SUCCESS,
-        withAutomaticClosing: true
-      })
-    )
+    const success = await dispatch(updateProducerOrganizationMemberships(fileType.blobFile as File))
+
+    if (success) {
+      dispatch(
+        addMainWindowBanner({
+          children: 'Mise à jour des données effectuée',
+          closingDelay: 6000,
+          isClosable: true,
+          level: Level.SUCCESS,
+          withAutomaticClosing: true
+        })
+      )
+    }
   }
 
   const updateSearchQuery = useCallback(

--- a/frontend/src/features/ProducerOrganizationMembership/useCases/updateProducerOrganizationMemberships.ts
+++ b/frontend/src/features/ProducerOrganizationMembership/useCases/updateProducerOrganizationMemberships.ts
@@ -6,7 +6,7 @@ import { displayOrLogError } from 'domain/use_cases/error/displayOrLogError'
 import type { BackofficeAppThunk } from '@store'
 
 export const updateProducerOrganizationMemberships =
-  (file: File): BackofficeAppThunk<Promise<void>> =>
+  (file: File): BackofficeAppThunk<Promise<boolean>> =>
   async dispatch => {
     try {
       const nextMemberships = await getNextMembershipsFromFile(file)
@@ -14,7 +14,11 @@ export const updateProducerOrganizationMemberships =
       await dispatch(
         producerOrganizationMembershipApi.endpoints.setProducerOrganizationMemberships.initiate(nextMemberships)
       ).unwrap()
+
+      return true
     } catch (err) {
-      dispatch(displayOrLogError(err, undefined, true, DisplayedErrorKey.BACKOFFICE_PRODUCER_ORGANIZATION_ERROR))
+      dispatch(displayOrLogError(err, undefined, false, DisplayedErrorKey.BACKOFFICE_PRODUCER_ORGANIZATION_ERROR))
+
+      return false
     }
   }

--- a/frontend/src/features/ProducerOrganizationMembership/useCases/utils/utils.ts
+++ b/frontend/src/features/ProducerOrganizationMembership/useCases/utils/utils.ts
@@ -36,6 +36,10 @@ export const getNextMembershipsFromFile = async (file: File): Promise<ProducerOr
 
   const rowsAsArray: string[][] = utils.sheet_to_json<string[]>(worksheet, { header: 1 }).slice(1)
 
+  if (rowsAsArray.length === 0) {
+    throw new Error(EMPTY_CSV_ERROR)
+  }
+
   return rowsAsArray.map(row => ({
     internalReferenceNumber: getFieldOrThrow(row, 0),
     joiningDate: getFieldOrThrow(row, 8),


### PR DESCRIPTION
Fixes https://github.com/MTES-MCT/monitorfish/issues/3705#issuecomment-2548226510

- [x] Afficher une bannière d'erreur monitor-ui quand l'upload fail
- [x] Ne pas afficher une bannière de succès quand l'upload fail
- [x] Ajout d'un check supplémentaire en cas de fichier vide

J'ai pris la liberté d'ajouter le dernier point parce-que la logique considérait que l'upload était un succès quand on importait un fichier texte vide

<img width="1452" height="404" alt="Screenshot 2026-05-11 at 11 48 05" src="https://github.com/user-attachments/assets/abba7cef-9240-438a-a823-139ea2442f49" />