### PR TITLE
[Tech] Backend - Bump Spring Boot 4, Security 7, Flyway 12, Ktor 3.5 & non-major group

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -104,12 +104,15 @@ dependencies {
     api("org.springframework.security:spring-security-oauth2-resource-server:$springSecurityVersion")
     api("org.springframework.security:spring-security-oauth2-jose:$springSecurityVersion")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
-    implementation("org.springframework.cloud:spring-cloud-gateway-mvc:4.3.4")
+    // Renamed from spring-cloud-gateway-mvc in Spring Cloud 2025.x; version managed by the BOM so it
+    // stays compatible with Spring Boot 4. Keeps the org.springframework.cloud.gateway.mvc.* package.
+    implementation("org.springframework.cloud:spring-cloud-gateway-proxyexchange-webmvc")
     implementation("org.springframework.kafka:spring-kafka")
     // Spring Boot 4 split several pieces out of spring-boot / spring-boot-autoconfigure into
     // dedicated modules that are no longer pulled transitively by the web starter.
     implementation("org.springframework.boot:spring-boot-restclient:$springBootVersion")
     implementation("org.springframework.boot:spring-boot-kafka:$springBootVersion")
+    implementation("org.springframework.boot:spring-boot-flyway:$springBootVersion")
 
     // Kotlin
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
@@ -127,8 +130,10 @@ dependencies {
     implementation("org.flywaydb:flyway-core:12.5.0")
     implementation("org.flywaydb:flyway-database-postgresql:12.5.0")
     implementation("org.hibernate.validator:hibernate-validator:8.0.2.Final")
-    implementation("org.hibernate:hibernate-spatial:7.3.6.Final")
-    implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.15.2")
+    // Version managed by the Spring Boot BOM so it stays aligned with the managed hibernate-core
+    // (an explicit newer hibernate-spatial pulls APIs absent from the BOM's hibernate-core).
+    implementation("org.hibernate.orm:hibernate-spatial")
+    implementation("io.hypersistence:hypersistence-utils-hibernate-71:3.15.2")
     api("org.locationtech.jts:jts-core:1.20.0")
     implementation("org.n52.jackson:jackson-datatype-jts:2.0.0")
     implementation("org.locationtech.proj4j:proj4j:1.4.2")

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -2,15 +2,15 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
 
-val springBootVersion = "3.5.8"
+val springBootVersion = "4.0.6"
 val kotlinVersion = "2.3.21"
-val springSecurityVersion = "6.5.6"
+val springSecurityVersion = "7.0.5"
 
 plugins {
     `java-library`
     `maven-publish`
 
-    id("org.springframework.boot") version "3.5.8"
+    id("org.springframework.boot") version "4.0.6"
     id("io.spring.dependency-management") version "1.1.7"
     id("org.jetbrains.kotlin.plugin.spring") version "2.3.21"
     id("org.jetbrains.kotlin.plugin.allopen") version "2.3.21"
@@ -56,6 +56,16 @@ dependencyManagement {
     imports {
         mavenBom("org.springframework.cloud:spring-cloud-dependencies:2025.1.1")
     }
+
+    // Ktor 3.5 is compiled against kotlinx-coroutines 1.11. An imported BOM otherwise pins the
+    // *-jvm coroutines artifacts to 1.8.1, causing a java.lang.NoSuchMethodError at runtime in the
+    // Ktor HTTP client. Override the managed version so every coroutines artifact stays aligned.
+    dependencies {
+        dependency("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
+        dependency("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.11.0")
+        dependency("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.11.0")
+        dependency("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:1.11.0")
+    }
 }
 
 repositories {
@@ -96,47 +106,51 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     implementation("org.springframework.cloud:spring-cloud-gateway-mvc:4.3.4")
     implementation("org.springframework.kafka:spring-kafka")
+    // Spring Boot 4 split several pieces out of spring-boot / spring-boot-autoconfigure into
+    // dedicated modules that are no longer pulled transitively by the web starter.
+    implementation("org.springframework.boot:spring-boot-restclient:$springBootVersion")
+    implementation("org.springframework.boot:spring-boot-kafka:$springBootVersion")
 
     // Kotlin
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
     api("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
 
     // HTTP client
-    implementation("io.ktor:ktor-client-core-jvm:3.4.3")
-    implementation("io.ktor:ktor-client-java-jvm:3.4.3")
-    implementation("io.ktor:ktor-client-content-negotiation-jvm:3.4.3")
-    implementation("io.ktor:ktor-serialization-kotlinx-json-jvm:3.4.3")
+    implementation("io.ktor:ktor-client-core-jvm:3.5.0")
+    implementation("io.ktor:ktor-client-java-jvm:3.5.0")
+    implementation("io.ktor:ktor-client-content-negotiation-jvm:3.5.0")
+    implementation("io.ktor:ktor-serialization-kotlinx-json-jvm:3.5.0")
 
     // Data / persistence
-    implementation("org.flywaydb:flyway-core:11.18.0")
-    implementation("org.flywaydb:flyway-database-postgresql:11.18.0")
+    implementation("org.flywaydb:flyway-core:12.5.0")
+    implementation("org.flywaydb:flyway-database-postgresql:12.5.0")
     implementation("org.hibernate.validator:hibernate-validator:8.0.2.Final")
-    implementation("org.hibernate:hibernate-spatial:7.3.2.Final")
+    implementation("org.hibernate:hibernate-spatial:7.3.6.Final")
     implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.15.2")
     api("org.locationtech.jts:jts-core:1.20.0")
     implementation("org.n52.jackson:jackson-datatype-jts:2.0.0")
-    implementation("org.locationtech.proj4j:proj4j:1.4.1")
-    implementation("org.locationtech.proj4j:proj4j-epsg:1.4.1")
-    runtimeOnly("org.postgresql:postgresql:42.7.10")
+    implementation("org.locationtech.proj4j:proj4j:1.4.2")
+    implementation("org.locationtech.proj4j:proj4j-epsg:1.4.2")
+    runtimeOnly("org.postgresql:postgresql:42.7.11")
 
     // Serialization / API
-    api("com.fasterxml.jackson.module:jackson-module-kotlin:2.21.2")
+    api("com.fasterxml.jackson.module:jackson-module-kotlin:2.21.3")
     implementation("jakarta.validation:jakarta.validation-api:3.1.1")
-    api("org.springdoc:springdoc-openapi-ui:1.8.0")
+    api("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3")
 
     // Utilities
     api("com.neovisionaries:nv-i18n:1.29")
-    implementation("com.github.ben-manes.caffeine:caffeine:3.2.3")
-    implementation("io.sentry:sentry:8.40.0")
-    implementation("io.sentry:sentry-log4j2:8.40.0")
+    implementation("com.github.ben-manes.caffeine:caffeine:3.2.4")
+    implementation("io.sentry:sentry:8.42.0")
+    implementation("io.sentry:sentry-log4j2:8.42.0")
 
     // Runtime
     runtimeOnly("org.springframework.boot:spring-boot-devtools:$springBootVersion")
 
     // Test
-    testImplementation("io.ktor:ktor-client-mock-jvm:3.4.3")
+    testImplementation("io.ktor:ktor-client-mock-jvm:3.5.0")
     testImplementation("org.springframework.kafka:spring-kafka-test") {
         exclude(group = "ch.qos.logback", module = "logback-classic")
     }
@@ -150,6 +164,7 @@ dependencies {
     testImplementation("jakarta.servlet:jakarta.servlet-api:6.1.0")
     testImplementation("com.squareup.okhttp3:mockwebserver:5.3.2")
     testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
+    testImplementation("org.springframework.boot:spring-boot-webmvc-test:$springBootVersion")
     testImplementation("org.springframework.security:spring-security-test:$springSecurityVersion")
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc:3.0.5")
 }

--- a/backend/gradle/wrapper/gradle-wrapper.properties
+++ b/backend/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,9 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
+retries=0
+retryBackOffMs=500
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/config/AJPConfig.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/config/AJPConfig.kt
@@ -3,7 +3,7 @@ package fr.gouv.cnsp.monitorfish.config
 import org.apache.catalina.connector.Connector
 import org.apache.coyote.ajp.AbstractAjpProtocol
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory
 import org.springframework.boot.web.server.WebServerFactoryCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -15,14 +15,12 @@ class AJPConfig {
     private val AJPProperties: AJPProperties? = null
 
     @Bean
-    fun servletContainer(): WebServerFactoryCustomizer<TomcatServletWebServerFactory?>? =
-        WebServerFactoryCustomizer { server: TomcatServletWebServerFactory? ->
-            if (server is TomcatServletWebServerFactory) {
-                server.addAdditionalTomcatConnectors(redirectConnector())
-            }
+    fun servletContainer(): WebServerFactoryCustomizer<TomcatServletWebServerFactory> =
+        WebServerFactoryCustomizer { server: TomcatServletWebServerFactory ->
+            server.addAdditionalConnectors(redirectConnector())
         }
 
-    private fun redirectConnector(): Connector? {
+    private fun redirectConnector(): Connector {
         val connector = Connector("AJP/1.3")
         connector.scheme = "http"
         connector.port = AJPProperties?.port?.toInt() ?: 8000

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/config/AuthenticationPrincipalResolverConfig.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/config/AuthenticationPrincipalResolverConfig.kt
@@ -1,0 +1,22 @@
+package fr.gouv.cnsp.monitorfish.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+/**
+ * Registers Spring Security's [AuthenticationPrincipalArgumentResolver] so that controller parameters
+ * annotated with `@AuthenticationPrincipal` (e.g. `OidcUser`) are resolved.
+ *
+ * In the full application this resolver is also contributed by `@EnableWebSecurity`, but it is not
+ * auto-registered in `@WebMvcTest` slices under Spring Boot 4 / Spring Security 7. Declaring it through a
+ * [WebMvcConfigurer] makes it available in both the full context and the test slices (duplicate
+ * registration is harmless: the first matching resolver wins).
+ */
+@Configuration
+class AuthenticationPrincipalResolverConfig : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(AuthenticationPrincipalArgumentResolver())
+    }
+}

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/config/KafkaAisConsumerConfig.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/config/KafkaAisConsumerConfig.kt
@@ -4,7 +4,7 @@ import fr.gouv.cnsp.monitorfish.infrastructure.kafka.AisPositionMessage
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.boot.autoconfigure.kafka.KafkaProperties
+import org.springframework.boot.kafka.autoconfigure.KafkaProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.kafka.annotation.EnableKafka
@@ -52,7 +52,7 @@ class KafkaAisConsumerConfig(
         val factory = ConcurrentKafkaListenerContainerFactory<String, AisPositionMessage>()
         factory.setConsumerFactory(consumerFactory())
         factory.setCommonErrorHandler(errorHandler())
-        factory.isBatchListener = true
+        factory.setBatchListener(true)
         factory.containerProperties.idleBetweenPolls = kafkaAisProperties.idleBetweenPolls
         return factory
     }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/config/RestTemplateConfig.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/config/RestTemplateConfig.kt
@@ -2,7 +2,7 @@ package fr.gouv.cnsp.monitorfish.config
 
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.boot.restclient.RestTemplateBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.client.ClientHttpRequestInterceptor
@@ -47,7 +47,7 @@ class RestTemplateConfig {
 
         val restTemplate =
             restTemplateBuilder
-                .requestFactoryBuilder { requestFactory }
+                .requestFactory { requestFactory }
                 .build()
 
         restTemplate.interceptors.add(

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/config/SecurityConfig.kt
@@ -256,8 +256,7 @@ class SecurityConfig(
                         .logoutSuccessHandler(oidcLogoutSuccessHandler())
                         .logoutRequestMatcher(
                             PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.GET, "/logout"),
-                        )
-                        .invalidateHttpSession(true)
+                        ).invalidateHttpSession(true)
                         .clearAuthentication(true)
                         .deleteCookies("JSESSIONID")
                 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/config/SecurityConfig.kt
@@ -31,7 +31,7 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher
 import org.springframework.web.client.RestTemplate
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
@@ -254,7 +254,9 @@ class SecurityConfig(
                 }.logout { logout ->
                     logout
                         .logoutSuccessHandler(oidcLogoutSuccessHandler())
-                        .logoutRequestMatcher(AntPathRequestMatcher("/logout", "GET"))
+                        .logoutRequestMatcher(
+                            PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.GET, "/logout"),
+                        )
                         .invalidateHttpSession(true)
                         .clearAuthentication(true)
                         .deleteCookies("JSESSIONID")

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationController.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationController.kt
@@ -315,10 +315,10 @@ class PriorNotificationController(
         @PathParam("Logbook message `reportId`")
         @PathVariable(name = "reportId")
         reportId: String,
-    ): ResponseEntity<ByteArray?> {
+    ): ResponseEntity<ByteArray> {
         val pdfDocument =
             getPriorNotificationPdfDocument.execute(reportId = reportId, isVerifyingExistence = false)
-                ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null)
+                ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
 
         val fileName = "preavis_debarquement_${pdfDocument.generationDatetimeUtc.format(ISO_DATE_TIME)}.pdf"
         val headers =

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/development/KeycloakProxyController.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/development/KeycloakProxyController.kt
@@ -61,7 +61,7 @@ class KeycloakProxyController(
     @GetMapping("/realms/**")
     @Throws(Exception::class)
     fun get(
-        proxy: ProxyExchange<ByteArray?>,
+        proxy: ProxyExchange<ByteArray>,
         request: HttpServletRequest,
     ): ResponseEntity<*> {
         val targetUri = StringBuilder("${oidcProperties.proxyUrl}${request.requestURI}?${request.queryString}")
@@ -111,7 +111,7 @@ class KeycloakProxyController(
     @GetMapping("/resources/**")
     @Throws(Exception::class)
     fun getResources(
-        proxy: ProxyExchange<ByteArray?>,
+        proxy: ProxyExchange<ByteArray>,
         request: HttpServletRequest,
         response: HttpServletResponse,
     ): Void? {
@@ -167,7 +167,7 @@ class KeycloakProxyController(
     )
     @Throws(Exception::class)
     fun post(
-        proxy: ProxyExchange<ByteArray?>,
+        proxy: ProxyExchange<ByteArray>,
         request: HttpServletRequest,
     ): ResponseEntity<*> {
         val params = request.parameterMap

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/development/KeycloakProxyController.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/development/KeycloakProxyController.kt
@@ -130,7 +130,7 @@ class KeycloakProxyController(
         response.status = cleanedResponse.statusCode.value()
 
         // Copy headers, excluding problematic ones that cause chunked encoding issues
-        cleanedResponse.headers.forEach { (name, values) ->
+        cleanedResponse.headers.forEach { name, values ->
             if (name.lowercase() !in
                 setOf(
                     "transfer-encoding",
@@ -230,7 +230,7 @@ class KeycloakProxyController(
     private fun removeCorsHeader(response: ResponseEntity<*>): ResponseEntity<*> {
         // In Spring Boot 3.4+, headers are ReadOnlyHttpHeaders and cannot be modified
         // We need to create a new ResponseEntity with filtered headers
-        val newHeaders = response.headers.toMutableMap()
+        val newHeaders = response.headers.asMultiValueMap().toMutableMap()
         newHeaders.remove("Access-Control-Allow-Origin")
 
         return ResponseEntity
@@ -271,7 +271,7 @@ class KeycloakProxyController(
             val rewrittenBody = rewrittenHtml.toByteArray(StandardCharsets.UTF_8)
 
             // Create new headers without Content-Length (Spring will set it automatically)
-            val newHeaders = response.headers.toMutableMap()
+            val newHeaders = response.headers.asMultiValueMap().toMutableMap()
             newHeaders.remove("Content-Length")
 
             return ResponseEntity

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/log/LogResponseWithBody.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/log/LogResponseWithBody.kt
@@ -17,7 +17,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
 @ControllerAdvice
 class LogResponseWithBody(
     val mapper: ObjectMapper,
-) : ResponseBodyAdvice<Any?> {
+) : ResponseBodyAdvice<Any> {
     private val logger = LoggerFactory.getLogger(LogGETRequests::class.java)
 
     override fun supports(

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/SpaController.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/SpaController.kt
@@ -4,7 +4,7 @@ import jakarta.servlet.RequestDispatcher
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
-import org.springframework.boot.web.servlet.error.ErrorController
+import org.springframework.boot.webmvc.error.ErrorController
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/VersionController.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/VersionController.kt
@@ -11,7 +11,7 @@ class VersionController(
     @GetMapping("/version")
     fun version(): Map<String, String> =
         mapOf(
-            "version" to buildProperties.version,
-            "commit" to buildProperties.get("commit.hash"),
+            "version" to (buildProperties.version ?: ""),
+            "commit" to (buildProperties.get("commit.hash") ?: ""),
         )
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/security/BffFilterConfig.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/security/BffFilterConfig.kt
@@ -20,18 +20,21 @@ class BffFilterConfig(
 
     @Bean(name = ["userAuthorizationCheckFilter"])
     fun userAuthorizationCheckFilter(): FilterRegistrationBean<UserAuthorizationCheckFilter> {
-        val registrationBean = FilterRegistrationBean<UserAuthorizationCheckFilter>()
+        val registrationBean =
+            FilterRegistrationBean(
+                UserAuthorizationCheckFilter(
+                    oidcProperties = oidcProperties,
+                    protectedPathsAPIProperties = protectedPathsAPIProperties,
+                    getIsAuthorizedUser = getIsAuthorizedUser,
+                ),
+            )
 
         registrationBean.order = USER_AUTH_FILTER_PRECEDENCE
-        registrationBean.filter =
-            UserAuthorizationCheckFilter(
-                oidcProperties = oidcProperties,
-                protectedPathsAPIProperties = protectedPathsAPIProperties,
-                getIsAuthorizedUser = getIsAuthorizedUser,
-            )
-        registrationBean.urlPatterns = protectedPathsAPIProperties.paths
 
-        if (registrationBean.urlPatterns == null) {
+        val paths = protectedPathsAPIProperties.paths
+        if (paths != null) {
+            registrationBean.setUrlPatterns(paths)
+        } else {
             logger.warn(
                 "WARNING: No user authentication path given." +
                     "See `monitorfish.api.protected.paths` application property.",
@@ -46,15 +49,19 @@ class BffFilterConfig(
 
     @Bean(name = ["publicPathsApiKeyCheckFilter"])
     fun publicPathsApiKeyCheckFilter(): FilterRegistrationBean<ApiKeyCheckFilter> {
-        val registrationBean = FilterRegistrationBean<ApiKeyCheckFilter>()
+        val registrationBean =
+            FilterRegistrationBean(
+                ApiKeyCheckFilter(
+                    protectedPathsAPIProperties,
+                ),
+            )
 
         registrationBean.order = API_KEY_FILTER_PRECEDENCE
-        registrationBean.filter =
-            ApiKeyCheckFilter(
-                protectedPathsAPIProperties,
-            )
-        registrationBean.urlPatterns = protectedPathsAPIProperties.publicPaths
-        if (registrationBean.urlPatterns == null) {
+
+        val publicPaths = protectedPathsAPIProperties.publicPaths
+        if (publicPaths != null) {
+            registrationBean.setUrlPatterns(publicPaths)
+        } else {
             logger.warn(
                 "WARNING: Public paths are not protected." +
                     "See `monitorfish.api.protected.public-paths` application property.",

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/LogbookReportEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/LogbookReportEntity.kt
@@ -9,7 +9,7 @@ import io.hypersistence.utils.hibernate.type.json.JsonBinaryType
 import jakarta.persistence.*
 import org.hibernate.annotations.JdbcType
 import org.hibernate.annotations.Type
-import org.hibernate.dialect.PostgreSQLEnumJdbcType
+import org.hibernate.dialect.type.PostgreSQLEnumJdbcType
 import java.time.Instant
 import java.time.ZoneOffset.UTC
 

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/MissionActionEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/MissionActionEntity.kt
@@ -9,7 +9,7 @@ import io.hypersistence.utils.hibernate.type.json.JsonBinaryType
 import jakarta.persistence.*
 import org.hibernate.annotations.JdbcType
 import org.hibernate.annotations.Type
-import org.hibernate.dialect.PostgreSQLEnumJdbcType
+import org.hibernate.dialect.type.PostgreSQLEnumJdbcType
 import java.time.Instant
 import java.time.ZoneOffset
 

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/PendingAlertEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/PendingAlertEntity.kt
@@ -10,7 +10,7 @@ import io.hypersistence.utils.hibernate.type.json.JsonBinaryType
 import jakarta.persistence.*
 import org.hibernate.annotations.JdbcType
 import org.hibernate.annotations.Type
-import org.hibernate.dialect.PostgreSQLEnumJdbcType
+import org.hibernate.dialect.type.PostgreSQLEnumJdbcType
 import java.time.ZonedDateTime
 
 @Entity

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/PriorNotificationPdfDocumentEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/PriorNotificationPdfDocumentEntity.kt
@@ -4,7 +4,7 @@ import fr.gouv.cnsp.monitorfish.domain.entities.prior_notification.PdfDocument
 import fr.gouv.cnsp.monitorfish.domain.entities.prior_notification.PriorNotificationSource
 import jakarta.persistence.*
 import org.hibernate.annotations.JdbcType
-import org.hibernate.dialect.PostgreSQLEnumJdbcType
+import org.hibernate.dialect.type.PostgreSQLEnumJdbcType
 import org.hibernate.type.descriptor.jdbc.BinaryJdbcType
 import java.time.ZonedDateTime
 

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/ReportingEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/ReportingEntity.kt
@@ -13,7 +13,7 @@ import io.hypersistence.utils.hibernate.type.json.JsonBinaryType
 import jakarta.persistence.*
 import org.hibernate.annotations.JdbcType
 import org.hibernate.annotations.Type
-import org.hibernate.dialect.PostgreSQLEnumJdbcType
+import org.hibernate.dialect.type.PostgreSQLEnumJdbcType
 import java.time.ZonedDateTime
 
 @Entity

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/SilencedAlertEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/entities/SilencedAlertEntity.kt
@@ -11,7 +11,7 @@ import io.hypersistence.utils.hibernate.type.json.JsonBinaryType
 import jakarta.persistence.*
 import org.hibernate.annotations.JdbcType
 import org.hibernate.annotations.Type
-import org.hibernate.dialect.PostgreSQLEnumJdbcType
+import org.hibernate.dialect.type.PostgreSQLEnumJdbcType
 import java.time.ZonedDateTime
 
 @Entity

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaLogbookReportRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaLogbookReportRepository.kt
@@ -23,7 +23,7 @@ import org.springframework.cache.annotation.Cacheable
 import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.stereotype.Repository
-import java.sql.Timestamp
+import java.time.LocalDateTime
 import java.time.ZoneOffset.UTC
 import java.time.ZonedDateTime
 
@@ -139,10 +139,10 @@ class JpaLogbookReportRepository(
             dbLogbookReportRepository.findAllTrips(internalReferenceNumber).map {
                 VoyageDatesAndTripNumber(
                     tripNumber = it[0] as String,
-                    startDateTime = (it[1] as Timestamp).toInstant().atZone(UTC),
-                    endDateTime = (it[2] as Timestamp).toInstant().atZone(UTC),
-                    firstOperationDateTime = (it[3] as Timestamp).toInstant().atZone(UTC),
-                    lastOperationDateTime = (it[4] as Timestamp).toInstant().atZone(UTC),
+                    startDateTime = (it[1] as LocalDateTime).atZone(UTC),
+                    endDateTime = (it[2] as LocalDateTime).atZone(UTC),
+                    firstOperationDateTime = (it[3] as LocalDateTime).atZone(UTC),
+                    lastOperationDateTime = (it[4] as LocalDateTime).atZone(UTC),
                 )
             }
         } catch (e: RuntimeException) {
@@ -213,7 +213,7 @@ class JpaLogbookReportRepository(
         }
 
         return dbLogbookReportRepository.getActiveTrips(cfrs.joinToString(",")).associate { row ->
-            (row[0] as String) to (row[1] as Timestamp).toInstant().atZone(UTC)
+            (row[0] as String) to (row[1] as LocalDateTime).atZone(UTC)
         }
     }
 

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/interfaces/DBLastPositionRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/interfaces/DBLastPositionRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
+import java.time.LocalDateTime
 import java.time.ZonedDateTime
 
 @DynamicUpdate
@@ -23,7 +23,7 @@ interface DBLastPositionRepository : JpaRepository<LastPositionEntity, Int> {
         "select last_position_datetime_utc from last_positions where last_position_datetime_utc < now() order by last_position_datetime_utc desc limit 1",
         nativeQuery = true,
     )
-    fun findLastPositionDateTime(): Instant
+    fun findLastPositionDateTime(): LocalDateTime
 
     @Query(
         """

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/interfaces/DBLogbookReportRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/interfaces/DBLogbookReportRepository.kt
@@ -5,7 +5,7 @@ import org.hibernate.annotations.DynamicUpdate
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
-import java.time.Instant
+import java.time.LocalDateTime
 import java.time.ZonedDateTime
 
 @DynamicUpdate
@@ -147,7 +147,7 @@ interface DBLogbookReportRepository :
         """,
         nativeQuery = true,
     )
-    fun findLastOperationDateTime(): Instant
+    fun findLastOperationDateTime(): LocalDateTime
 
     @Query(
         """

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/interfaces/DBPositionRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/interfaces/DBPositionRepository.kt
@@ -3,7 +3,7 @@ package fr.gouv.cnsp.monitorfish.infrastructure.database.repositories.interfaces
 import fr.gouv.cnsp.monitorfish.infrastructure.database.entities.PositionEntity
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
-import java.time.Instant
+import java.time.LocalDateTime
 import java.time.ZonedDateTime
 
 interface DBPositionRepository : CrudRepository<PositionEntity, Long> {
@@ -123,5 +123,5 @@ interface DBPositionRepository : CrudRepository<PositionEntity, Long> {
         """,
         nativeQuery = true,
     )
-    fun findLastPositionDateTime(): Instant
+    fun findLastPositionDateTime(): LocalDateTime
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -59,6 +59,11 @@ logging:
         org.springframework.security.web.authentication.logout: DEBUG
 
 spring:
+    # The application's API contract relies on the Jackson 2 ObjectMapper (see MapperConfiguration).
+    # Spring Boot 4 defaults to Jackson 3 for HTTP message conversion, so opt back into Jackson 2.
+    http:
+        converters:
+            preferred-json-mapper: jackson2
     threads:
         virtual:
             enabled: false

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ActivityVisualizationControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ActivityVisualizationControllerITests.kt
@@ -1,13 +1,14 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.use_cases.activity.GetActivityVisualizationFile
 import fr.gouv.cnsp.monitorfish.infrastructure.api.ControllersExceptionHandler
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
@@ -15,7 +16,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(SentryConfig::class, ControllersExceptionHandler::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class, ControllersExceptionHandler::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [ActivityVisualizationController::class])
 class ActivityVisualizationControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ActivityVisualizationControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ActivityVisualizationControllerITests.kt
@@ -17,7 +17,10 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class, ControllersExceptionHandler::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+    ControllersExceptionHandler::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [ActivityVisualizationController::class])
 class ActivityVisualizationControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/BeaconMalfunctionControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/BeaconMalfunctionControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
@@ -20,8 +21,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -31,7 +32,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.ZonedDateTime
 
-@Import(SentryConfig::class, ControllersExceptionHandler::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class, ControllersExceptionHandler::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [BeaconMalfunctionController::class])
 class BeaconMalfunctionControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/BeaconMalfunctionControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/BeaconMalfunctionControllerITests.kt
@@ -1,11 +1,11 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.verify
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.CommunicationMeans
 import fr.gouv.cnsp.monitorfish.domain.entities.beacon_malfunctions.*
@@ -33,7 +33,10 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.ZonedDateTime
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class, ControllersExceptionHandler::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+    ControllersExceptionHandler::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [BeaconMalfunctionController::class])
 class BeaconMalfunctionControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ControlObjectiveAdminControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ControlObjectiveAdminControllerITests.kt
@@ -1,7 +1,7 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.control_objective.ControlObjective
 import fr.gouv.cnsp.monitorfish.domain.use_cases.control_objective.*
@@ -22,7 +22,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(ControlObjectiveAdminController::class)])
 class ControlObjectiveAdminControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ControlObjectiveAdminControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ControlObjectiveAdminControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.control_objective.ControlObjective
@@ -10,8 +11,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -20,7 +21,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(ControlObjectiveAdminController::class)])
 class ControlObjectiveAdminControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/DataReferentialControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/DataReferentialControllerITests.kt
@@ -1,7 +1,7 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.fleet_segment.ScipSpeciesType
 import fr.gouv.cnsp.monitorfish.domain.entities.gear.Gear
@@ -24,7 +24,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(DataReferentialController::class)])
 class DataReferentialControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/DataReferentialControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/DataReferentialControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.fleet_segment.ScipSpeciesType
@@ -13,8 +14,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
@@ -22,7 +23,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(DataReferentialController::class)])
 class DataReferentialControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/DistrictControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/DistrictControllerITests.kt
@@ -18,7 +18,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(DistrictController::class)])
 class DistrictControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/DistrictControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/DistrictControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.district.District
 import fr.gouv.cnsp.monitorfish.domain.use_cases.district.GetAllDistricts
@@ -7,8 +8,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
@@ -16,7 +17,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(DistrictController::class)])
 class DistrictControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/FaoAreaControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/FaoAreaControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.verify
@@ -10,8 +11,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
@@ -19,7 +20,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(FaoAreaController::class)])
 class FaoAreaControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/FaoAreaControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/FaoAreaControllerITests.kt
@@ -1,9 +1,9 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.verify
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.use_cases.fao_areas.ComputeVesselFaoAreas
 import fr.gouv.cnsp.monitorfish.domain.use_cases.fao_areas.GetFaoAreas
@@ -21,7 +21,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(FaoAreaController::class)])
 class FaoAreaControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/FleetSegmentAdminControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/FleetSegmentAdminControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.any
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
@@ -10,8 +11,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -20,7 +21,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(FleetSegmentAdminController::class)])
 class FleetSegmentAdminControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/FleetSegmentAdminControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/FleetSegmentAdminControllerITests.kt
@@ -1,8 +1,8 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.any
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.fleet_segment.FleetSegment
 import fr.gouv.cnsp.monitorfish.domain.use_cases.fleet_segment.*
@@ -22,7 +22,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(FleetSegmentAdminController::class)])
 class FleetSegmentAdminControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/FleetSegmentControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/FleetSegmentControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.any
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
@@ -13,8 +14,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -24,7 +25,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(FleetSegmentController::class)])
 class FleetSegmentControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/FleetSegmentControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/FleetSegmentControllerITests.kt
@@ -1,8 +1,8 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.any
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.fleet_segment.FleetSegment
 import fr.gouv.cnsp.monitorfish.domain.use_cases.fleet_segment.ComputeFleetSegmentsFromControl
@@ -26,7 +26,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(FleetSegmentController::class)])
 class FleetSegmentControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ForeignFMCsControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ForeignFMCsControllerITests.kt
@@ -18,7 +18,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(ForeignFMCsController::class)])
 class ForeignFMCsControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ForeignFMCsControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ForeignFMCsControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.beacon_malfunctions.ForeignFMC
 import fr.gouv.cnsp.monitorfish.domain.use_cases.beacon_malfunction.GetAllForeignFMCs
@@ -7,8 +8,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
@@ -16,7 +17,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(ForeignFMCsController::class)])
 class ForeignFMCsControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/MissionActionsControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/MissionActionsControllerITests.kt
@@ -1,9 +1,9 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.neovisionaries.i18n.CountryCode
 import com.nhaarman.mockitokotlin2.*
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.control_unit.LegacyControlUnit
 import fr.gouv.cnsp.monitorfish.domain.entities.mission.mission_actions.*
@@ -35,7 +35,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.ZonedDateTime
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(MissionActionsController::class)])
 class MissionActionsControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/MissionActionsControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/MissionActionsControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.neovisionaries.i18n.CountryCode
 import com.nhaarman.mockitokotlin2.*
@@ -22,8 +23,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -33,7 +34,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.ZonedDateTime
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(MissionActionsController::class)])
 class MissionActionsControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/MissionsControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/MissionsControllerITests.kt
@@ -1,10 +1,10 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.neovisionaries.i18n.CountryCode
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.mission.Mission
 import fr.gouv.cnsp.monitorfish.domain.entities.mission.MissionAndActions
@@ -33,7 +33,9 @@ import java.time.ZoneOffset
 import java.time.ZonedDateTime
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(MissionController::class)])
 class MissionsControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/MissionsControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/MissionsControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.neovisionaries.i18n.CountryCode
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
@@ -20,8 +21,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
@@ -31,7 +32,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(MissionController::class)])
 class MissionsControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PendingAlertControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PendingAlertControllerITests.kt
