### PR TITLE
Dev - Retire commentaire obsolette et ajoute section sur le box-sizing monitor-ui dans CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,8 @@
     - [Local development](#local-development)
     - [Remote deployment](#remote-deployment)
     - [Restoring a remote dump locally (for debugging purposes)](#restoring-a-remote-dump-locally-for-debugging-purposes)
+- [Tech debt](#tech-debt)
+  - [monitor-ui box-sizing](#monitor-ui-box-sizing)
 
 ## File Structure
 
@@ -265,3 +267,9 @@ Then use SCP to download the dump locally into the `.backups/` directory and res
 tar -xvzf ./.backups/YYYY-MM-DD-[daily|weekly].tar.gz -C ./.backups
 make dev-restore-db TAG=YYYY-MM-DD-[daily|weekly]
 ```
+
+## Tech debt
+
+### monitor-ui box-sizing
+
+monitor-ui uses a global `box-sizing: border-box` on all elements that is not applied on monitorfish. Beware that components imported from monitor-ui might require adding it to function properly.

--- a/frontend/src/features/Vessel/components/VesselSidebar/components/VesselContactToUpdateForm.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/components/VesselContactToUpdateForm.tsx
@@ -100,7 +100,7 @@ export function VesselContactToUpdateForm({ vesselId }: VesselContactToUpdateFor
 
 const StyledFormikTextarea = styled(FormikTextarea)`
   > textarea {
-    box-sizing: border-box; // ensures the textarea width matches the parent div. TODO: move this into monitorui, see https://github.com/MTES-MCT/monitor-ui/issues/1984
+    box-sizing: border-box; // ensures the textarea width matches the parent div
   }
 `
 


### PR DESCRIPTION
J'ai appris qu'on s’attend à ce que monitorfish ajoute ces propres `box-sizing: border-box` sur les composants `monitor-ui`.

Donc petite PR pour
- retirer un commentaire obsolète disant de fix ça upstream
- ajouter de l'information dans le `CONTIBUTING.md` pour éviter du travail inutile a de futurs contributeurs.

## Linked issues

- https://github.com/MTES-MCT/monitor-ui/issues/1984#issuecomment-4925306869

----

- [ ] Tests E2E (Cypress)
