### PR TITLE
Signalements INN - Amélioration des filtres dans la liste

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/reporting/GetAllCurrentReportings.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/reporting/GetAllCurrentReportings.kt
@@ -14,6 +14,8 @@ import fr.gouv.cnsp.monitorfish.domain.repositories.VesselRepository
 import fr.gouv.cnsp.monitorfish.domain.use_cases.control_units.GetAllLegacyControlUnits
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.time.ZoneOffset.UTC
+import java.time.ZonedDateTime
 
 @UseCase
 class GetAllCurrentReportings(
@@ -31,6 +33,7 @@ class GetAllCurrentReportings(
                 isArchived = false.takeIf { absentVessel != true },
                 isDeleted = false,
                 types = listOf(ReportingType.ALERT, ReportingType.INFRACTION_SUSPICION, ReportingType.OBSERVATION),
+                afterCreationDate = ZonedDateTime.of(2025, 1, 1, 0, 0, 0, 0, UTC).takeIf { absentVessel == true },
             )
 
         val currentReportings = reportingRepository.findAll(filter)

--- a/frontend/src/constants/seafront.ts
+++ b/frontend/src/constants/seafront.ts
@@ -75,3 +75,7 @@ export function filterBySeafrontGroup<T>(
     return seaFront !== undefined && seafronts.includes(seaFront)
   })
 }
+
+export function seafrontGroupSupportsAbsentVesselFilter(group: SeafrontGroup): boolean {
+  return [SeafrontGroup.OUTREMEROA, SeafrontGroup.OUTREMEROI, SeafrontGroup.NO_FACADE].includes(group)
+}

--- a/frontend/src/features/Alert/components/SideWindowAlerts/index.tsx
+++ b/frontend/src/features/Alert/components/SideWindowAlerts/index.tsx
@@ -1,5 +1,5 @@
 import { RTK_FIVE_MINUTES_POLLING_QUERY_OPTIONS } from '@api/constants'
-import { filterBySeafrontGroup, SeafrontGroup } from '@constants/seafront'
+import { filterBySeafrontGroup, SeafrontGroup, seafrontGroupSupportsAbsentVesselFilter } from '@constants/seafront'
 import { AlertAndReportingTab } from '@features/Alert/components/SideWindowAlerts/AlertListAndReportingList/constants'
 import { AlertManagementForm } from '@features/Alert/components/SideWindowAlerts/AlertManagementForm'
 import { AlertsManagementList } from '@features/Alert/components/SideWindowAlerts/AlertsManagementList'