@@ -22,8 +22,8 @@ import org.hamcrest.Matchers
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PortControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PortControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.use_cases.port.GetActivePorts
 import fr.gouv.cnsp.monitorfish.fakers.PortFaker
@@ -7,8 +8,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
@@ -16,7 +17,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(PortController::class)])
 class PortControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PortControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PortControllerITests.kt
@@ -18,7 +18,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(PortController::class)])
 class PortControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PositionAlertSpecificationControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PositionAlertSpecificationControllerITests.kt
@@ -2,6 +2,8 @@ package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.*
+import fr.gouv.cnsp.monitorfish.config.OIDCProperties
+import fr.gouv.cnsp.monitorfish.config.SecurityConfig
 import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.domain.use_cases.alert.*
 import fr.gouv.cnsp.monitorfish.domain.use_cases.authorization.GetIsAuthorizedUser
@@ -20,7 +22,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(MapperConfiguration::class)
+@Import(
+    SecurityConfig::class,
+    OIDCProperties::class,MapperConfiguration::class)
 @WebMvcTest(value = [PositionAlertSpecificationController::class])
 class PositionAlertSpecificationControllerITests {
     @Autowired

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PositionAlertSpecificationControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PositionAlertSpecificationControllerITests.kt
@@ -2,9 +2,9 @@ package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.*
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.OIDCProperties
 import fr.gouv.cnsp.monitorfish.config.SecurityConfig
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.domain.use_cases.alert.*
 import fr.gouv.cnsp.monitorfish.domain.use_cases.authorization.GetIsAuthorizedUser
 import fr.gouv.cnsp.monitorfish.infrastructure.api.bff.TestUtils.DUMMY_POSITION_ALERT
@@ -24,7 +24,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
     SecurityConfig::class,
-    OIDCProperties::class,MapperConfiguration::class)
+    OIDCProperties::class,
+    MapperConfiguration::class,
+)
 @WebMvcTest(value = [PositionAlertSpecificationController::class])
 class PositionAlertSpecificationControllerITests {
     @Autowired

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PositionAlertSpecificationControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PositionAlertSpecificationControllerITests.kt
@@ -9,7 +9,7 @@ import fr.gouv.cnsp.monitorfish.infrastructure.api.bff.TestUtils.DUMMY_POSITION_
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationControllerUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationControllerUTests.kt
@@ -3,9 +3,9 @@ package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.OIDCProperties
 import fr.gouv.cnsp.monitorfish.config.SecurityConfig
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.facade.SeafrontGroup
 import fr.gouv.cnsp.monitorfish.domain.entities.logbook.LogbookMessageAndValue

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationControllerUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationControllerUTests.kt
@@ -1,9 +1,11 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
+import fr.gouv.cnsp.monitorfish.config.OIDCProperties
+import fr.gouv.cnsp.monitorfish.config.SecurityConfig
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.facade.SeafrontGroup
 import fr.gouv.cnsp.monitorfish.domain.entities.logbook.LogbookMessageAndValue
@@ -34,7 +36,11 @@ import java.time.ZonedDateTime
 import kotlin.text.Charsets.UTF_8
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    SecurityConfig::class,
+    OIDCProperties::class,
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @WebMvcTest(value = [(PriorNotificationController::class)])
 class PriorNotificationControllerUTests {
     @Autowired

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationControllerUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationControllerUTests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
@@ -20,7 +21,7 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
@@ -32,7 +33,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import java.time.ZonedDateTime
 import kotlin.text.Charsets.UTF_8
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @WebMvcTest(value = [(PriorNotificationController::class)])
 class PriorNotificationControllerUTests {
     @Autowired

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationSubscriberControllerUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationSubscriberControllerUTests.kt
@@ -1,8 +1,8 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.any
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.use_cases.prior_notification.*
 import fr.gouv.cnsp.monitorfish.domain.use_cases.prior_notification.dtos.PriorNotificationSubscriber
@@ -22,7 +22,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(PriorNotificationSubscriberController::class)])
 class PriorNotificationSubscriberControllerUTests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationSubscriberControllerUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/PriorNotificationSubscriberControllerUTests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.any
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
@@ -11,8 +12,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -20,7 +21,8 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(PriorNotificationSubscriberController::class)])
 class PriorNotificationSubscriberControllerUTests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ProducerOrganizationMembershipControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ProducerOrganizationMembershipControllerITests.kt
