### PR TITLE
Tech - Corrrection d'un test flaky sur la pipeline

### DIFF
--- a/pipeline/tests/test_flows/test_distribute_pnos.py
+++ b/pipeline/tests/test_flows/test_distribute_pnos.py
@@ -678,7 +678,7 @@ def extracted_pnos() -> pd.DataFrame:
                 None,
                 None,
                 None,
-                now - relativedelta(days=30, minutes=35),
+                now - relativedelta(months=1, minutes=35),
                 None,
                 None,
                 None,


### PR DESCRIPTION
The test_extract_pnos_to_generate fixture computed previous_notification_date_utc with relativedelta(days=30) while the SQL test data uses INTERVAL '1 month'. These diverge after 31-day months (e.g. June), causing a 1-day mismatch.

----

- [ ] Tests E2E (Cypress)
