### PR TITLE
CR de contrôles - Modification des contrôles en mer et à la débarque pour e-ISR v1.3

### DIFF
--- a/frontend/cypress/e2e/side_window/mission_form/land_control.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/land_control.spec.ts
@@ -14,7 +14,7 @@ context('Side Window > Mission Form > Land Control', () => {
   })
 
   it('Should fill the form and send the expected data to the API', () => {
-    cy.getDataCy('action-completion-status').contains('21 champs nécessaires aux statistiques à compléter')
+    cy.getDataCy('action-completion-status').contains('22 champs nécessaires aux statistiques à compléter')
     cy.getDataCy('action-contains-missing-fields').should('exist')
 
     const now = getUtcDateInMultipleFormats()
@@ -58,8 +58,9 @@ context('Side Window > Mission Form > Land Control', () => {
     cy.fill('Port de contrôle', 'Auray')
 
     // Obligations déclaratives et autorisations
-    // VMS / AIS / propulsion power checks are not displayed on land controls (forced to N/A)
-    cy.fill("Contrôle de l’émission VMS avant l’arrivée à terre", "Oui")
+    // The propulsion power check is not displayed on land controls (forced to N/A); VMS / AIS are controlled.
+    cy.fill("Bonne émission VMS", "Oui")
+    cy.fill("Bonne émission AIS", "Non")
     cy.fill("Accès au port / autorisation de débarquement conformes", "Non")
     cy.fill("Déclarations journal de pêche conformes à l’activité du navire", "N/A")
     cy.fill("Autorisations de pêche (AEP) conformes à l’activité du navire ", "Non")
@@ -184,9 +185,8 @@ context('Side Window > Mission Form > Land Control', () => {
           controlQualityComments: 'Une observation sur le déroulé du contrôle.',
           controlUnits: [],
           districtCode: 'AY',
-          emitsAis: 'NOT_APPLICABLE',
-          emitsVms: 'NOT_APPLICABLE',
-          vmsEmissionControlBeforeArrival: 'YES',
+          emitsAis: 'NO',
+          emitsVms: 'YES',
           portEntranceAndLandingAuthorized: 'NO',
           externalReferenceNumber: 'DONTSINK',
           facade: null,

--- a/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
@@ -1089,9 +1089,9 @@ context('Side Window > Mission Form > Sea Control', () => {
     // Verify pre-filled values visible in the form
 
     // The discards are now displayed in the dedicated "Rejets" card (a flat table whose column headers are
-    // "Espèce(s) rejetées" / "Qté" / "Nature rejet" / "Zone"; the per-field labels only exist on row hover).
+    // "Espèce rejetée" / "Qté" / "Nature rejet" / "Zone"; the per-field labels only exist on row hover).
     cy.contains('Rejets').should('exist')
-    cy.contains('Espèce(s) rejetées').should('exist')
+    cy.contains('Espèce rejetée').should('exist')
     cy.contains('Nature rejet').should('exist')
 
     // Verify the request body includes the split catches / discards
@@ -1138,7 +1138,7 @@ context('Side Window > Mission Form > Sea Control', () => {
       .should('eq', 201)
   })
 
-  it('Should edit the sous-taille field on row hover and remove extra rejet lines when delete buttons are clicked', () => {
+  it('Should edit the sous-taille field on row hover and remove species / rejet lines through the confirmation modal', () => {
     fillSideWindowMissionFormBase(Mission.MissionTypeLabel.SEA)
 
     cy.clickButton('Ajouter')
@@ -1158,14 +1158,29 @@ context('Side Window > Mission Form > Sea Control', () => {
     cy.get('[data-cy="species-onboard-row-0"]').trigger('mouseout', { force: true })
     cy.get('[id="speciesOnboard[0].underSizedWeight"]').should('not.exist')
 
+    // Add a second species, then remove it through the confirmation modal: cancelling keeps the row,
+    // confirming deletes only the targeted row.
+    cy.clickButton('Ajouter une espèce')
+    pickHoverEditSpecies('species-onboard-row-1', 'HKE')
+    cy.get('[data-cy="species-onboard-row-1"]').find('[title="Retirer l\'espèce"]').click({ force: true })
+    cy.contains('Suppression de l’espèce').should('be.visible')
+    cy.contains('Êtes-vous sûr de vouloir supprimer').should('be.visible')
+    cy.clickButton('Annuler')
+    cy.get('[data-cy="species-onboard-row-1"]').should('exist')
+    cy.get('[data-cy="species-onboard-row-1"]').find('[title="Retirer l\'espèce"]').click({ force: true })
+    cy.clickButton('Confirmer la suppression')
+    cy.get('[data-cy="species-onboard-row-1"]').should('not.exist')
+    cy.get('[data-cy="species-onboard-row-0"]').should('exist')
+
     // Add two rejected-species rows via the in-table add row, then remove the second via its own row
-    // delete button. The "Rejets" card is now a flat table (one row per discard): the per-species
-    // grouping and the "Ajouter rejet" button are gone, and every row carries a "Retirer le rejet" action.
+    // delete button. Removing a row now also goes through the confirmation modal.
     cy.clickButton('Ajouter une espèce rejetée')
     cy.get('[data-cy="discarded-species-row-0"]').should('exist')
     cy.clickButton('Ajouter une espèce rejetée')
     cy.get('[data-cy="discarded-species-row-1"]').should('exist')
     cy.get('[data-cy="discarded-species-row-1"]').find('[title="Retirer le rejet"]').click({ force: true })
+    cy.contains('Suppression du rejet').should('be.visible')
+    cy.clickButton('Confirmer la suppression')
     cy.get('[data-cy="discarded-species-row-1"]').should('not.exist')
     cy.get('[data-cy="discarded-species-row-0"]').should('exist')
   })

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/__tests__/schemas.test.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/__tests__/schemas.test.ts
@@ -184,7 +184,7 @@ describe('ActionForm/schemas', () => {
   })
 
   describe('getLandControlFormCompletionSchema', () => {
-    // On land controls the propulsion engine power, VMS and AIS emission checks are forced to N/A.
+    // On land controls the propulsion engine power check is forced to N/A; VMS and AIS emissions are still controlled.
     const completionValuesWithoutEISR = {
       actionDatetimeUtc: '2026-06-15T10:00:00Z',
       completedBy: 'DEF',
@@ -214,10 +214,9 @@ describe('ActionForm/schemas', () => {
       underSizedSeparateStowage: MissionAction.ControlCheck.YES
     }
 
-    // The two land-specific obligation checks, required only when e-ISR is enabled.
+    // The land-specific obligation check, required only when e-ISR is enabled.
     const landEisrChecks = {
-      portEntranceAndLandingAuthorized: MissionAction.ControlCheck.YES,
-      vmsEmissionControlBeforeArrival: MissionAction.ControlCheck.YES
+      portEntranceAndLandingAuthorized: MissionAction.ControlCheck.YES
     }
 
     // The land-specific species checks (two subsections), required only when e-ISR is enabled.

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/schemas.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/schemas.ts
@@ -26,7 +26,6 @@ function makeEIsrDeclarativeObligationsSchema(isEISR: boolean) {
 function makeLandControlEIsrObligationsSchema(isEISR: boolean) {
   return isEISR
     ? object({
-        vmsEmissionControlBeforeArrival: string().required(HIDDEN_ERROR),
         portEntranceAndLandingAuthorized: string().required(HIDDEN_ERROR)
       })
     : object({})

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/ControlCheckTable.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/ControlCheckTable.tsx
@@ -64,7 +64,7 @@ const borderBottom = css`
 
 const TableGrid = styled.div`
   display: grid;
-  grid-template-columns: 1fr 0.17fr 0.17fr 0.17fr;
+  grid-template-columns: 1fr 0.14fr 0.14fr 0.14fr;
   align-items: stretch;
   row-gap: 4px;
 `

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/DiscardedSpeciesField.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/DiscardedSpeciesField.tsx
@@ -1,4 +1,6 @@
+import { ConfirmationModal } from '@components/ConfirmationModal'
 import { Ellipsised } from '@components/Ellipsised'
+import { Bold } from '@components/style'
 import { DISCARD_REASON_AS_OPTIONS } from '@features/Mission/components/MissionForm/ActionForm/shared/constants'
 import { getDefaultFaoZones } from '@features/Mission/components/MissionForm/ActionForm/utils'
 import { useIsEISREnabled } from '@features/Mission/components/MissionForm/hooks/useIsEISREnabled'
@@ -6,14 +8,17 @@ import { DISCARD_REASON_LABEL } from '@features/Mission/constants'
 import { MissionAction } from '@features/Mission/missionAction.types'
 import { useGetVesselQuery } from '@features/Vessel/vesselApi'
 import { FrontendError } from '@libs/FrontendError'
-import { Accent, FormikSelect, Icon, IconButton, SimpleTable } from '@mtes-mct/monitor-ui'
+import { Accent, FormikSelect, Icon, IconButton, SimpleTable, useNewWindow } from '@mtes-mct/monitor-ui'
 import { skipToken } from '@reduxjs/toolkit/query'
 import { useField, useFormikContext } from 'formik'
+import { useState } from 'react'
+import { createPortal } from 'react-dom'
 import styled from 'styled-components'
 
 import {
   AddSpeciesButton,
   DeleteCell,
+  RequiredAsterisk,
   selectFieldCss,
   SpeciesTableWrapper,
   StyledPickerTd
@@ -31,6 +36,8 @@ export function DiscardedSpeciesField() {
   const [input, , helper] = useField<MissionActionFormValues['discardedSpecies']>('discardedSpecies')
   const isEISREnabled = useIsEISREnabled(values.actionDatetimeUtc)
   const { data: vessel } = useGetVesselQuery(values.vesselId ?? skipToken)
+  const { newWindowContainerRef } = useNewWindow()
+  const [discardToDeleteIndex, setDiscardToDeleteIndex] = useState<number | undefined>(undefined)
 
   const { customSearch, faoAreasAsOptions, getSpecyNameFromSpecyCode, speciesAsOptions } = useSpeciesAndFaoOptions()
 
@@ -76,6 +83,23 @@ export function DiscardedSpeciesField() {
     helper.setValue(input.value.filter((_, currentIndex) => currentIndex !== index))
   }
 
+  const getDiscardReasonOptions = (index: number) => {
+    const currentSpeciesCode = input.value?.[index]?.speciesCode
+    const usedReasons = new Set<string>(
+      (input.value ?? [])
+        .filter(
+          (discard, currentIndex) =>
+            currentIndex !== index && discard.speciesCode === currentSpeciesCode && !!discard.discardReason
+        )
+        .map(discard => discard.discardReason as string)
+    )
+
+    return DISCARD_REASON_AS_OPTIONS.map(option => ({
+      ...option,
+      isDisabled: usedReasons.has(option.value)
+    }))
+  }
+
   if (!speciesAsOptions.length || !customSearch) {
     return <FieldsetGroupSpinner isLight legend="Rejets" />
   }
@@ -88,10 +112,12 @@ export function DiscardedSpeciesField() {
         <SimpleTable.Table>
           <SimpleTable.Head>
             <tr>
-              <SimpleTable.Th $width={165}>Espèce(s) rejetées</SimpleTable.Th>
+              <SimpleTable.Th $width={165}>Espèce rejetée</SimpleTable.Th>
               <SimpleTable.Th $width={55}>Qté</SimpleTable.Th>
               <SimpleTable.Th $width={180}>Nature rejet</SimpleTable.Th>
-              <SimpleTable.Th $width={80}>Zone</SimpleTable.Th>
+              <SimpleTable.Th $width={80}>
+                Zone <RequiredAsterisk>*</RequiredAsterisk>
+              </SimpleTable.Th>
               <SimpleTable.Th $width={21} aria-label="Retirer" />
             </tr>
           </SimpleTable.Head>
@@ -148,7 +174,7 @@ export function DiscardedSpeciesField() {
                         name={`discardedSpecies[${index}].discardReason`}
                         onClose={() => handlePickerClose(index)}
                         onOpen={() => handlePickerOpen(index)}
-                        options={DISCARD_REASON_AS_OPTIONS}
+                        options={getDiscardReasonOptions(index)}
                         popupWidth={220}
                       />
                     ) : (
@@ -172,7 +198,7 @@ export function DiscardedSpeciesField() {
                       accent={Accent.TERTIARY}
                       disabled={isDisabled}
                       Icon={Icon.Minus}
-                      onClick={() => removeDiscard(index)}
+                      onClick={() => setDiscardToDeleteIndex(index)}
                       title="Retirer le rejet"
                     />
                   </DeleteCell>
@@ -190,6 +216,25 @@ export function DiscardedSpeciesField() {
           </tbody>
         </SimpleTable.Table>
       </SpeciesTableWrapper>
+      {discardToDeleteIndex !== undefined &&
+        createPortal(
+          <ConfirmationModal
+            confirmationButtonLabel="Confirmer la suppression"
+            message={
+              <>
+                <p>Êtes-vous sûr de vouloir supprimer</p>
+                <Bold>le rejet ?</Bold>
+              </>
+            }
+            onCancel={() => setDiscardToDeleteIndex(undefined)}
+            onConfirm={() => {
+              removeDiscard(discardToDeleteIndex)
+              setDiscardToDeleteIndex(undefined)
+            }}
+            title="Suppression du rejet"
+          />,
+          newWindowContainerRef.current
+        )}
     </FieldsetGroup>
   )
 }

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/DiscardedSpeciesField.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/DiscardedSpeciesField.tsx
@@ -8,11 +8,10 @@ import { DISCARD_REASON_LABEL } from '@features/Mission/constants'
 import { MissionAction } from '@features/Mission/missionAction.types'
 import { useGetVesselQuery } from '@features/Vessel/vesselApi'
 import { FrontendError } from '@libs/FrontendError'
-import { Accent, FormikSelect, Icon, IconButton, SimpleTable, useNewWindow } from '@mtes-mct/monitor-ui'
+import { Accent, FormikSelect, Icon, IconButton, SimpleTable } from '@mtes-mct/monitor-ui'
 import { skipToken } from '@reduxjs/toolkit/query'
 import { useField, useFormikContext } from 'formik'
 import { useState } from 'react'
-import { createPortal } from 'react-dom'
 import styled from 'styled-components'
 
 import {
@@ -36,7 +35,6 @@ export function DiscardedSpeciesField() {
   const [input, , helper] = useField<MissionActionFormValues['discardedSpecies']>('discardedSpecies')
   const isEISREnabled = useIsEISREnabled(values.actionDatetimeUtc)
   const { data: vessel } = useGetVesselQuery(values.vesselId ?? skipToken)
-  const { newWindowContainerRef } = useNewWindow()
   const [discardToDeleteIndex, setDiscardToDeleteIndex] = useState<number | undefined>(undefined)
 
   const { customSearch, faoAreasAsOptions, getSpecyNameFromSpecyCode, speciesAsOptions } = useSpeciesAndFaoOptions()
@@ -216,25 +214,23 @@ export function DiscardedSpeciesField() {
           </tbody>
         </SimpleTable.Table>
       </SpeciesTableWrapper>
-      {discardToDeleteIndex !== undefined &&
-        createPortal(
-          <ConfirmationModal
-            confirmationButtonLabel="Confirmer la suppression"
-            message={
-              <>
-                <p>Êtes-vous sûr de vouloir supprimer</p>
-                <Bold>le rejet ?</Bold>
-              </>
-            }
-            onCancel={() => setDiscardToDeleteIndex(undefined)}
-            onConfirm={() => {
-              removeDiscard(discardToDeleteIndex)
-              setDiscardToDeleteIndex(undefined)
-            }}
-            title="Suppression du rejet"
-          />,
-          newWindowContainerRef.current
-        )}
+      {discardToDeleteIndex !== undefined && (
+        <ConfirmationModal
+          confirmationButtonLabel="Confirmer la suppression"
+          message={
+            <>
+              <p>Êtes-vous sûr de vouloir supprimer</p>
+              <Bold>le rejet ?</Bold>
+            </>
+          }
+          onCancel={() => setDiscardToDeleteIndex(undefined)}
+          onConfirm={() => {
+            removeDiscard(discardToDeleteIndex)
+            setDiscardToDeleteIndex(undefined)
+          }}
+          title="Suppression du rejet"
+        />
+      )}
     </FieldsetGroup>
   )
 }

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/FormikGangwayField.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/FormikGangwayField.tsx
@@ -17,6 +17,7 @@ const GANGWAY_DEPENDENT_FIELDS: Array<keyof MissionActionFormValues> = [
   'emitsVms',
   'emitsAis',
   'licencesMatchActivity',
+  'logbookMatchesActivity',
   'separateStowageOfPreservedSpecies',
   'speciesWeightControlled',
   'speciesSizeControlled',
@@ -56,6 +57,11 @@ export function FormikGangwayField() {
       })
     } else if (values.isGangwayDeployed === true) {
       GANGWAY_DEPENDENT_FIELDS.forEach(field => setFieldValue(field, undefined))
+
+      values.gearOnboard?.forEach((_, index) => {
+        setFieldValue(`gearOnboard[${index}].gearWasControlled`, undefined)
+        setFieldValue(`gearOnboard[${index}].gearMarkingIsCompliant`, undefined)
+      })
     }
   }, [values.gearOnboard, values.isGangwayDeployed, setFieldValue])
 

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/LicencesAndLogbookField.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/LicencesAndLogbookField.tsx
@@ -11,12 +11,8 @@ import { FieldsetGroupSeparator } from '../../shared/FieldsetGroupSeparator'
 import type { ControlCheckRow } from './ControlCheckTable'
 import type { MissionActionFormValues } from '../../types'
 
-// On land controls these checks are not relevant: they are hidden and forced to N/A.
-const LAND_CONTROL_NOT_APPLICABLE_FIELDS: Array<keyof MissionActionFormValues> = [
-  'propulsionEnginePowerControl',
-  'emitsVms',
-  'emitsAis'
-]
+// On land controls this check is not relevant: it is hidden and forced to N/A.
+const LAND_CONTROL_NOT_APPLICABLE_FIELDS: Array<keyof MissionActionFormValues> = ['propulsionEnginePowerControl']
 
 export function LicencesAndLogbookField() {
   const { setFieldValue, values } = useFormikContext<MissionActionFormValues>()
@@ -35,15 +31,12 @@ export function LicencesAndLogbookField() {
     })
     // Only trigger from values of LAND_CONTROL_NOT_APPLICABLE_FIELDS const
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLandControl, setFieldValue, values.propulsionEnginePowerControl, values.emitsVms, values.emitsAis])
+  }, [isLandControl, setFieldValue, values.propulsionEnginePowerControl])
 
   const landControlFields = isEISREnabled
     ? [
-        {
-          isRequired: true,
-          label: 'Contrôle de l’émission VMS avant l’arrivée à terre',
-          name: 'vmsEmissionControlBeforeArrival'
-        },
+        { isRequired: true, label: 'Bonne émission VMS', name: 'emitsVms' },
+        { isRequired: true, label: 'Bonne émission AIS', name: 'emitsAis' },
         {
           isRequired: true,
           label: 'Accès au port / autorisation de débarquement conformes',

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/SpeciesTableRow.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/SpeciesTableRow.tsx
@@ -46,6 +46,7 @@ type SpeciesSelectCellProps = Readonly<{
   isActive: boolean
   isDisabled: boolean
   isHovered: boolean
+  isNotLanded?: boolean
   name: string
   onChange: (newSpecy: Specy | undefined) => void
   onPickerClose: () => void
@@ -60,6 +61,7 @@ export function SpeciesSelectCell({
   isActive,
   isDisabled,
   isHovered,
+  isNotLanded,
   name,
   onChange,
   onPickerClose,
@@ -72,7 +74,7 @@ export function SpeciesSelectCell({
   return (
     <StyledPickerTd $isActive={isActive}>
       {speciesCode && !isActive ? (
-        <SpeciesName>{speciesLabel}</SpeciesName>
+        <SpeciesName $isNotLanded={!!isNotLanded}>{speciesLabel}</SpeciesName>
       ) : (
         <StyledSpeciesSelect
           $isHovered={isHovered}

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/speciesTable.styles.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/speciesTable.styles.ts
@@ -12,6 +12,7 @@ export const SpeciesTableWrapper = styled.div`
   th {
     padding-left: 5px;
     padding-right: 5px;
+    text-align: left;
   }
 
   /* Keep a stable row height whether a cell shows plain text or its editor, to avoid jitter. */
@@ -76,6 +77,15 @@ export const AddSpeciesButton = styled.button`
   color: ${p => p.theme.color.slateGray};
   cursor: pointer;
   font-weight: 500;
+
+  &:disabled {
+    color: ${p => p.theme.color.lightGray};
+    cursor: not-allowed;
+  }
+`
+
+export const RequiredAsterisk = styled.span`
+  color: ${p => p.theme.color.maximumRed};
 `
 
 export const QuantityWrapper = styled.div`
@@ -98,13 +108,21 @@ export const Kg = styled.span`
   padding-left: 4px;
 `
 
-export const SpeciesName = styled.span`
+export const SpeciesName = styled.span<{
+  $isNotLanded?: boolean
+}>`
   font-weight: 700;
   display: inline-block;
   max-width: 100%;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
+  ${p =>
+    p.$isNotLanded &&
+    css`
+      color: ${p.theme.color.slateGray};
+      font-style: italic;
+    `}
 `
 
 export const SelectValue = styled.span`

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/SpeciesField.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/SpeciesField.tsx
@@ -13,14 +13,12 @@ import {
   IconButton,
   SimpleTable,
   THEME,
-  useNewWindow,
   usePrevious
 } from '@mtes-mct/monitor-ui'
 import { skipToken } from '@reduxjs/toolkit/query'
 import { useField, useFormikContext } from 'formik'
 import { isEqual } from 'lodash-es'
 import { useEffect, useState } from 'react'
-import { createPortal } from 'react-dom'
 
 import { getDefaultFaoZones, getDefaultPresentationCodes } from '../utils'
 import { ControlCheckTable } from './ControlCheckTable'
@@ -59,7 +57,6 @@ export function SpeciesField() {
   const { updateSegments } = useGetMissionActionFormikUsecases()
   const isEISREnabled = useIsEISREnabled(values.actionDatetimeUtc)
   const { data: vessel } = useGetVesselQuery(values.vesselId ?? skipToken)
-  const { newWindowContainerRef } = useNewWindow()
   const [speciesToDeleteIndex, setSpeciesToDeleteIndex] = useState<number | undefined>(undefined)
 
   const isLandControl = values.actionType === MissionAction.MissionActionType.LAND_CONTROL
@@ -349,25 +346,23 @@ export function SpeciesField() {
       </SpeciesTableWrapper>
       <FieldsetGroupSeparator marginBottom={12} />
       <FormikTextarea label="Observations (hors infraction) sur les espèces" name="speciesObservations" rows={2} />
-      {speciesToDeleteIndex !== undefined &&
-        createPortal(
-          <ConfirmationModal
-            confirmationButtonLabel="Confirmer la suppression"
-            message={
-              <>
-                <p>Êtes-vous sûr de vouloir supprimer</p>
-                <Bold>l’espèce ?</Bold>
-              </>
-            }
-            onCancel={() => setSpeciesToDeleteIndex(undefined)}
-            onConfirm={() => {
-              remove(speciesToDeleteIndex)
-              setSpeciesToDeleteIndex(undefined)
-            }}
-            title="Suppression de l’espèce"
-          />,
-          newWindowContainerRef.current
-        )}
+      {speciesToDeleteIndex !== undefined && (
+        <ConfirmationModal
+          confirmationButtonLabel="Confirmer la suppression"
+          message={
+            <>
+              <p>Êtes-vous sûr de vouloir supprimer</p>
+              <Bold>l’espèce ?</Bold>
+            </>
+          }
+          onCancel={() => setSpeciesToDeleteIndex(undefined)}
+          onConfirm={() => {
+            remove(speciesToDeleteIndex)
+            setSpeciesToDeleteIndex(undefined)
+          }}
+          title="Suppression de l’espèce"
+        />
+      )}
     </FieldsetGroup>
   )
 }

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/SpeciesField.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/SpeciesField.tsx
@@ -1,4 +1,6 @@
+import { ConfirmationModal } from '@components/ConfirmationModal'
 import { Ellipsised } from '@components/Ellipsised'
+import { Bold } from '@components/style'
 import { LogbookSpeciesPresentation } from '@features/Logbook/constants'
 import { MissionAction } from '@features/Mission/missionAction.types'
 import { useGetVesselQuery } from '@features/Vessel/vesselApi'
@@ -11,12 +13,14 @@ import {
   IconButton,
   SimpleTable,
   THEME,
+  useNewWindow,
   usePrevious
 } from '@mtes-mct/monitor-ui'
 import { skipToken } from '@reduxjs/toolkit/query'
 import { useField, useFormikContext } from 'formik'
 import { isEqual } from 'lodash-es'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
 
 import { getDefaultFaoZones, getDefaultPresentationCodes } from '../utils'
 import { ControlCheckTable } from './ControlCheckTable'
@@ -24,6 +28,7 @@ import { getSpeciesControlCheckRows } from './Species/speciesControlCheckRows'
 import {
   AddSpeciesButton,
   DeleteCell,
+  RequiredAsterisk,
   SelectValue,
   SpeciesTableWrapper,
   StyledCheckPicker,
@@ -54,6 +59,8 @@ export function SpeciesField() {
   const { updateSegments } = useGetMissionActionFormikUsecases()
   const isEISREnabled = useIsEISREnabled(values.actionDatetimeUtc)
   const { data: vessel } = useGetVesselQuery(values.vesselId ?? skipToken)
+  const { newWindowContainerRef } = useNewWindow()
+  const [speciesToDeleteIndex, setSpeciesToDeleteIndex] = useState<number | undefined>(undefined)
 
   const isLandControl = values.actionType === MissionAction.MissionActionType.LAND_CONTROL
   const legend = isLandControl ? 'Inspection des captures' : 'Espèces à bord'
@@ -90,9 +97,9 @@ export function SpeciesField() {
     const newSpecies: MissionAction.SpeciesOnboardControl = {
       controlledWeight: undefined,
       declaredWeight: undefined,
-      faoZones: undefined,
+      faoZones: getDefaultFaoZones(isEISREnabled, values.faoAreas, vessel?.length),
       nbFish: undefined,
-      presentationCodes: undefined,
+      presentationCodes: getDefaultPresentationCodes(isEISREnabled, vessel?.length),
       speciesCode: '',
       speciesName: undefined,
       underSized: false,
@@ -182,7 +189,7 @@ export function SpeciesField() {
         <SimpleTable.Table>
           <SimpleTable.Head>
             <tr>
-              <SimpleTable.Th $width={isEISREnabled ? 165 : 320}>Espèce(s)</SimpleTable.Th>
+              <SimpleTable.Th $width={isEISREnabled ? 165 : 320}>Espèce</SimpleTable.Th>
               <SimpleTable.Th $width={isEISREnabled ? 55 : 80}>
                 {isEISREnabled ? 'Déclaré' : 'Qté déclarée'}
               </SimpleTable.Th>
@@ -193,7 +200,11 @@ export function SpeciesField() {
                 {isEISREnabled ? 'Ss-taille' : 'Sous-taille'}
               </SimpleTable.Th>
               {isEISREnabled && <SimpleTable.Th $width={70}>Présentation</SimpleTable.Th>}
-              {isEISREnabled && <SimpleTable.Th $width={70}>Zone</SimpleTable.Th>}
+              {isEISREnabled && (
+                <SimpleTable.Th $width={70}>
+                  Zone <RequiredAsterisk>*</RequiredAsterisk>
+                </SimpleTable.Th>
+              )}
               <SimpleTable.Th $width={isEISREnabled ? actionColumnWidth : 25} aria-label="Retirer" />
             </tr>
           </SimpleTable.Head>
@@ -216,6 +227,7 @@ export function SpeciesField() {
                     isActive={isActive}
                     isDisabled={isDisabled}
                     isHovered={isHovered}
+                    isNotLanded={!!specyOnboard.isNotLanded}
                     name={`speciesOnboard[${index}].speciesCode`}
                     onChange={newSpecy => setSpecies(index, newSpecy)}
                     onPickerClose={() => handlePickerClose(index)}
@@ -317,7 +329,7 @@ export function SpeciesField() {
                       accent={Accent.TERTIARY}
                       disabled={isDisabled}
                       Icon={Icon.Minus}
-                      onClick={() => remove(index)}
+                      onClick={() => setSpeciesToDeleteIndex(index)}
                       title="Retirer l'espèce"
                     />
                   </DeleteCell>
@@ -337,6 +349,25 @@ export function SpeciesField() {
       </SpeciesTableWrapper>
       <FieldsetGroupSeparator marginBottom={12} />
       <FormikTextarea label="Observations (hors infraction) sur les espèces" name="speciesObservations" rows={2} />
+      {speciesToDeleteIndex !== undefined &&
+        createPortal(
+          <ConfirmationModal
+            confirmationButtonLabel="Confirmer la suppression"
+            message={
+              <>
+                <p>Êtes-vous sûr de vouloir supprimer</p>
+                <Bold>l’espèce ?</Bold>
+              </>
+            }
+            onCancel={() => setSpeciesToDeleteIndex(undefined)}
+            onConfirm={() => {
+              remove(speciesToDeleteIndex)
+              setSpeciesToDeleteIndex(undefined)
+            }}
+            title="Suppression de l’espèce"
+          />,
+          newWindowContainerRef.current
+        )}
     </FieldsetGroup>
   )
 }

--- a/frontend/src/features/Mission/components/MissionForm/useCases/__tests__/updateActionLogbookFilledPriorToControl.test.ts
+++ b/frontend/src/features/Mission/components/MissionForm/useCases/__tests__/updateActionLogbookFilledPriorToControl.test.ts
@@ -31,10 +31,10 @@ describe('features/Mission/components/MissionForm/useCases.updateActionLogbookFi
     expect(mockSetFieldValue).not.toHaveBeenCalled()
   })
 
-  it('Should set NOT_APPLICABLE When the vessel is under 12 meters', async () => {
+  it('Should set NOT_APPLICABLE When the vessel is under 10 meters', async () => {
     // Given
     mockDispatch
-      .mockResolvedValueOnce({ data: { length: 10 } } as never) // getVessel
+      .mockResolvedValueOnce({ data: { length: 8 } } as never) // getVessel
       .mockResolvedValueOnce({ data: true } as never) // getHasFilledLogbookForCurrentTrip
 
     // When
@@ -51,6 +51,25 @@ describe('features/Mission/components/MissionForm/useCases.updateActionLogbookFi
       'logbookFilledPriorToControl',
       MissionAction.ControlCheck.NOT_APPLICABLE
     )
+  })
+
+  it('Should leave the field empty When the vessel is between 10 and 12 meters', async () => {
+    // Given
+    mockDispatch
+      .mockResolvedValueOnce({ data: { length: 10 } } as never) // getVessel
+      .mockResolvedValueOnce({ data: true } as never) // getHasFilledLogbookForCurrentTrip
+
+    // When
+    await updateActionLogbookFilledPriorToControl(
+      mockDispatch,
+      mockSetFieldValue
+    )({
+      ...dummyAction,
+      vesselId: 1
+    } as any)
+
+    // Then
+    expect(mockSetFieldValue).toHaveBeenCalledWith('logbookFilledPriorToControl', undefined)
   })
 
   it('Should set the logbook-filled value When the vessel is over 12 meters', async () => {

--- a/frontend/src/features/Mission/components/MissionForm/useCases/updateActionLogbookFilledPriorToControl.ts
+++ b/frontend/src/features/Mission/components/MissionForm/useCases/updateActionLogbookFilledPriorToControl.ts
@@ -22,9 +22,17 @@ export const updateActionLogbookFilledPriorToControl =
     ])
 
     const vessel = vesselResult?.data
-    const isVesselUnder10m = !!vessel?.length && vessel.length < 12
-    if (isVesselUnder10m) {
+    const vesselLength = vessel?.length
+
+    if (!!vesselLength && vesselLength < 10) {
       setFieldValue('logbookFilledPriorToControl', MissionAction.ControlCheck.NOT_APPLICABLE)
+
+      return
+    }
+
+    // Between 10m and 12m the field is left empty: the user must check the paper logbook on board.
+    if (!!vesselLength && vesselLength < 12) {
+      setFieldValue('logbookFilledPriorToControl', undefined)
 
       return
     }


### PR DESCRIPTION
Sea control (#4477):
- Force "Déclarations journal de pêche conformes" to N/A when the gangway is not deployed
- Reset gear fields when the gangway is set back to deployed
- Leave "Journal de pêche complété" empty for 10-12m vessels (N/A only under 10m)
- Pre-fill WHL presentation and control-point zone for new species on -12m vessels
- Grey out discard reasons already used for the same species
- Confirm before deleting a species / discard row
- Add a required asterisk on the Zone column, left-align headers, singular labels
- Light gray "add species" button text when disabled

Land control (#4476):
- Show "Bonne émission VMS" / "Bonne émission AIS" and drop the redundant "Contrôle de l'émission VMS avant l'arrivée à terre"
- Slate gray italic species name when flagged as not landed

Widen the obligations label column so the weighing-certificate asterisk no longer wraps.

## Linked issues

- Resolve #4476
- Resolve #4477

----

- [ ] Tests E2E (Cypress)