@@ -1,8 +1,8 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.whenever
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.producer_organization.ProducerOrganizationMembership
 import fr.gouv.cnsp.monitorfish.domain.use_cases.producer_organization_membership.GetAllProducerOrganizationMemberships
@@ -21,7 +21,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(ProducerOrganizationMembershipController::class)
 class ProducerOrganizationMembershipControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ProducerOrganizationMembershipControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ProducerOrganizationMembershipControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.whenever
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
@@ -9,8 +10,8 @@ import fr.gouv.cnsp.monitorfish.domain.use_cases.producer_organization_membershi
 import fr.gouv.cnsp.monitorfish.domain.use_cases.producer_organization_membership.SetProducerOrganizationMemberships
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -19,7 +20,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(ProducerOrganizationMembershipController::class)
 class ProducerOrganizationMembershipControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ReportingControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ReportingControllerITests.kt
@@ -7,6 +7,8 @@ import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.given
 import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
+import fr.gouv.cnsp.monitorfish.config.OIDCProperties
+import fr.gouv.cnsp.monitorfish.config.SecurityConfig
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.control_unit.LegacyControlUnit
 import fr.gouv.cnsp.monitorfish.domain.entities.reporting.InfractionSuspicionThreat
@@ -36,7 +38,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.ZonedDateTime
 
