### PR TITLE
e-ISR - Cacher des champs facultatifs

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/outputs/SpeciesDataOutput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/outputs/SpeciesDataOutput.kt
@@ -1,16 +1,19 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.outputs
 
+import fr.gouv.cnsp.monitorfish.domain.entities.fleet_segment.ScipSpeciesType
 import fr.gouv.cnsp.monitorfish.domain.entities.species.Species
 
 data class SpeciesDataOutput(
     val code: String,
     val name: String,
+    val scipSpeciesType: ScipSpeciesType?,
 ) {
     companion object {
         fun fromSpecies(species: Species): SpeciesDataOutput =
             SpeciesDataOutput(
                 code = species.code,
                 name = species.name,
+                scipSpeciesType = species.scipSpeciesType,
             )
     }
 }

--- a/frontend/src/domain/types/specy.ts
+++ b/frontend/src/domain/types/specy.ts
@@ -1,8 +1,11 @@
+import type { ScipSpeciesType } from '@features/FleetSegment/types'
+
 // TODO Exist both in Vessel and Specy.
 export type Specy = {
   /** ID. */
   code: string
   name: string
+  scipSpeciesType?: ScipSpeciesType
 }
 
 export type SpecyGroup = {

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/__tests__/getSpeciesEISRApplicability.test.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/__tests__/getSpeciesEISRApplicability.test.ts
@@ -2,6 +2,7 @@ import { ScipSpeciesType } from '@features/FleetSegment/types'
 import { expect } from '@jest/globals'
 
 import {
+  DEFAULT_SPECIES_EISR_APPLICABILITY,
   getSmallPelagicsShare,
   getSpeciesEISRApplicability,
   hasBftOrSwoOnboard,
@@ -159,6 +160,23 @@ describe('getSpeciesEISRApplicability', () => {
       const speciesOnboard = [makeSpecy('COD', { controlledWeight: 50 })]
 
       expect(getSpeciesEISRApplicability(speciesOnboard, lookup, 13)).toStrictEqual({
+        isSeparateStowageOfPreservedSpeciesApplicable: true,
+        isUnderSizedSeparateRecordingApplicable: true,
+        isUnderSizedSeparateStowageApplicable: true
+      })
+    })
+
+    it('should return not-applicable for separateStowageOfPreservedSpecies with no species and no vessel length', () => {
+      // Callers must not invoke this before a vessel is selected — see DEFAULT_SPECIES_EISR_APPLICABILITY.
+      expect(getSpeciesEISRApplicability([], lookup, undefined).isSeparateStowageOfPreservedSpeciesApplicable).toBe(
+        false
+      )
+    })
+  })
+
+  describe('DEFAULT_SPECIES_EISR_APPLICABILITY', () => {
+    it('should default every field to applicable', () => {
+      expect(DEFAULT_SPECIES_EISR_APPLICABILITY).toStrictEqual({
         isSeparateStowageOfPreservedSpeciesApplicable: true,
         isUnderSizedSeparateRecordingApplicable: true,
         isUnderSizedSeparateStowageApplicable: true

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/__tests__/getSpeciesEISRApplicability.test.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/__tests__/getSpeciesEISRApplicability.test.ts
@@ -108,30 +108,30 @@ describe('getSpeciesEISRApplicability', () => {
   })
 
   describe('isUnderSizedSeparateStowageApplicable', () => {
-    it('should be applicable for vessels >= 12m regardless of species', () => {
-      expect(isUnderSizedSeparateStowageApplicable([makeSpecy('PIL', { controlledWeight: 100 })], 12)).toBe(true)
-    })
-
-    it('should not be applicable for vessels < 12m with >= 80% small pelagics', () => {
-      const speciesOnboard = [makeSpecy('PIL', { controlledWeight: 90 }), makeSpecy('COD', { controlledWeight: 10 })]
-
-      expect(isUnderSizedSeparateStowageApplicable(speciesOnboard, 11)).toBe(false)
-    })
-
-    it('should be applicable for vessels < 12m with < 80% small pelagics', () => {
+    it('should be applicable for vessels >= 12m with < 80% small pelagics', () => {
       const speciesOnboard = [makeSpecy('PIL', { controlledWeight: 79 }), makeSpecy('COD', { controlledWeight: 21 })]
 
-      expect(isUnderSizedSeparateStowageApplicable(speciesOnboard, 11)).toBe(true)
+      expect(isUnderSizedSeparateStowageApplicable(speciesOnboard, 12)).toBe(true)
     })
 
-    it('should not be applicable at exactly 80% small pelagics', () => {
+    it('should be applicable for vessels >= 12m with no weighed catch yet', () => {
+      expect(isUnderSizedSeparateStowageApplicable([], 12)).toBe(true)
+    })
+
+    it('should be applicable at exactly 80% small pelagics', () => {
       const speciesOnboard = [makeSpecy('PIL', { controlledWeight: 80 }), makeSpecy('COD', { controlledWeight: 20 })]
 
-      expect(isUnderSizedSeparateStowageApplicable(speciesOnboard, 11)).toBe(false)
+      expect(isUnderSizedSeparateStowageApplicable(speciesOnboard, 12)).toBe(true)
     })
 
-    it('should be applicable for vessels < 12m with no weighed catch yet', () => {
-      expect(isUnderSizedSeparateStowageApplicable([], 11)).toBe(true)
+    it('should not be applicable for vessels >= 12m with more than 80% small pelagics', () => {
+      const speciesOnboard = [makeSpecy('PIL', { controlledWeight: 81 }), makeSpecy('COD', { controlledWeight: 19 })]
+
+      expect(isUnderSizedSeparateStowageApplicable(speciesOnboard, 12)).toBe(false)
+    })
+
+    it('should not be applicable for vessels < 12m regardless of species', () => {
+      expect(isUnderSizedSeparateStowageApplicable([makeSpecy('COD', { controlledWeight: 100 })], 11.9)).toBe(false)
     })
 
     it('should be applicable when vessel length is unknown (conservative default)', () => {

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/__tests__/getSpeciesEISRApplicability.test.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/__tests__/getSpeciesEISRApplicability.test.ts
@@ -1,0 +1,168 @@
+import { ScipSpeciesType } from '@features/FleetSegment/types'
+import { expect } from '@jest/globals'
+
+import {
+  getSmallPelagicsShare,
+  getSpeciesEISRApplicability,
+  hasBftOrSwoOnboard,
+  hasDemersalSpeciesOnboard,
+  isSeparateStowageOfPreservedSpeciesApplicable,
+  isUnderSizedSeparateRecordingApplicable,
+  isUnderSizedSeparateStowageApplicable
+} from '../getSpeciesEISRApplicability'
+
+import type { MissionAction } from '@features/Mission/missionAction.types'
+
+function makeSpecy(
+  speciesCode: string,
+  weights: { controlledWeight?: number; declaredWeight?: number } = {}
+): MissionAction.SpeciesOnboardControl {
+  return {
+    controlledWeight: weights.controlledWeight,
+    declaredWeight: weights.declaredWeight,
+    faoZones: undefined,
+    isNotLanded: undefined,
+    nbFish: undefined,
+    presentationCodes: undefined,
+    speciesCode,
+    speciesName: undefined,
+    underSized: false,
+    underSizedWeight: undefined
+  }
+}
+
+const scipSpeciesTypeByCode: Record<string, ScipSpeciesType> = {
+  COD: ScipSpeciesType.DEMERSAL,
+  HKE: ScipSpeciesType.DEMERSAL,
+  PIL: ScipSpeciesType.PELAGIC
+}
+const lookup = (code: string) => scipSpeciesTypeByCode[code]
+
+describe('getSpeciesEISRApplicability', () => {
+  describe('hasDemersalSpeciesOnboard', () => {
+    it('should return true when a demersal species is onboard', () => {
+      expect(hasDemersalSpeciesOnboard([makeSpecy('COD'), makeSpecy('PIL')], lookup)).toBe(true)
+    })
+
+    it('should return false when no demersal species is onboard', () => {
+      expect(hasDemersalSpeciesOnboard([makeSpecy('PIL')], lookup)).toBe(false)
+    })
+
+    it('should return false when speciesOnboard is undefined', () => {
+      expect(hasDemersalSpeciesOnboard(undefined, lookup)).toBe(false)
+    })
+  })
+
+  describe('hasBftOrSwoOnboard', () => {
+    it('should return true when BFT is onboard', () => {
+      expect(hasBftOrSwoOnboard([makeSpecy('BFT')])).toBe(true)
+    })
+
+    it('should return true when SWO is onboard', () => {
+      expect(hasBftOrSwoOnboard([makeSpecy('SWO')])).toBe(true)
+    })
+
+    it('should return false otherwise', () => {
+      expect(hasBftOrSwoOnboard([makeSpecy('COD')])).toBe(false)
+    })
+  })
+
+  describe('getSmallPelagicsShare', () => {
+    it('should return undefined when there is no weighed catch', () => {
+      expect(getSmallPelagicsShare([])).toBeUndefined()
+      expect(getSmallPelagicsShare(undefined)).toBeUndefined()
+    })
+
+    it('should compute the share using controlledWeight, falling back to declaredWeight', () => {
+      const speciesOnboard = [makeSpecy('PIL', { controlledWeight: 80 }), makeSpecy('COD', { declaredWeight: 20 })]
+
+      expect(getSmallPelagicsShare(speciesOnboard)).toBeCloseTo(0.8)
+    })
+  })
+
+  describe('isSeparateStowageOfPreservedSpeciesApplicable', () => {
+    it('should be applicable when a demersal species is onboard and vessel is >= 12m', () => {
+      expect(isSeparateStowageOfPreservedSpeciesApplicable([makeSpecy('COD')], lookup, 12)).toBe(true)
+    })
+
+    it('should not be applicable when a demersal species is onboard but vessel is < 12m and no BFT/SWO', () => {
+      expect(isSeparateStowageOfPreservedSpeciesApplicable([makeSpecy('COD')], lookup, 11.9)).toBe(false)
+    })
+
+    it('should be applicable regardless of length when BFT is onboard', () => {
+      expect(isSeparateStowageOfPreservedSpeciesApplicable([makeSpecy('BFT')], lookup, 5)).toBe(true)
+    })
+
+    it('should be applicable regardless of length when SWO is onboard', () => {
+      expect(isSeparateStowageOfPreservedSpeciesApplicable([makeSpecy('SWO')], lookup, 5)).toBe(true)
+    })
+
+    it('should not be applicable when no demersal/BFT/SWO species onboard', () => {
+      expect(isSeparateStowageOfPreservedSpeciesApplicable([makeSpecy('PIL')], lookup, 20)).toBe(false)
+    })
+
+    it('should be applicable for a demersal species when vessel length is unknown (conservative default)', () => {
+      expect(isSeparateStowageOfPreservedSpeciesApplicable([makeSpecy('COD')], lookup, undefined)).toBe(true)
+    })
+  })
+
+  describe('isUnderSizedSeparateStowageApplicable', () => {
+    it('should be applicable for vessels >= 12m regardless of species', () => {
+      expect(isUnderSizedSeparateStowageApplicable([makeSpecy('PIL', { controlledWeight: 100 })], 12)).toBe(true)
+    })
+
+    it('should not be applicable for vessels < 12m with >= 80% small pelagics', () => {
+      const speciesOnboard = [makeSpecy('PIL', { controlledWeight: 90 }), makeSpecy('COD', { controlledWeight: 10 })]
+
+      expect(isUnderSizedSeparateStowageApplicable(speciesOnboard, 11)).toBe(false)
+    })
+
+    it('should be applicable for vessels < 12m with < 80% small pelagics', () => {
+      const speciesOnboard = [makeSpecy('PIL', { controlledWeight: 79 }), makeSpecy('COD', { controlledWeight: 21 })]
+
+      expect(isUnderSizedSeparateStowageApplicable(speciesOnboard, 11)).toBe(true)
+    })
+
+    it('should not be applicable at exactly 80% small pelagics', () => {
+      const speciesOnboard = [makeSpecy('PIL', { controlledWeight: 80 }), makeSpecy('COD', { controlledWeight: 20 })]
+
+      expect(isUnderSizedSeparateStowageApplicable(speciesOnboard, 11)).toBe(false)
+    })
+
+    it('should be applicable for vessels < 12m with no weighed catch yet', () => {
+      expect(isUnderSizedSeparateStowageApplicable([], 11)).toBe(true)
+    })
+
+    it('should be applicable when vessel length is unknown (conservative default)', () => {
+      const speciesOnboard = [makeSpecy('PIL', { controlledWeight: 90 }), makeSpecy('COD', { controlledWeight: 10 })]
+
+      expect(isUnderSizedSeparateStowageApplicable(speciesOnboard, undefined)).toBe(true)
+    })
+  })
+
+  describe('isUnderSizedSeparateRecordingApplicable', () => {
+    it('should be applicable for vessels >= 10m', () => {
+      expect(isUnderSizedSeparateRecordingApplicable(10)).toBe(true)
+    })
+
+    it('should not be applicable for vessels < 10m', () => {
+      expect(isUnderSizedSeparateRecordingApplicable(9.9)).toBe(false)
+    })
+
+    it('should be applicable when vessel length is unknown (conservative default)', () => {
+      expect(isUnderSizedSeparateRecordingApplicable(undefined)).toBe(true)
+    })
+  })
+
+  describe('getSpeciesEISRApplicability', () => {
+    it('should aggregate the three applicability flags', () => {
+      const speciesOnboard = [makeSpecy('COD', { controlledWeight: 50 })]
+
+      expect(getSpeciesEISRApplicability(speciesOnboard, lookup, 13)).toStrictEqual({
+        isSeparateStowageOfPreservedSpeciesApplicable: true,
+        isUnderSizedSeparateRecordingApplicable: true,
+        isUnderSizedSeparateStowageApplicable: true
+      })
+    })
+  })
+})

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/getSpeciesEISRApplicability.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/getSpeciesEISRApplicability.ts
@@ -74,17 +74,23 @@ export function isSeparateStowageOfPreservedSpeciesApplicable(
   return isDemersalAndLongEnough || hasBftOrSwoOnboard(speciesOnboard)
 }
 
+// All vessels >= 12m are subject to this obligation, unless more than 80% of the catch onboard is
+// small pelagics — vessels < 12m are never subject to it.
 export function isUnderSizedSeparateStowageApplicable(
   speciesOnboard: MissionAction.SpeciesOnboardControl[] | undefined,
   vesselLength: number | undefined
 ): boolean {
-  if (vesselLength === undefined || vesselLength >= UNDER_SIZED_SEPARATE_STOWAGE_MIN_VESSEL_LENGTH_METERS) {
+  if (vesselLength === undefined) {
     return true
+  }
+
+  if (vesselLength < UNDER_SIZED_SEPARATE_STOWAGE_MIN_VESSEL_LENGTH_METERS) {
+    return false
   }
 
   const smallPelagicsShare = getSmallPelagicsShare(speciesOnboard)
 
-  return smallPelagicsShare === undefined || smallPelagicsShare < SMALL_PELAGICS_SHARE_THRESHOLD
+  return smallPelagicsShare === undefined || smallPelagicsShare <= SMALL_PELAGICS_SHARE_THRESHOLD
 }
 
 export function isUnderSizedSeparateRecordingApplicable(vesselLength: number | undefined): boolean {

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/getSpeciesEISRApplicability.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/getSpeciesEISRApplicability.ts
@@ -1,0 +1,110 @@
+import { ScipSpeciesType } from '@features/FleetSegment/types'
+import { MissionAction } from '@features/Mission/missionAction.types'
+
+import {
+  BLUEFIN_TUNA_SPECY_CODE,
+  SEPARATE_STOWAGE_MIN_VESSEL_LENGTH_METERS,
+  SMALL_PELAGICS_SHARE_THRESHOLD,
+  SMALL_PELAGIC_SPECIES_CODES,
+  SWORDFISH_SPECY_CODE,
+  UNDER_SIZED_SEPARATE_RECORDING_MIN_VESSEL_LENGTH_METERS,
+  UNDER_SIZED_SEPARATE_STOWAGE_MIN_VESSEL_LENGTH_METERS
+} from './speciesEISRVisibility.constants'
+
+export type ScipSpeciesTypeLookup = (speciesCode: string) => ScipSpeciesType | undefined
+
+export type SpeciesEISRApplicability = {
+  isSeparateStowageOfPreservedSpeciesApplicable: boolean
+  isUnderSizedSeparateRecordingApplicable: boolean
+  isUnderSizedSeparateStowageApplicable: boolean
+}
+
+export function hasDemersalSpeciesOnboard(
+  speciesOnboard: MissionAction.SpeciesOnboardControl[] | undefined,
+  getScipSpeciesTypeFromSpecyCode: ScipSpeciesTypeLookup
+): boolean {
+  return (speciesOnboard ?? []).some(
+    species => getScipSpeciesTypeFromSpecyCode(species.speciesCode) === ScipSpeciesType.DEMERSAL
+  )
+}
+
+export function hasBftOrSwoOnboard(speciesOnboard: MissionAction.SpeciesOnboardControl[] | undefined): boolean {
+  return (speciesOnboard ?? []).some(
+    species => species.speciesCode === BLUEFIN_TUNA_SPECY_CODE || species.speciesCode === SWORDFISH_SPECY_CODE
+  )
+}
+
+/** Returns `undefined` when there is no weighed catch at all onboard (nothing to divide by),
+ *  in which case callers should treat the share as "not proven to be ≥ the threshold". */
+export function getSmallPelagicsShare(
+  speciesOnboard: MissionAction.SpeciesOnboardControl[] | undefined
+): number | undefined {
+  const totalWeight = (speciesOnboard ?? []).reduce(
+    (sum, species) => sum + (species.controlledWeight ?? species.declaredWeight ?? 0),
+    0
+  )
+  if (totalWeight === 0) {
+    return undefined
+  }
+
+  const smallPelagicsWeight = (speciesOnboard ?? [])
+    .filter(species => SMALL_PELAGIC_SPECIES_CODES.includes(species.speciesCode))
+    .reduce((sum, species) => sum + (species.controlledWeight ?? species.declaredWeight ?? 0), 0)
+
+  return smallPelagicsWeight / totalWeight
+}
+
+export function isSeparateStowageOfPreservedSpeciesApplicable(
+  speciesOnboard: MissionAction.SpeciesOnboardControl[] | undefined,
+  getScipSpeciesTypeFromSpecyCode: ScipSpeciesTypeLookup,
+  vesselLength: number | undefined
+): boolean {
+  const isLongEnough = vesselLength === undefined || vesselLength >= SEPARATE_STOWAGE_MIN_VESSEL_LENGTH_METERS
+  const isDemersalAndLongEnough =
+    hasDemersalSpeciesOnboard(speciesOnboard, getScipSpeciesTypeFromSpecyCode) && isLongEnough
+
+  return isDemersalAndLongEnough || hasBftOrSwoOnboard(speciesOnboard)
+}
+
+export function isUnderSizedSeparateStowageApplicable(
+  speciesOnboard: MissionAction.SpeciesOnboardControl[] | undefined,
+  vesselLength: number | undefined
+): boolean {
+  if (vesselLength === undefined || vesselLength >= UNDER_SIZED_SEPARATE_STOWAGE_MIN_VESSEL_LENGTH_METERS) {
+    return true
+  }
+
+  const smallPelagicsShare = getSmallPelagicsShare(speciesOnboard)
+
+  return smallPelagicsShare === undefined || smallPelagicsShare < SMALL_PELAGICS_SHARE_THRESHOLD
+}
+
+export function isUnderSizedSeparateRecordingApplicable(vesselLength: number | undefined): boolean {
+  return vesselLength === undefined || vesselLength >= UNDER_SIZED_SEPARATE_RECORDING_MIN_VESSEL_LENGTH_METERS
+}
+
+export function getSpeciesEISRApplicability(
+  speciesOnboard: MissionAction.SpeciesOnboardControl[] | undefined,
+  getScipSpeciesTypeFromSpecyCode: ScipSpeciesTypeLookup,
+  vesselLength: number | undefined
+): SpeciesEISRApplicability {
+  return {
+    isSeparateStowageOfPreservedSpeciesApplicable: isSeparateStowageOfPreservedSpeciesApplicable(
+      speciesOnboard,
+      getScipSpeciesTypeFromSpecyCode,
+      vesselLength
+    ),
+    isUnderSizedSeparateRecordingApplicable: isUnderSizedSeparateRecordingApplicable(vesselLength),
+    isUnderSizedSeparateStowageApplicable: isUnderSizedSeparateStowageApplicable(speciesOnboard, vesselLength)
+  }
+}
+
+// Shared by speciesControlCheckRows.tsx and useForceSpeciesEISRFieldsNotApplicable.ts so the
+// field-name-to-flag mapping isn't duplicated between them.
+export function getApplicabilityByFieldName(applicability: SpeciesEISRApplicability): Record<string, boolean> {
+  return {
+    separateStowageOfPreservedSpecies: applicability.isSeparateStowageOfPreservedSpeciesApplicable,
+    underSizedSeparateRecording: applicability.isUnderSizedSeparateRecordingApplicable,
+    underSizedSeparateStowage: applicability.isUnderSizedSeparateStowageApplicable
+  }
+}

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/getSpeciesEISRApplicability.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/getSpeciesEISRApplicability.ts
@@ -19,6 +19,14 @@ export type SpeciesEISRApplicability = {
   isUnderSizedSeparateStowageApplicable: boolean
 }
 
+// Before a vessel is selected there is no species/length data to decide anything from — default
+// to applicable, the same conservative stance taken for an unknown vessel length.
+export const DEFAULT_SPECIES_EISR_APPLICABILITY: SpeciesEISRApplicability = {
+  isSeparateStowageOfPreservedSpeciesApplicable: true,
+  isUnderSizedSeparateRecordingApplicable: true,
+  isUnderSizedSeparateStowageApplicable: true
+}
+
 export function hasDemersalSpeciesOnboard(
   speciesOnboard: MissionAction.SpeciesOnboardControl[] | undefined,
   getScipSpeciesTypeFromSpecyCode: ScipSpeciesTypeLookup

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/speciesControlCheckRows.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/speciesControlCheckRows.tsx
@@ -1,3 +1,5 @@
+import { Icon } from '@mtes-mct/monitor-ui'
+
 import { getApplicabilityByFieldName } from './getSpeciesEISRApplicability'
 
 import type { SpeciesEISRApplicability } from './getSpeciesEISRApplicability'
@@ -8,7 +10,12 @@ const BASE_SPECIES_CHECK_ROWS: ControlCheckRow[] = [
   { isRequired: true, label: 'Taille des espèces vérifiées', name: 'speciesSizeControlled' },
   {
     isRequired: true,
-    label: 'Arrimage séparé des espèces soumises à plan',
+    label: (
+      <>
+        Arrimage séparé des espèces soumises à plan{' '}
+        <Icon.Info size={16} title="concernés : espèces démersales / SWO / BFT" />
+      </>
+    ),
     name: 'separateStowageOfPreservedSpecies'
   }
 ]

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/speciesControlCheckRows.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/speciesControlCheckRows.tsx
@@ -1,3 +1,6 @@
+import { getApplicabilityByFieldName } from './getSpeciesEISRApplicability'
+
+import type { SpeciesEISRApplicability } from './getSpeciesEISRApplicability'
 import type { ControlCheckRow } from '../ControlCheckTable'
 
 const BASE_SPECIES_CHECK_ROWS: ControlCheckRow[] = [
@@ -66,10 +69,26 @@ const SEA_CONTROL_EISR_CHECK_ROWS: ControlCheckRow[] = [
   }
 ]
 
-export function getSpeciesControlCheckRows(isLandControl: boolean, isEISREnabled: boolean): ControlCheckRow[] {
-  if (isLandControl) {
-    return isEISREnabled ? LAND_CONTROL_EISR_CHECK_ROWS : BASE_SPECIES_CHECK_ROWS
+export function getSpeciesControlCheckRows(
+  isLandControl: boolean,
+  isEISREnabled: boolean,
+  applicability: SpeciesEISRApplicability
+): ControlCheckRow[] {
+  const rows = isLandControl
+    ? isEISREnabled
+      ? LAND_CONTROL_EISR_CHECK_ROWS
+      : BASE_SPECIES_CHECK_ROWS
+    : isEISREnabled
+      ? [...BASE_SPECIES_CHECK_ROWS, ...SEA_CONTROL_EISR_CHECK_ROWS]
+      : BASE_SPECIES_CHECK_ROWS
+
+  if (!isEISREnabled) {
+    return rows
   }
 
-  return isEISREnabled ? [...BASE_SPECIES_CHECK_ROWS, ...SEA_CONTROL_EISR_CHECK_ROWS] : BASE_SPECIES_CHECK_ROWS
+  const isRowApplicable = getApplicabilityByFieldName(applicability)
+
+  return rows.map(row =>
+    row.name in isRowApplicable && !isRowApplicable[row.name] ? Object.assign({}, row, { disabled: true }) : row
+  )
 }

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/speciesControlCheckRows.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/speciesControlCheckRows.tsx
@@ -81,17 +81,13 @@ export function getSpeciesControlCheckRows(
   isEISREnabled: boolean,
   applicability: SpeciesEISRApplicability
 ): ControlCheckRow[] {
-  const rows = isLandControl
-    ? isEISREnabled
-      ? LAND_CONTROL_EISR_CHECK_ROWS
-      : BASE_SPECIES_CHECK_ROWS
-    : isEISREnabled
-      ? [...BASE_SPECIES_CHECK_ROWS, ...SEA_CONTROL_EISR_CHECK_ROWS]
-      : BASE_SPECIES_CHECK_ROWS
-
   if (!isEISREnabled) {
-    return rows
+    return BASE_SPECIES_CHECK_ROWS
   }
+
+  const rows = isLandControl
+    ? LAND_CONTROL_EISR_CHECK_ROWS
+    : [...BASE_SPECIES_CHECK_ROWS, ...SEA_CONTROL_EISR_CHECK_ROWS]
 
   const isRowApplicable = getApplicabilityByFieldName(applicability)
 

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/speciesEISRVisibility.constants.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/speciesEISRVisibility.constants.ts
@@ -1,5 +1,6 @@
-// Hardcoded per business decision — see GitHub #5168.
-export const SMALL_PELAGIC_SPECIES_CODES = ['ANE', 'PIL', 'HER', 'HOM', 'MAC', 'SPR', 'WHB', 'ARG']
+// Species listed at art. 6 of Regulation (EU) 2019/1241 (anchovy, sardine, herring, horse mackerel,
+// mackerel, sprat, blue whiting, boarfish, argentine), plus sandeel (SAN) added per DGAMPA doctrine.
+export const SMALL_PELAGIC_SPECIES_CODES = ['ANE', 'PIL', 'HER', 'HOM', 'MAC', 'SPR', 'WHB', 'BOC', 'ARG', 'SAN']
 
 // Duplicated rather than imported from `features/PriorNotification/constants.ts`, since
 // `features/Mission` never imports from peer features in this codebase.

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/speciesEISRVisibility.constants.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/speciesEISRVisibility.constants.ts
@@ -1,0 +1,12 @@
+// Hardcoded per business decision — see GitHub #5168.
+export const SMALL_PELAGIC_SPECIES_CODES = ['ANE', 'PIL', 'HER', 'HOM', 'MAC', 'SPR', 'WHB', 'ARG']
+
+// Duplicated rather than imported from `features/PriorNotification/constants.ts`, since
+// `features/Mission` never imports from peer features in this codebase.
+export const BLUEFIN_TUNA_SPECY_CODE = 'BFT'
+export const SWORDFISH_SPECY_CODE = 'SWO'
+
+export const SEPARATE_STOWAGE_MIN_VESSEL_LENGTH_METERS = 12
+export const UNDER_SIZED_SEPARATE_STOWAGE_MIN_VESSEL_LENGTH_METERS = 12
+export const UNDER_SIZED_SEPARATE_RECORDING_MIN_VESSEL_LENGTH_METERS = 10
+export const SMALL_PELAGICS_SHARE_THRESHOLD = 0.8

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/useForceSpeciesEISRFieldsNotApplicable.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/useForceSpeciesEISRFieldsNotApplicable.ts
@@ -25,13 +25,13 @@ export function useForceSpeciesEISRFieldsNotApplicable(
       const currentValue = values[field as keyof MissionActionFormValues]
 
       if (!isApplicable && currentValue !== MissionAction.ControlCheck.NOT_APPLICABLE) {
-        setFieldValue(field, MissionAction.ControlCheck.NOT_APPLICABLE)
+        void setFieldValue(field, MissionAction.ControlCheck.NOT_APPLICABLE)
       } else if (
         isApplicable &&
         currentValue === MissionAction.ControlCheck.NOT_APPLICABLE &&
         values.isGangwayDeployed !== false
       ) {
-        setFieldValue(field, undefined)
+        void setFieldValue(field, undefined)
       }
     })
     // Only re-run when the applicability flags themselves change — not on every value change,

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/useForceSpeciesEISRFieldsNotApplicable.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/useForceSpeciesEISRFieldsNotApplicable.ts
@@ -1,0 +1,48 @@
+import { MissionAction } from '@features/Mission/missionAction.types'
+import { useFormikContext } from 'formik'
+import { useEffect } from 'react'
+
+import { getApplicabilityByFieldName } from './getSpeciesEISRApplicability'
+
+import type { SpeciesEISRApplicability } from './getSpeciesEISRApplicability'
+import type { MissionActionFormValues } from '../../../types'
+
+// FormikGangwayField.tsx's GANGWAY_DEPENDENT_FIELDS effect targets these same three fields for a
+// different reason (gangway not deployed) — its NOT_APPLICABLE always takes precedence, so this
+// effect never resets a field away from NOT_APPLICABLE while the gangway isn't deployed.
+export function useForceSpeciesEISRFieldsNotApplicable(
+  isEISREnabled: boolean,
+  applicability: SpeciesEISRApplicability
+): void {
+  const { setFieldValue, values } = useFormikContext<MissionActionFormValues>()
+
+  useEffect(() => {
+    if (!isEISREnabled) {
+      return
+    }
+
+    Object.entries(getApplicabilityByFieldName(applicability)).forEach(([field, isApplicable]) => {
+      const currentValue = values[field as keyof MissionActionFormValues]
+
+      if (!isApplicable && currentValue !== MissionAction.ControlCheck.NOT_APPLICABLE) {
+        setFieldValue(field, MissionAction.ControlCheck.NOT_APPLICABLE)
+      } else if (
+        isApplicable &&
+        currentValue === MissionAction.ControlCheck.NOT_APPLICABLE &&
+        values.isGangwayDeployed !== false
+      ) {
+        setFieldValue(field, undefined)
+      }
+    })
+    // Only re-run when the applicability flags themselves change — not on every value change,
+    // otherwise this would fight a user's own answer on a still-applicable field.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    isEISREnabled,
+    applicability.isSeparateStowageOfPreservedSpeciesApplicable,
+    applicability.isUnderSizedSeparateRecordingApplicable,
+    applicability.isUnderSizedSeparateStowageApplicable,
+    values.isGangwayDeployed,
+    setFieldValue
+  ])
+}

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/useSpeciesAndFaoOptions.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/useSpeciesAndFaoOptions.ts
@@ -46,5 +46,17 @@ export function useSpeciesAndFaoOptions() {
     [getSpeciesApiQuery.data]
   )
 
-  return { customSearch, faoAreasAsOptions, getSpecyNameFromSpecyCode, speciesAsOptions }
+  const getScipSpeciesTypeFromSpecyCode = useCallback(
+    (specyCode: Specy['code']) =>
+      getSpeciesApiQuery.data?.species.find(({ code }) => code === specyCode)?.scipSpeciesType,
+    [getSpeciesApiQuery.data]
+  )
+
+  return {
+    customSearch,
+    faoAreasAsOptions,
+    getScipSpeciesTypeFromSpecyCode,
+    getSpecyNameFromSpecyCode,
+    speciesAsOptions
+  }
 }

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/SpeciesField.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/SpeciesField.tsx
@@ -22,7 +22,7 @@ import { useEffect, useState } from 'react'
 
 import { getDefaultFaoZones, getDefaultPresentationCodes } from '../utils'
 import { ControlCheckTable } from './ControlCheckTable'
-import { getSpeciesEISRApplicability } from './Species/getSpeciesEISRApplicability'
+import { DEFAULT_SPECIES_EISR_APPLICABILITY, getSpeciesEISRApplicability } from './Species/getSpeciesEISRApplicability'
 import { getSpeciesControlCheckRows } from './Species/speciesControlCheckRows'
 import {
   AddSpeciesButton,
@@ -75,11 +75,10 @@ export function SpeciesField() {
   const activation = useRowActivation()
   const { deactivate, handlePickerClose, handlePickerOpen, hoveredIndex, isRowActive } = activation
 
-  const speciesEISRApplicability = getSpeciesEISRApplicability(
-    input.value,
-    getScipSpeciesTypeFromSpecyCode,
-    vessel?.length
-  )
+  const speciesEISRApplicability =
+    values.vesselId !== undefined
+      ? getSpeciesEISRApplicability(input.value, getScipSpeciesTypeFromSpecyCode, vessel?.length)
+      : DEFAULT_SPECIES_EISR_APPLICABILITY
   useForceSpeciesEISRFieldsNotApplicable(isEISREnabled, speciesEISRApplicability)
 
   /**

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/SpeciesField.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/SpeciesField.tsx
@@ -22,6 +22,7 @@ import { useEffect, useState } from 'react'
 
 import { getDefaultFaoZones, getDefaultPresentationCodes } from '../utils'
 import { ControlCheckTable } from './ControlCheckTable'
+import { getSpeciesEISRApplicability } from './Species/getSpeciesEISRApplicability'
 import { getSpeciesControlCheckRows } from './Species/speciesControlCheckRows'
 import {
   AddSpeciesButton,
@@ -34,6 +35,7 @@ import {
   TdWithoutPaddingWhenActive
 } from './Species/speciesTable.styles'
 import { FaoZonesCell, SpeciesSelectCell, SpeciesTableRow, WeightCell } from './Species/SpeciesTableRow'
+import { useForceSpeciesEISRFieldsNotApplicable } from './Species/useForceSpeciesEISRFieldsNotApplicable'
 import { useRowActivation } from './Species/useRowActivation'
 import { useSpeciesAndFaoOptions } from './Species/useSpeciesAndFaoOptions'
 import { useGetMissionActionFormikUsecases } from '../../hooks/useGetMissionActionFormikUsecases'
@@ -62,10 +64,23 @@ export function SpeciesField() {
   const isLandControl = values.actionType === MissionAction.MissionActionType.LAND_CONTROL
   const legend = isLandControl ? 'Inspection des captures' : 'Espèces à bord'
 
-  const { customSearch, faoAreasAsOptions, getSpecyNameFromSpecyCode, speciesAsOptions } = useSpeciesAndFaoOptions()
+  const {
+    customSearch,
+    faoAreasAsOptions,
+    getScipSpeciesTypeFromSpecyCode,
+    getSpecyNameFromSpecyCode,
+    speciesAsOptions
+  } = useSpeciesAndFaoOptions()
 
   const activation = useRowActivation()
   const { deactivate, handlePickerClose, handlePickerOpen, hoveredIndex, isRowActive } = activation
+
+  const speciesEISRApplicability = getSpeciesEISRApplicability(
+    input.value,
+    getScipSpeciesTypeFromSpecyCode,
+    vessel?.length
+  )
+  useForceSpeciesEISRFieldsNotApplicable(isEISREnabled, speciesEISRApplicability)
 
   /**
    * This is only used to re-compute fleet segments when a species is modified
@@ -179,7 +194,7 @@ export function SpeciesField() {
 
   return (
     <FieldsetGroup isLight legend={legend}>
-      <ControlCheckTable rows={getSpeciesControlCheckRows(isLandControl, isEISREnabled)} />
+      <ControlCheckTable rows={getSpeciesControlCheckRows(isLandControl, isEISREnabled, speciesEISRApplicability)} />
 
       <FieldsetGroupSeparator marginBottom={12} />
       <SpeciesTableWrapper>


### PR DESCRIPTION

Separate-stowage/recording checks only apply under specific EU stowage rules (vessel length, demersal/BFT/SWO species onboard, small-pelagics share), so keep them visible but disable and force them to N/A when the underlying obligation doesn't apply to the vessel/catch being controlled.

## Linked issues

- Resolve #5168

----

- [ ] Tests E2E (Cypress)
