### PR TITLE
CR de contrôle - Sauvegarder un contrôle rendu valide après un changement de date de mission

### DIFF
--- a/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
@@ -1,6 +1,7 @@
 import { Mission } from '@features/Mission/mission.types'
 
 import { fillSideWindowMissionFormBase, openSideWindowNewMission, pickHoverEditSpecies } from './utils'
+import { customDayjs } from '../../utils/customDayjs'
 import { getUtcDateInMultipleFormats } from '../../utils/getUtcDateInMultipleFormats'
 
 context('Side Window > Mission Form > Sea Control', () => {
@@ -1183,5 +1184,46 @@ context('Side Window > Mission Form > Sea Control', () => {
     cy.clickButton('Confirmer la suppression')
     cy.get('[data-cy="discarded-species-row-1"]').should('not.exist')
     cy.get('[data-cy="discarded-species-row-0"]').should('exist')
+  })
+
+  // Non-regression: an action is only auto-saved when its own form changes, so a control dated after
+  // the mission end (invalid) was never persisted, and extending the mission end date past it — which
+  // only triggers the main-form save — left the now-valid control unsaved until the user re-edited it.
+  it('Should persist a control that becomes valid after extending the mission end date', () => {
+    // Base form sets the mission end date to now + 7 days (auto-save stays enabled).
+    fillSideWindowMissionFormBase(Mission.MissionTypeLabel.SEA, false)
+    // Main-form auto-save endpoint (extending the end date hits this).
+    cy.intercept('POST', '/api/v1/missions/1', { body: { id: 1 }, statusCode: 201 }).as('updateMission')
+
+    cy.clickButton('Ajouter')
+    cy.clickButton('Ajouter un contrôle en mer')
+
+    cy.intercept('POST', '/bff/v1/mission_actions', { body: { id: 1 }, statusCode: 201 }).as('createControl')
+
+    cy.fill('Navire inconnu', true)
+    cy.fill('Nom du navire', 'Un navire')
+    cy.fill('Nationalité', 'France')
+    cy.fill('Ajouter un engin', 'MIS')
+    cy.fill('Saisi par', 'Marlin')
+
+    // The control is created with the default (current) date, which is within the mission range.
+    cy.wait('@createControl').its('response.statusCode').should('eq', 201)
+
+    // From here on, persisting the control means updating it.
+    cy.intercept('PUT', '/bff/v1/mission_actions/1', { body: { id: 1 }, statusCode: 201 }).as('updateControl')
+
+    // When the control date is moved after the mission end date → invalid, not persisted (error shown).
+    const controlDate = getUtcDateInMultipleFormats(customDayjs().utc().add(14, 'day').toISOString())
+    cy.fill('Date et heure du contrôle', controlDate.utcDateTupleWithTime)
+    cy.wait(1000)
+    cy.contains('La date du contrôle doit être antérieure à la date de fin de la mission.').should('exist')
+
+    // When extending the mission end date past the control date — WITHOUT touching the control form again
+    const newEndDate = getUtcDateInMultipleFormats(customDayjs().utc().add(21, 'day').toISOString())
+    cy.fill('Fin de mission', newEndDate.utcDateTupleWithTime)
+    cy.wait('@updateMission')
+
+    // Then the now-valid control must be persisted without re-editing it.
+    cy.wait('@updateControl', { timeout: 8000 }).its('request.body.actionDatetimeUtc').should('contain', controlDate.utcDateAsStringWithoutMs.slice(0, 10))
   })
 })

--- a/frontend/src/features/Mission/components/MissionForm/index.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/index.tsx
@@ -326,6 +326,10 @@ export function MissionForm() {
         return
       }
 
+      const haveMissionDatesChanged =
+        mainFormValues.startDateTimeUtc !== nextMissionMainFormValues.startDateTimeUtc ||
+        mainFormValues.endDateTimeUtc !== nextMissionMainFormValues.endDateTimeUtc
+
       const savedMainFormValues = await dispatch(
         autoSaveMission(nextMissionMainFormValues, mainFormValues, missionIdRef.current, isAutoSaveEnabled)
       )
@@ -336,8 +340,52 @@ export function MissionForm() {
       setMainFormValues(savedMainFormValues)
       missionIdRef.current = savedMainFormValues.id
       updateReduxSliceDraft()
+
+      /**
+       * A control date must fall within the mission period, so changing the mission dates can make a
+       * previously out-of-range action valid. An action is otherwise only auto-saved when its own form
+       * changes, so we re-attempt saving the edited action here to persist a control that just became
+       * valid (without this, the user has to re-edit the control date to trigger its save).
+       */
+      if (!haveMissionDatesChanged || editedActionIndex === undefined) {
+        return
+      }
+
+      const editedActionFormValues = actionsFormValues[editedActionIndex]
+      if (!editedActionFormValues) {
+        return
+      }
+
+      // Persist the draft synchronously so the action validation (which reads the mission dates from the
+      // draft) sees the updated dates instead of the debounced, still-stale ones.
+      dispatch(
+        missionFormActions.setDraft({
+          actionsFormValues: [...actionsFormValues],
+          mainFormValues: { ...savedMainFormValues }
+        })
+      )
+
+      const savedActionId = await dispatch(
+        autoSaveMissionAction(editedActionFormValues, missionIdRef.current, isAutoSaveEnabled)
+      )
+      if (savedActionId !== editedActionFormValues.id) {
+        setActionsFormValues(previousActionsFormValues =>
+          previousActionsFormValues.map((action, index) =>
+            index === editedActionIndex ? { ...editedActionFormValues, id: savedActionId } : action
+          )
+        )
+        updateReduxSliceDraft()
+      }
     },
-    [dispatch, updateEditedActionFormValues, updateReduxSliceDraft, mainFormValues, isAutoSaveEnabled]
+    [
+      dispatch,
+      updateEditedActionFormValues,
+      updateReduxSliceDraft,
+      mainFormValues,
+      isAutoSaveEnabled,
+      editedActionIndex,
+      actionsFormValues
+    ]
   )
 
   const updateMainFormValues = useDebouncedCallback(


### PR DESCRIPTION
## Problem

A user reported that when a control's date is after the mission end, the control date stays red and the mission action cannot be saved — **even after extending the mission end date past the control**. The only workaround was to re-edit the control date itself.

## Root cause

In the auto-save flow, a mission action is only auto-saved when its **own** form changes (`autoSaveMissionAction`, via the debounced `updateEditedActionFormValues`). A control dated outside the mission period fails validation, so it is marked dirty and **never persisted**. Extending the mission end date triggers only the **main-form** save (`autoSaveMission`) — it never re-saves the now-valid control.

Compounding this, the action date validation reads the mission start/end from the **Redux draft**, which is updated by a 250 ms-debounced callback, so it lags the form values.

## Fix

In `updateMainFormValuesCallback` (`MissionForm/index.tsx`), when the mission start/end dates change while an action is being edited:
1. Seed the Redux draft synchronously with the saved main-form values so the action date validation sees the new dates (not the debounced, stale ones).
2. Re-attempt `autoSaveMissionAction` for the edited action, persisting a control that just became valid.

Guarded behind an actual date-change check to avoid redundant writes.

## Test

Adds a non-regression e2e test in `sea_control.spec.ts` asserting that, after extending the mission end date past the control (without touching the control form), the control is persisted (`PUT /bff/v1/mission_actions/:id`). Verified red before the fix (the PUT never fired) and green after.

## Known limitation

The fix re-saves only the **edited** action. A non-edited out-of-range control elsewhere in the same mission would still need a date change to re-persist; this can be extended to all actions if desired.