-@Import(SentryConfig::class, MapperConfiguration::class)
+@Import(SentryConfig::class, MapperConfiguration::class, SecurityConfig::class, OIDCProperties::class)
 @WebMvcTest(value = [ReportingController::class])
 class ReportingControllerITests {
     @Autowired

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ReportingControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/ReportingControllerITests.kt
@@ -24,7 +24,7 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/UserAuthorizationControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/UserAuthorizationControllerITests.kt
@@ -2,9 +2,9 @@ package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.OIDCProperties
 import fr.gouv.cnsp.monitorfish.config.SecurityConfig
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.domain.entities.authorization.AuthorizedUser
 import fr.gouv.cnsp.monitorfish.domain.use_cases.authorization.GetAuthorizedUser
 import org.hamcrest.CoreMatchers.equalTo
@@ -21,7 +21,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
     SecurityConfig::class,
-    OIDCProperties::class,MapperConfiguration::class)
+    OIDCProperties::class,
+    MapperConfiguration::class,
+)
 @WebMvcTest(value = [(UserAuthorizationController::class)])
 class UserAuthorizationControllerITests {
     @Autowired

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/UserAuthorizationControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/UserAuthorizationControllerITests.kt
@@ -3,11 +3,13 @@ package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.given
 import fr.gouv.cnsp.monitorfish.domain.entities.authorization.AuthorizedUser
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.domain.use_cases.authorization.GetAuthorizedUser
 import org.hamcrest.CoreMatchers.equalTo
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
@@ -15,6 +17,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
+@Import(MapperConfiguration::class)
 @WebMvcTest(value = [(UserAuthorizationController::class)])
 class UserAuthorizationControllerITests {
     @Autowired

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/UserAuthorizationControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/UserAuthorizationControllerITests.kt
@@ -2,8 +2,10 @@ package fr.gouv.cnsp.monitorfish.infrastructure.api.bff
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.given
-import fr.gouv.cnsp.monitorfish.domain.entities.authorization.AuthorizedUser
+import fr.gouv.cnsp.monitorfish.config.OIDCProperties
+import fr.gouv.cnsp.monitorfish.config.SecurityConfig
 import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
+import fr.gouv.cnsp.monitorfish.domain.entities.authorization.AuthorizedUser
 import fr.gouv.cnsp.monitorfish.domain.use_cases.authorization.GetAuthorizedUser
 import org.hamcrest.CoreMatchers.equalTo
 import org.junit.jupiter.api.Test
@@ -17,7 +19,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(MapperConfiguration::class)
+@Import(
+    SecurityConfig::class,
+    OIDCProperties::class,MapperConfiguration::class)
 @WebMvcTest(value = [(UserAuthorizationController::class)])
 class UserAuthorizationControllerITests {
     @Autowired

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/VesselControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/VesselControllerITests.kt
@@ -5,9 +5,9 @@ import com.neovisionaries.i18n.CountryCode
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.OIDCProperties
 import fr.gouv.cnsp.monitorfish.config.SecurityConfig
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.domain.entities.alerts.type.AlertType
 import fr.gouv.cnsp.monitorfish.domain.entities.beacon_malfunctions.*
 import fr.gouv.cnsp.monitorfish.domain.entities.facade.Seafront.NAMO
@@ -62,7 +62,9 @@ import java.time.ZonedDateTime
 @WebMvcTest(value = [VesselController::class])
 @Import(
     SecurityConfig::class,
-    OIDCProperties::class,MapperConfiguration::class)
+    OIDCProperties::class,
+    MapperConfiguration::class,
+)
 class VesselControllerITests {
     @Autowired
     private lateinit var api: MockMvc

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/VesselControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/VesselControllerITests.kt
@@ -5,6 +5,8 @@ import com.neovisionaries.i18n.CountryCode
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
+import fr.gouv.cnsp.monitorfish.config.OIDCProperties
+import fr.gouv.cnsp.monitorfish.config.SecurityConfig
 import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.domain.entities.alerts.type.AlertType
 import fr.gouv.cnsp.monitorfish.domain.entities.beacon_malfunctions.*
@@ -58,7 +60,9 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 
 @WebMvcTest(value = [VesselController::class])
-@Import(MapperConfiguration::class)
+@Import(
+    SecurityConfig::class,
+    OIDCProperties::class,MapperConfiguration::class)
 class VesselControllerITests {
     @Autowired
     private lateinit var api: MockMvc

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/VesselControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/VesselControllerITests.kt
@@ -40,7 +40,7 @@ import org.mockito.BDDMockito
 import org.mockito.BDDMockito.given
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/VesselGroupControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/VesselGroupControllerITests.kt
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.neovisionaries.i18n.CountryCode
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.OIDCProperties
 import fr.gouv.cnsp.monitorfish.config.SecurityConfig
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.domain.entities.vessel.VesselIdentifier
 import fr.gouv.cnsp.monitorfish.domain.entities.vessel_group.*
 import fr.gouv.cnsp.monitorfish.domain.use_cases.TestUtils.getCreateOrUpdateDynamicVesselGroupCommands
@@ -34,7 +34,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
     SecurityConfig::class,
-    OIDCProperties::class,MapperConfiguration::class)
+    OIDCProperties::class,
+    MapperConfiguration::class,
+)
 @WebMvcTest(value = [(VesselGroupController::class)])
 class VesselGroupControllerITests {
     @Autowired

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/VesselGroupControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/VesselGroupControllerITests.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.neovisionaries.i18n.CountryCode
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cnsp.monitorfish.config.OIDCProperties
+import fr.gouv.cnsp.monitorfish.config.SecurityConfig
 import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.domain.entities.vessel.VesselIdentifier
 import fr.gouv.cnsp.monitorfish.domain.entities.vessel_group.*
@@ -30,7 +32,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(MapperConfiguration::class)
+@Import(
+    SecurityConfig::class,
+    OIDCProperties::class,MapperConfiguration::class)
 @WebMvcTest(value = [(VesselGroupController::class)])
 class VesselGroupControllerITests {
     @Autowired

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/VesselGroupControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/bff/VesselGroupControllerITests.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.neovisionaries.i18n.CountryCode
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.domain.entities.vessel.VesselIdentifier
 import fr.gouv.cnsp.monitorfish.domain.entities.vessel_group.*
 import fr.gouv.cnsp.monitorfish.domain.use_cases.TestUtils.getCreateOrUpdateDynamicVesselGroupCommands
@@ -18,7 +19,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin
@@ -28,6 +30,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
+@Import(MapperConfiguration::class)
 @WebMvcTest(value = [(VesselGroupController::class)])
 class VesselGroupControllerITests {
     @Autowired

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/HealthcheckControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/HealthcheckControllerITests.kt
@@ -19,7 +19,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.ZonedDateTime
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(HealthcheckController::class)])
 class HealthcheckControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/HealthcheckControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/HealthcheckControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.health.Health
 import fr.gouv.cnsp.monitorfish.domain.use_cases.healthcheck.GetHealthcheck
@@ -7,8 +8,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
@@ -17,7 +18,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.ZonedDateTime
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(HealthcheckController::class)])
 class HealthcheckControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/InfractionControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/InfractionControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.infraction.Infraction
 import fr.gouv.cnsp.monitorfish.domain.entities.infraction.InfractionCategory
@@ -10,8 +11,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
@@ -19,7 +20,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(InfractionController::class)])
 class InfractionControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/InfractionControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/InfractionControllerITests.kt
