### PR TITLE
Préavis - Afficher la raison pour laquelle le préavis est "à vérifier" (note, signalement, port état tiers)

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/prior_notification/PriorNotification.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/prior_notification/PriorNotification.kt
@@ -35,7 +35,6 @@ data class PriorNotification(
     val updatedAt: ZonedDateTime?,
     val vessel: Vessel?,
     var lastControlDateTime: ZonedDateTime?,
-    var vesselRiskFactor: Double? = null,
 ) {
     /** Each prior notification and each of its updates have a unique fingerprint. */
     val fingerprint: String = listOf(reportId, updatedAt, state).joinToString(separator = ".")
@@ -92,7 +91,7 @@ data class PriorNotification(
                     isManual = isManuallyCreated,
                     port = port,
                     vesselFlagCountryCode = vessel?.flagState,
-                    vesselRiskFactor = vesselRiskFactor,
+                    vesselRiskFactor = logbookMessageAndValue.value.riskFactor,
                     infractionSuspicionsCount = reportingCount ?: 0,
                 )
             }
@@ -128,7 +127,6 @@ data class PriorNotification(
             }
 
         lastControlDateTime = riskFactor?.lastControlDateTime
-        vesselRiskFactor = riskFactor?.riskFactor
     }
 
     fun enrichLogbookMessage(

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/prior_notification/PriorNotificationState.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/prior_notification/PriorNotificationState.kt
@@ -19,7 +19,7 @@ enum class PriorNotificationState {
     /** "Diffusion en cours". */
     PENDING_SEND,
 
-    /** "À vérifier (CNSP)". */
+    /** "À vérifier". */
     PENDING_VERIFICATION,
 
     /** "Vérifié et diffusé". */

--- a/frontend/cypress/e2e/side_window/logbook_prior_notification_card/card.spec.ts
+++ b/frontend/cypress/e2e/side_window/logbook_prior_notification_card/card.spec.ts
@@ -41,7 +41,7 @@ context('Side Window > Logbook Prior Notification Card > Card', () => {
     cy.contains(`25 kg`).should('be.visible')
 
     // Verification reason labels
-    cy.contains('À vérifier (CNSP) - note ≥ 2,3').should('be.visible')
+    cy.contains('À vérifier - note ≥ 2,3').should('be.visible')
     cy.contains('Le préavis doit être vérifié par le CNSP avant sa diffusion (note de risque du navire égale ou supérieure à 2,3).').should('be.visible')
   })
 

--- a/frontend/cypress/e2e/side_window/manual_prior_notification_card/card.spec.ts
+++ b/frontend/cypress/e2e/side_window/manual_prior_notification_card/card.spec.ts
@@ -21,7 +21,7 @@ context('Side Window > Manual Prior Notification Card > Card', () => {
     openSideWindowPriorNotificationCardAsUser('FILET DOUX', '00000000-0000-4000-0000-000000000007')
 
     cy.contains('FILET DOUX (CFR122)').should('be.visible')
-    cy.contains('À vérifier (CNSP) - note ≥ 2,3').should('be.visible')
+    cy.contains('À vérifier - note ≥ 2,3').should('be.visible')
     cy.contains('Le préavis doit être vérifié par le CNSP avant sa diffusion (note de risque du navire égale ou supérieure à 2,3).').should('be.visible')
   })
 

--- a/frontend/cypress/e2e/side_window/prior_notification_list/filter_bar.spec.ts
+++ b/frontend/cypress/e2e/side_window/prior_notification_list/filter_bar.spec.ts
@@ -121,7 +121,7 @@ context('Side Window > Prior Notification List > Filter Bar', () => {
     ])
     cy.wait('@getPriorNotificationsStatuses')
     cy.get('.Table-SimpleTable tr').should('have.length.to.be.greaterThan', 0)
-    cy.get('[title="À vérifier (CNSP) - note ≥ 2,3"]').should('exist')
+    cy.get('[title="À vérifier - note ≥ 2,3"]').should('exist')
     cy.getDataCy('prior-notification-reset-filters').click()
 
     /**

--- a/frontend/src/features/PriorNotification/PriorNotification.types.ts
+++ b/frontend/src/features/PriorNotification/PriorNotification.types.ts
@@ -217,7 +217,7 @@ export namespace PriorNotification {
     PENDING_AUTO_SEND = 'PENDING_AUTO_SEND',
     /** "Diffusion en cours". */
     PENDING_SEND = 'PENDING_SEND',
-    /** "À vérifier (CNSP)". */
+    /** "À vérifier". */
     PENDING_VERIFICATION = 'PENDING_VERIFICATION',
     /** "Vérifié et diffusé". */
     VERIFIED_AND_SENT = 'VERIFIED_AND_SENT'
@@ -229,7 +229,7 @@ export namespace PriorNotification {
     OUT_OF_VERIFICATION_SCOPE: 'Hors vérification',
     PENDING_AUTO_SEND: 'Envoi auto. en cours',
     PENDING_SEND: 'Diffusion en cours',
-    PENDING_VERIFICATION: 'À vérifier (CNSP)',
+    PENDING_VERIFICATION: 'À vérifier',
     VERIFIED_AND_SENT: 'Vérifié et diffusé'
   }
 

--- a/frontend/src/features/PriorNotification/components/PriorNotificationCard.tsx
+++ b/frontend/src/features/PriorNotification/components/PriorNotificationCard.tsx
@@ -142,7 +142,7 @@ export function PriorNotificationCard({
 const StyledCard = styled(SideWindowCard)<{
   $isSuperUser: boolean
 }>`
-  left: ${p => (p.$isSuperUser ? '70px' : 0)};
+  left: ${p => (p.$isSuperUser ? '64px' : 0)};
 `
 
 const Body = styled.div`

--- a/frontend/src/features/PriorNotification/components/PriorNotificationList/constants.ts
+++ b/frontend/src/features/PriorNotification/components/PriorNotificationList/constants.ts
@@ -87,7 +87,7 @@ export const IS_INVALIDATED_LABEL = 'Invalidé'
 export const IS_PRIOR_NOTIFICATION_ZERO = 'IS_PRIOR_NOTIFICATION_ZERO'
 export const IS_PRIOR_NOTIFICATION_ZERO_LABEL = 'Préavis Zéro'
 export const FILTER_STATUSES_AS_OPTIONS: Option<FilterStatus>[] = [
-  { label: 'À vérifier (CNSP)', value: PriorNotification.State.PENDING_VERIFICATION },
+  { label: 'À vérifier', value: PriorNotification.State.PENDING_VERIFICATION },
   { label: 'Hors vérification', value: PriorNotification.State.OUT_OF_VERIFICATION_SCOPE },
   { label: 'Vérifié et diffusé', value: PriorNotification.State.VERIFIED_AND_SENT },
   { label: IS_INVALIDATED_LABEL, value: IS_INVALIDATED },

--- a/frontend/src/features/PriorNotification/components/ReportingList.tsx
+++ b/frontend/src/features/PriorNotification/components/ReportingList.tsx
@@ -114,7 +114,7 @@ export function ReportingList() {
 const StyledCard = styled(SideWindowCard)<{
   $isSuperUser: boolean
 }>`
-  left: ${p => (p.$isSuperUser ? '70px' : 0)};
+  left: ${p => (p.$isSuperUser ? '64px' : 0)};
   z-index: 1001;
 `
 


### PR DESCRIPTION
## Linked issues

- Resolve #4820

----

- [ ] Tests E2E (Cypress)