@@ -49,6 +49,10 @@ export function SideWindowAlerts({ isFromUrl }: SideWindowAlertsProps) {
       }
 
       if (selectedTab === AlertAndReportingTab.REPORTING) {
+        if (absentVessel && !seafrontGroupSupportsAbsentVesselFilter(group)) {
+          return 0
+        }
+
         let filtered = filterBySeafrontGroup(currentReportings ?? [], group, r => r.value.seaFront)
 
         if (reportingTypesDisplayed) {
@@ -60,7 +64,7 @@ export function SideWindowAlerts({ isFromUrl }: SideWindowAlertsProps) {
 
       return 0
     },
-    [currentReportings, pendingAlerts, reportingTypesDisplayed, selectedTab]
+    [absentVessel, currentReportings, pendingAlerts, reportingTypesDisplayed, selectedTab]
   )
 
   return (

--- a/frontend/src/features/Reporting/components/ReportingTable/Filters/constants.ts
+++ b/frontend/src/features/Reporting/components/ReportingTable/Filters/constants.ts
@@ -2,7 +2,10 @@ import { ReportingType } from '@features/Reporting/types/ReportingType'
 
 import type { Option } from '@mtes-mct/monitor-ui'
 
-export const REPORTING_TYPE_FILTER_OPTIONS: Option<ReportingType>[] = [
-  { label: 'Observations', value: ReportingType.OBSERVATION },
-  { label: "Suspicions d'infraction", value: ReportingType.INFRACTION_SUSPICION }
+export const REPORTING_TYPE_FILTER_OPTIONS: Option<ReportingType[]>[] = [
+  { label: 'Observations', value: [ReportingType.OBSERVATION] },
+  {
+    label: "Suspicions d'infraction",
+    value: [ReportingType.INFRACTION_SUSPICION, ReportingType.ALERT]
+  }
 ]

--- a/frontend/src/features/Reporting/components/ReportingTable/Filters/index.tsx
+++ b/frontend/src/features/Reporting/components/ReportingTable/Filters/index.tsx
@@ -1,15 +1,19 @@
+import { SeafrontGroup, seafrontGroupSupportsAbsentVesselFilter } from '@constants/seafront'
 import { reportingTableFiltersActions } from '@features/Reporting/components/ReportingTable/Filters/slice'
 import { ReportingType } from '@features/Reporting/types/ReportingType'
 import { useMainAppDispatch } from '@hooks/useMainAppDispatch'
 import { useMainAppSelector } from '@hooks/useMainAppSelector'
-import { Checkbox, CheckPicker, Size, TextInput } from '@mtes-mct/monitor-ui'
-import { useState } from 'react'
+import { Checkbox, Select, Size, TextInput } from '@mtes-mct/monitor-ui'
+import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { useDebouncedCallback } from 'use-debounce'
 
 import { REPORTING_TYPE_FILTER_OPTIONS } from './constants'
 
-export function Filters() {
+type FiltersProps = Readonly<{
+  selectedSeafrontGroup: SeafrontGroup
+}>
+export function Filters({ selectedSeafrontGroup }: FiltersProps) {
   const dispatch = useMainAppDispatch()
   const searchQuery = useMainAppSelector(state => state.reportingTableFilters.searchQuery)
   const reportingTypesDisplayed = useMainAppSelector(state => state.reportingTableFilters.reportingTypesDisplayed)
@@ -25,16 +29,21 @@ export function Filters() {
   )
 
   const updateReportingTypes = (nextValue: ReportingType[] | undefined) => {
-    let enrichedNextValue = nextValue
-    if (nextValue?.includes(ReportingType.INFRACTION_SUSPICION)) {
-      enrichedNextValue = [...nextValue, ReportingType.ALERT]
-    }
-    dispatch(reportingTableFiltersActions.setReportingTypesDisplayed(enrichedNextValue))
+    dispatch(reportingTableFiltersActions.setReportingTypesDisplayed(nextValue))
   }
 
   const handleCheckAbsentVessel = (isChecked: boolean | undefined) => {
     dispatch(reportingTableFiltersActions.setAbsentVessel(!!isChecked))
   }
+
+  const showAbsentVesselToggle = seafrontGroupSupportsAbsentVesselFilter(selectedSeafrontGroup)
+
+  // uncheck absent vessel filter if on a tab that do not supports it
+  useEffect(() => {
+    if (!showAbsentVesselToggle && absentVesselChecked) {
+      dispatch(reportingTableFiltersActions.setAbsentVessel(false))
+    }
+  }, [absentVesselChecked, dispatch, showAbsentVesselToggle])
 
   return (
     <Wrapper>
@@ -53,25 +62,26 @@ export function Filters() {
         size={Size.LARGE}
         value={searchText}
       />
-      <StyledCheckPicker
+      <Select
         isLabelHidden
         isTransparent
         label="Type de signalement"
         name="reportingType"
         onChange={updateReportingTypes}
         options={REPORTING_TYPE_FILTER_OPTIONS}
+        // @ts-expect-error: using the number 0 as key is ignored, see https://github.com/MTES-MCT/monitor-ui/issues/2068
+        optionValueKey="0"
         placeholder="Type de signalement"
-        renderValue={(_: unknown, items: unknown[]) =>
-          items.length > 0 ? <OptionValue>Type de signalement ({items.length}) </OptionValue> : <></>
-        }
         value={reportingTypesDisplayed}
       />
-      <StyledCheckbox
-        checked={absentVesselChecked}
-        label="Navires sans fiche"
-        name="absentVessel"
-        onChange={handleCheckAbsentVessel}
-      />
+      {showAbsentVesselToggle && (
+        <Checkbox
+          checked={absentVesselChecked}
+          label="Navires sans fiche"
+          name="absentVessel"
+          onChange={handleCheckAbsentVessel}
+        />
+      )}
     </Wrapper>
   )
 }
@@ -79,24 +89,10 @@ export function Filters() {
 const Wrapper = styled.div`
   display: flex;
   align-items: center;
+  gap: 24px;
 `
 
 const StyledSearch = styled(TextInput)`
   border: 1px solid ${p => p.theme.color.lightGray};
   width: 300px;
-`
-
-const StyledCheckPicker = styled(CheckPicker)`
-  margin-left: 24px;
-`
-
-const StyledCheckbox = styled(Checkbox)`
-  margin-left: 24px;
-`
-
-const OptionValue = styled.span`
-  display: flex;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 `

--- a/frontend/src/features/Reporting/components/ReportingTable/index.tsx
+++ b/frontend/src/features/Reporting/components/ReportingTable/index.tsx
@@ -125,7 +125,7 @@ export function ReportingTable({ isFromUrl, selectedSeafrontGroup }: ReportingTa
     <Page>
       <Body>
         <TableOuterWrapper>
-          <Filters />
+          <Filters selectedSeafrontGroup={selectedSeafrontGroup} />
           <TableTop $isFromUrl={isFromUrl}>
             <TableLegend>
               {reportings.length} {pluralize('signalement', reportings.length)} en cours


### PR DESCRIPTION
## Linked issues

- Resolve https://github.com/MTES-MCT/monitorfish/issues/5039#issuecomment-4610842110
  - [x] si on coche "navires sans fiche", il faut ajouter un filtre sur la date de création à 2025 (date à laquelle on avait déjà des vesselId dans les signalements).
  - [x] transformer le filtre "type de signalement" en `Select` exclusif aulieu du `CheckPicker`
  - [x] afficher le filtre "navires sans fiche" que dans les onglets de façade concernant l'outre-mer (Outre-mer OI, Outre-mer OA et Hors façade).

----

- [ ] Tests E2E (Cypress)