@@ -21,7 +21,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(InfractionController::class)])
 class InfractionControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PositionsControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PositionsControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.exceptions.NAFMessageParsingException
 import fr.gouv.cnsp.monitorfish.domain.use_cases.vessel.ParseAndSavePosition
@@ -8,15 +9,16 @@ import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(PositionsController::class)])
 class PositionsControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PositionsControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PositionsControllerITests.kt
@@ -18,7 +18,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(PositionsController::class)])
 class PositionsControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicBeaconMalfunctionControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicBeaconMalfunctionControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
@@ -16,8 +17,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -27,7 +28,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.ZonedDateTime
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(PublicBeaconMalfunctionController::class)])
 class PublicBeaconMalfunctionControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicBeaconMalfunctionControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicBeaconMalfunctionControllerITests.kt
@@ -1,10 +1,10 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.verify
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.beacon_malfunctions.*
 import fr.gouv.cnsp.monitorfish.domain.entities.vessel.VesselIdentifier
@@ -29,7 +29,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.ZonedDateTime
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(PublicBeaconMalfunctionController::class)])
 class PublicBeaconMalfunctionControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicMissionActionsControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicMissionActionsControllerITests.kt
@@ -1,9 +1,9 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.neovisionaries.i18n.CountryCode
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.given
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.mission.mission_actions.Completion
 import fr.gouv.cnsp.monitorfish.domain.entities.mission.mission_actions.MissionAction
@@ -30,7 +30,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.ZonedDateTime
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(PublicMissionActionsController::class)])
 class PublicMissionActionsControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicMissionActionsControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicMissionActionsControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.neovisionaries.i18n.CountryCode
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.given
@@ -16,8 +17,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -28,7 +29,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.ZonedDateTime
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(PublicMissionActionsController::class)])
 class PublicMissionActionsControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicPendingAlertControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicPendingAlertControllerITests.kt
@@ -14,7 +14,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(PublicOperationalAlertController::class)])
 class PublicPendingAlertControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicPendingAlertControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicPendingAlertControllerITests.kt
@@ -1,18 +1,20 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.use_cases.alert.ValidatePendingAlert
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(PublicOperationalAlertController::class)])
 class PublicPendingAlertControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicPortControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicPortControllerITests.kt
@@ -22,7 +22,10 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class, CaffeineConfiguration::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+    CaffeineConfiguration::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [PublicPortController::class])
 class PublicPortControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicPortControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicPortControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.use_cases.port.GetActivePorts
 import fr.gouv.cnsp.monitorfish.fakers.PortFaker
@@ -9,8 +10,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.cache.CacheManager
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -20,7 +21,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(SentryConfig::class, CaffeineConfiguration::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class, CaffeineConfiguration::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [PublicPortController::class])
 class PublicPortControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicReportingControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicReportingControllerITests.kt
@@ -1,19 +1,21 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.use_cases.reporting.ArchiveReporting
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [PublicReportingController::class])
 class PublicReportingControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicReportingControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicReportingControllerITests.kt
@@ -15,7 +15,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [PublicReportingController::class])
 class PublicReportingControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicVesselControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicVesselControllerITests.kt
@@ -1,8 +1,8 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.neovisionaries.i18n.CountryCode
 import com.nhaarman.mockitokotlin2.any
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.entities.beacon_malfunctions.*
 import fr.gouv.cnsp.monitorfish.domain.entities.vessel.*
@@ -22,7 +22,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(PublicVesselController::class)])
 class PublicVesselControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicVesselControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/PublicVesselControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.neovisionaries.i18n.CountryCode
 import com.nhaarman.mockitokotlin2.any
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
@@ -11,8 +12,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
@@ -20,7 +21,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(PublicVesselController::class)])
 class PublicVesselControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/UserManagementControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/UserManagementControllerITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.use_cases.authorization.DeleteUser
@@ -7,8 +8,8 @@ import fr.gouv.cnsp.monitorfish.domain.use_cases.authorization.SaveUser
 import fr.gouv.cnsp.monitorfish.infrastructure.api.public_api.input.AddUserDataInput
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -17,7 +18,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delet
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@Import(SentryConfig::class)
+@Import(
+    MapperConfiguration::class,SentryConfig::class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(UserManagementController::class)])
 class UserManagementControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/UserManagementControllerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/public_api/UserManagementControllerITests.kt
@@ -1,7 +1,7 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.public_api
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
 import fr.gouv.cnsp.monitorfish.domain.use_cases.authorization.DeleteUser
 import fr.gouv.cnsp.monitorfish.domain.use_cases.authorization.SaveUser
@@ -19,7 +19,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
-    MapperConfiguration::class,SentryConfig::class)
+    MapperConfiguration::class,
+    SentryConfig::class,
+)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(value = [(UserManagementController::class)])
 class UserManagementControllerITests {

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/security/BffFilterConfigITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/security/BffFilterConfigITests.kt
@@ -1,7 +1,7 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.security
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.*
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.domain.use_cases.authorization.GetIsAuthorizedUser
 import fr.gouv.cnsp.monitorfish.infrastructure.api.log.CustomAuthenticationEntryPoint
 import fr.gouv.cnsp.monitorfish.infrastructure.api.public_api.VersionController

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/security/BffFilterConfigITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/security/BffFilterConfigITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.security
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.*
 import fr.gouv.cnsp.monitorfish.domain.use_cases.authorization.GetIsAuthorizedUser
 import fr.gouv.cnsp.monitorfish.infrastructure.api.log.CustomAuthenticationEntryPoint
@@ -7,7 +8,7 @@ import fr.gouv.cnsp.monitorfish.infrastructure.api.public_api.VersionController
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.info.BuildProperties
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -17,6 +18,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @Import(
+    MapperConfiguration::class,
     SecurityConfig::class,
     OIDCProperties::class,
     ProtectedPathsAPIProperties::class,
@@ -56,12 +58,14 @@ class BffFilterConfigITests {
     private lateinit var buildProperties: BuildProperties
 
     @Test
-    fun `Should return 302 redirect for all user authorization protected paths`() {
+    fun `Should return 401 for all user authorization protected paths without authentication`() {
         // When
-        /**
-         * This test returns a 302 redirect to the login page when no valid OIDC authentication is provided.
-         * With OIDC enabled, these paths require proper authentication and redirect to login.
-         */
+        // Without a valid OIDC authentication, the user authorization filter rejects protected /bff
+        // paths with a 401.
+        // Note: in production the Spring Security filter chain (order -100) runs before this custom
+        // filter (order 1) and redirects unauthenticated browser requests to the login page (302);
+        // that behaviour is covered by SecurityConfigITests. In the @WebMvcTest MockMvc harness the
+        // registered servlet filter runs first, so the authorization filter's own 401 is observed here.
         listOf(
             "/bff/v1/vessels",
             "/bff/v1/beacon_malfunctions",
@@ -73,7 +77,7 @@ class BffFilterConfigITests {
             mockMvc
                 .perform(get(it))
                 // Then
-                .andExpect(status().isFound)
+                .andExpect(status().isUnauthorized)
         }
     }
 

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/security/SecurityConfigITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/security/SecurityConfigITests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.security
 
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.nhaarman.mockitokotlin2.given
 import fr.gouv.cnsp.monitorfish.config.KeycloakProxyProperties
 import fr.gouv.cnsp.monitorfish.config.OIDCProperties
@@ -15,7 +16,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.info.BuildProperties
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin
@@ -31,6 +32,7 @@ class SecurityConfigITests {
      */
     @Nested
     @Import(
+    MapperConfiguration::class,
         SecurityConfig::class,
         OIDCProperties::class,
         KeycloakProxyProperties::class,
@@ -154,6 +156,7 @@ class SecurityConfigITests {
      */
     @Nested
     @Import(
+    MapperConfiguration::class,
         SecurityConfig::class,
         OIDCProperties::class,
         KeycloakProxyProperties::class,

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/security/SecurityConfigITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/security/SecurityConfigITests.kt
@@ -1,8 +1,8 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.security
 
-import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import com.nhaarman.mockitokotlin2.given
 import fr.gouv.cnsp.monitorfish.config.KeycloakProxyProperties
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
 import fr.gouv.cnsp.monitorfish.config.OIDCProperties
 import fr.gouv.cnsp.monitorfish.config.SecurityConfig
 import fr.gouv.cnsp.monitorfish.config.SentryConfig
@@ -32,7 +32,7 @@ class SecurityConfigITests {
      */
     @Nested
     @Import(
-    MapperConfiguration::class,
+        MapperConfiguration::class,
         SecurityConfig::class,
         OIDCProperties::class,
         KeycloakProxyProperties::class,
@@ -156,7 +156,7 @@ class SecurityConfigITests {
      */
     @Nested
     @Import(
-    MapperConfiguration::class,
+        MapperConfiguration::class,
         SecurityConfig::class,
         OIDCProperties::class,
         KeycloakProxyProperties::class,

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -41,6 +41,9 @@ logging:
     org.hybernate.type.descriptor.sql.BasicBinder: TRACE
 
 spring:
+  http:
+    converters:
+      preferred-json-mapper: jackson2
   jmx:
     enabled: false
   mvc:


### PR DESCRIPTION
Combines the five backend Dependabot dependency PRs (#5137, #5138, #5139, #5140, #5141) onto a single branch and makes them build & pass together.

## Dependency updates
- **Spring Boot** 3.5.8 → 4.0.6 (+ Spring Framework 7, Jakarta EE 11)
- **Spring Security** 6.5.6 → 7.0.5
- **Flyway** 11.18 → 12.5
- **Ktor** 3.4.3 → 3.5.0 (+ kotlinx-coroutines 1.11.0)
- Non-major group: hibernate-spatial, proj4j, postgresql, jackson, caffeine, sentry, gradle wrapper 9.5.1
- springdoc-openapi-ui 1.8 → springdoc-openapi-starter-webmvc-ui 3.0.3

## Notable migration work
- **Boot 4 modularization**: added `spring-boot-restclient`, `spring-boot-kafka`, `spring-boot-flyway`, `spring-boot-webmvc-test` (split out of core)
- **Spring Cloud Gateway** 4.3 → 5 (`spring-cloud-gateway-mvc` → `spring-cloud-gateway-proxyexchange-webmvc`)
- **Hibernate 7**: hypersistence-utils `-71` variant, BOM-aligned hibernate-spatial, native-query `Timestamp`/`Instant` → `LocalDateTime`
- **Jackson**: kept Jackson 2 as the MVC mapper via `spring.http.converters.preferred-json-mapper=jackson2` (Boot 4 defaults to Jackson 3) to preserve the API contract
- API/package moves: Tomcat factory, `RestTemplateBuilder`, `KafkaProperties`, `ErrorController`, `HttpHeaders`, `ResponseEntity` bounds, `AntPathRequestMatcher` → `PathPatternRequestMatcher`, `PostgreSQLEnumJdbcType`
- Ktor `NoSuchMethodError` fixed by pinning kotlinx-coroutines to 1.11.0 (a transitive BOM was downgrading the `-jvm` artifacts)
- `@WebMvcTest` slices updated for Boot 4 (security filter chain, `@AuthenticationPrincipal` resolver, Jackson 2 `ObjectMapper`)

Full backend test suite passes locally.