### PR TITLE
CR de contrôle & Groupes de navires - Corrections

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/vessel_group/VesselGroup.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/vessel_group/VesselGroup.kt
@@ -181,9 +181,9 @@ data class PriorityVesselGroup(
                     id = -1,
                     name = "Segments P1",
                     description =
-                        "Navires appartenant à des segments aux objectifs non atteints et donc la priorité est " +
+                        "Navires appartenant à des segments aux objectifs non atteints et dont la priorité est " +
                             "élevée selon la note d'impact et/ou la saisonnalité",
-                    color = "#E1000F",
+                    color = "#FC4C0D",
                     priorityLevel = 4,
                 ),
                 PriorityVesselGroup(
@@ -192,7 +192,7 @@ data class PriorityVesselGroup(
                     description =
                         "Navires appartenant à des segments aux objectifs non atteints " +
                             "et dont la priorité est moindre",
-                    color = "#FF9940",
+                    color = "#EABD00",
                     priorityLevel = 3,
                 ),
             )

--- a/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
@@ -1288,14 +1288,13 @@ context('Side Window > Mission Form > Sea Control', () => {
     cy.clickButton('Ajouter une espèce')
     pickHoverEditSpecies('species-onboard-row-1', 'HKE')
 
-    // Up/Down in a weight input moves focus to the same field on the row above/below, spreadsheet-style.
-    // Row 1 is deliberately left un-hovered here, to prove ArrowDown mounts and focuses it on its own.
+    // ArrowDown/ArrowUp move focus to the same weight field on the row below/above. Row 1 is deliberately
+    // left un-hovered, to prove ArrowDown mounts and focuses it on its own.
     cy.get('[data-cy="species-onboard-row-0"]').trigger('mouseover', { force: true })
     cy.get('[id="speciesOnboard[0].declaredWeight"]').type('12', { force: true })
     cy.get('[id="speciesOnboard[0].declaredWeight"]').type('{downarrow}', { force: true })
     cy.get('[id="speciesOnboard[1].declaredWeight"]').should('have.focus')
     cy.get('[id="speciesOnboard[1].declaredWeight"]').type('34', { force: true })
-    // ArrowUp moves focus back up — and row 0's earlier value is still there, not lost in the round trip.
     cy.get('[id="speciesOnboard[1].declaredWeight"]').type('{uparrow}', { force: true })
     cy.get('[id="speciesOnboard[0].declaredWeight"]').should('have.focus').and('have.value', '12')
     cy.get('[data-cy="species-onboard-row-0"]').trigger('mouseout', { force: true })

--- a/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
@@ -1287,6 +1287,19 @@ context('Side Window > Mission Form > Sea Control', () => {
     // confirming deletes only the targeted row.
     cy.clickButton('Ajouter une espèce')
     pickHoverEditSpecies('species-onboard-row-1', 'HKE')
+
+    // Up/Down in a weight input moves focus to the same field on the row above/below, spreadsheet-style.
+    // Row 1 is deliberately left un-hovered here, to prove ArrowDown mounts and focuses it on its own.
+    cy.get('[data-cy="species-onboard-row-0"]').trigger('mouseover', { force: true })
+    cy.get('[id="speciesOnboard[0].declaredWeight"]').type('12', { force: true })
+    cy.get('[id="speciesOnboard[0].declaredWeight"]').type('{downarrow}', { force: true })
+    cy.get('[id="speciesOnboard[1].declaredWeight"]').should('have.focus')
+    cy.get('[id="speciesOnboard[1].declaredWeight"]').type('34', { force: true })
+    // ArrowUp moves focus back up — and row 0's earlier value is still there, not lost in the round trip.
+    cy.get('[id="speciesOnboard[1].declaredWeight"]').type('{uparrow}', { force: true })
+    cy.get('[id="speciesOnboard[0].declaredWeight"]').should('have.focus').and('have.value', '12')
+    cy.get('[data-cy="species-onboard-row-0"]').trigger('mouseout', { force: true })
+
     cy.get('[data-cy="species-onboard-row-1"]').find('[title="Retirer l\'espèce"]').click({ force: true })
     cy.contains('Suppression de l’espèce').should('be.visible')
     cy.contains('supprimer l’espèce ?').should('be.visible')

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/SpeciesTableRow.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/SpeciesTableRow.tsx
@@ -33,6 +33,7 @@ export function SpeciesTableRow({ activation, children, dataCy, index, isHovered
       data-cy={dataCy}
       onBlurCapture={event => activation.handleRowBlur(index, event)}
       onFocusCapture={event => activation.handleRowFocus(index, event)}
+      onMouseDown={() => activation.activateRowNow(index)}
       onMouseEnter={() => activation.handleRowMouseEnter(index)}
       onMouseLeave={() => activation.handleRowMouseLeave(index)}
     >

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/SpeciesTableRow.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/SpeciesTableRow.tsx
@@ -34,7 +34,7 @@ export function SpeciesTableRow({ activation, children, dataCy, index, isHovered
       onBlurCapture={event => activation.handleRowBlur(index, event)}
       onFocusCapture={event => activation.handleRowFocus(index, event)}
       onMouseDown={() => activation.activateRowNow(index)}
-      onMouseEnter={() => activation.handleRowMouseEnter(index)}
+      onMouseEnter={event => activation.handleRowMouseEnter(index, event)}
       onMouseLeave={() => activation.handleRowMouseLeave(index)}
     >
       {children}

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/SpeciesTableRow.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/SpeciesTableRow.tsx
@@ -103,25 +103,41 @@ export function SpeciesSelectCell({
 }
 
 type WeightCellProps = Readonly<{
+  clearFocusRequest?: (() => void) | undefined
+  focusRequestId?: string | undefined
   isActive: boolean
   isDisabled: boolean
   isHovered: boolean
   label: string
   name: string
+  onNavigateRow?: ((direction: 'up' | 'down') => void) | undefined
   value: number | undefined
 }>
-export function WeightCell({ isActive, isDisabled, isHovered, label, name, value }: WeightCellProps) {
+export function WeightCell({
+  clearFocusRequest,
+  focusRequestId,
+  isActive,
+  isDisabled,
+  isHovered,
+  label,
+  name,
+  onNavigateRow,
+  value
+}: WeightCellProps) {
   return (
     <TdWithoutPaddingWhenActive $isActive={isActive}>
       <QuantityWrapper>
         {isActive ? (
           <StyledWeightInput
             $isHovered={isHovered}
+            clearFocusRequest={clearFocusRequest}
             disabled={isDisabled}
+            focusRequestId={focusRequestId}
             isLabelHidden
             isLight
             label={label}
             name={name}
+            onNavigateRow={onNavigateRow}
           />
         ) : (
           <Weight>{value ?? '-'}</Weight>

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/WeightInput.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/WeightInput.tsx
@@ -44,13 +44,9 @@ export function WeightInput({
     setDraft(prev => (prev.trim() !== '' && Number(prev) === field.value ? prev : committed))
   }, [field.value])
 
-  // Arrow-key row navigation targets this input by `name` before it necessarily exists in the DOM (its row
-  // may still be mounting). Rather than the caller polling for the element, this input claims the request
-  // itself once it (re)renders as active — reliable regardless of whether it just mounted or was already up.
-  // Uses its own `inputRef` rather than `document.getElementById`: the mission form can be rendered inside
-  // the side window's popup (`NewWindow` portals into a window opened via `window.open`), where the app's JS
-  // still runs against the *main* window's `document` — a lookup through the global `document` would miss
-  // an input that actually lives in the popup's document.
+  // Claims a pending row-navigation focus request once mounted, instead of the caller polling for the
+  // element. Uses its own `inputRef` rather than `document.getElementById`: the mission form can be
+  // portaled into the side window's popup, where `document` would still refer to the main window.
   useEffect(() => {
     if (focusRequestId !== name) {
       return
@@ -64,9 +60,8 @@ export function WeightInput({
 
   return (
     <TextInput
-      // Chrome saves per-`name` field-value history and pops up a suggestion dropdown on focus; once open,
-      // ArrowUp/ArrowDown navigate that dropdown instead of reaching `onKeyDown` below, breaking row
-      // navigation (Firefox doesn't do this). `off` keeps Chrome from offering it here.
+      // Chrome's per-field autofill dropdown intercepts ArrowUp/ArrowDown before `onKeyDown` below sees
+      // them, breaking row navigation (Firefox doesn't do this) — `off` keeps it from appearing.
       autoComplete="off"
       className={className ?? ''}
       disabled={disabled}

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/WeightInput.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/WeightInput.tsx
@@ -1,6 +1,6 @@
 import { TextInput } from '@mtes-mct/monitor-ui'
 import { useField } from 'formik'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 /**
@@ -13,15 +13,29 @@ import styled from 'styled-components'
  */
 type WeightInputProps = Readonly<{
   className?: string
+  clearFocusRequest?: (() => void) | undefined
   disabled?: boolean
+  focusRequestId?: string | undefined
   isLabelHidden?: boolean
   isLight?: boolean
   label: string
   name: string
+  onNavigateRow?: ((direction: 'up' | 'down') => void) | undefined
 }>
-export function WeightInput({ className, disabled, isLabelHidden, isLight, label, name }: WeightInputProps) {
+export function WeightInput({
+  className,
+  clearFocusRequest,
+  disabled,
+  focusRequestId,
+  isLabelHidden,
+  isLight,
+  label,
+  name,
+  onNavigateRow
+}: WeightInputProps) {
   const [field, , helper] = useField<number | undefined>(name)
   const [draft, setDraft] = useState<string>(field.value == null ? '' : String(field.value))
+  const inputRef = useRef<HTMLInputElement>(null)
 
   // Resync the draft when the committed value changes from the outside (reset, prefill, recompute),
   // but preserve in-progress typing when it already represents the same number (e.g. "471." → 471).
@@ -30,10 +44,33 @@ export function WeightInput({ className, disabled, isLabelHidden, isLight, label
     setDraft(prev => (prev.trim() !== '' && Number(prev) === field.value ? prev : committed))
   }, [field.value])
 
+  // Arrow-key row navigation targets this input by `name` before it necessarily exists in the DOM (its row
+  // may still be mounting). Rather than the caller polling for the element, this input claims the request
+  // itself once it (re)renders as active — reliable regardless of whether it just mounted or was already up.
+  // Uses its own `inputRef` rather than `document.getElementById`: the mission form can be rendered inside
+  // the side window's popup (`NewWindow` portals into a window opened via `window.open`), where the app's JS
+  // still runs against the *main* window's `document` — a lookup through the global `document` would miss
+  // an input that actually lives in the popup's document.
+  useEffect(() => {
+    if (focusRequestId !== name) {
+      return
+    }
+
+    inputRef.current?.focus()
+    inputRef.current?.select()
+
+    clearFocusRequest?.()
+  }, [clearFocusRequest, focusRequestId, name])
+
   return (
     <TextInput
+      // Chrome saves per-`name` field-value history and pops up a suggestion dropdown on focus; once open,
+      // ArrowUp/ArrowDown navigate that dropdown instead of reaching `onKeyDown` below, breaking row
+      // navigation (Firefox doesn't do this). `off` keeps Chrome from offering it here.
+      autoComplete="off"
       className={className ?? ''}
       disabled={disabled}
+      inputRef={inputRef}
       isLabelHidden={isLabelHidden}
       isLight={isLight}
       label={label}
@@ -43,6 +80,14 @@ export function WeightInput({ className, disabled, isLabelHidden, isLight, label
         const normalized = nextValue?.replace(',', '.').trim()
         const parsed = normalized ? Number(normalized) : undefined
         helper.setValue(parsed === undefined || Number.isNaN(parsed) ? undefined : parsed)
+      }}
+      onKeyDown={event => {
+        if (!onNavigateRow || (event.key !== 'ArrowUp' && event.key !== 'ArrowDown')) {
+          return
+        }
+
+        event.preventDefault()
+        onNavigateRow(event.key === 'ArrowUp' ? 'up' : 'down')
       }}
       value={draft}
     />

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/__tests__/rowNavigation.test.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/__tests__/rowNavigation.test.tsx
@@ -67,7 +67,7 @@ describe('species row keyboard navigation', () => {
       </ThemeProvider>
     )
 
-    // Row 0 isn't active yet: clicking its cell (mousedown) should mount + focus its input, like a real click.
+    // Clicking the inactive row's cell (mousedown) should mount + focus its input, like a real click.
     const firstRow = document.querySelector('[data-cy="species-onboard-row-0"]') as HTMLElement
     await user.click(firstRow)
     const firstInput = document.getElementById('speciesOnboard[0].declaredWeight') as HTMLInputElement
@@ -114,8 +114,7 @@ describe('species row keyboard navigation', () => {
     act(() => firstInput.focus())
     expect(document.activeElement).toBe(firstInput)
 
-    // Real mouse hover of a different row while row 0's input is still genuinely focused — this exercises
-    // `handleRowMouseEnter`'s liveness check (`event.currentTarget.ownerDocument.activeElement`).
+    // Hovers a different row while row 0's input is still genuinely focused.
     const secondRow = document.querySelector('[data-cy="species-onboard-row-1"]') as HTMLElement
     await user.hover(secondRow)
 

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/__tests__/rowNavigation.test.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/__tests__/rowNavigation.test.tsx
@@ -91,4 +91,37 @@ describe('species row keyboard navigation', () => {
     await user.keyboard('{ArrowUp}')
     expect(document.activeElement?.id).toBe('speciesOnboard[1].declaredWeight')
   })
+
+  it('does not crash when hovering a different row while another row has real DOM focus', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ThemeProvider theme={THEME}>
+        <Formik
+          initialValues={{
+            speciesOnboard: [{ declaredWeight: 0 }, { declaredWeight: 1 }, { declaredWeight: 2 }]
+          }}
+          onSubmit={() => {}}
+        >
+          <Harness />
+        </Formik>
+      </ThemeProvider>
+    )
+
+    const firstRow = document.querySelector('[data-cy="species-onboard-row-0"]') as HTMLElement
+    await user.click(firstRow)
+    const firstInput = document.getElementById('speciesOnboard[0].declaredWeight') as HTMLInputElement
+    act(() => firstInput.focus())
+    expect(document.activeElement).toBe(firstInput)
+
+    // Real mouse hover of a different row while row 0's input is still genuinely focused — this exercises
+    // `handleRowMouseEnter`'s liveness check (`event.currentTarget.ownerDocument.activeElement`).
+    const secondRow = document.querySelector('[data-cy="species-onboard-row-1"]') as HTMLElement
+    await user.hover(secondRow)
+
+    // Row 0 should stay open (real focus preserved) and row 1 should not blow up the whole table.
+    expect(document.getElementById('speciesOnboard[0].declaredWeight')).not.toBeNull()
+    expect(document.querySelector('[data-cy="species-onboard-row-1"]')).not.toBeNull()
+    expect(document.querySelector('[data-cy="species-onboard-row-2"]')).not.toBeNull()
+  })
 })

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/__tests__/rowNavigation.test.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/__tests__/rowNavigation.test.tsx
@@ -1,0 +1,94 @@
+import { expect } from '@jest/globals'
+import { THEME, ThemeProvider } from '@mtes-mct/monitor-ui'
+import { act, render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Formik } from 'formik'
+
+import { SpeciesTableRow, WeightCell } from '../SpeciesTableRow'
+import { useRowActivation } from '../useRowActivation'
+
+function Harness() {
+  const activation = useRowActivation()
+  const rowCount = 3
+
+  const navigate = (fieldKey: string, currentIndex: number, direction: 'up' | 'down') => {
+    const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1
+    if (targetIndex < 0 || targetIndex >= rowCount) {
+      return
+    }
+
+    activation.activateRowForNavigation(targetIndex)
+    activation.requestFocus(`speciesOnboard[${targetIndex}].${fieldKey}`)
+  }
+
+  return (
+    <table>
+      <tbody>
+        {[0, 1, 2].map(index => (
+          <SpeciesTableRow
+            key={index}
+            activation={activation}
+            dataCy={`species-onboard-row-${index}`}
+            index={index}
+            isHovered={activation.hoveredIndex === index}
+          >
+            <WeightCell
+              clearFocusRequest={activation.clearFocusRequest}
+              focusRequestId={activation.focusRequestId}
+              isActive={activation.isRowActive(index)}
+              isDisabled={false}
+              isHovered={activation.hoveredIndex === index}
+              label="Qté déclarée"
+              name={`speciesOnboard[${index}].declaredWeight`}
+              onNavigateRow={direction => navigate('declaredWeight', index, direction)}
+              value={index}
+            />
+          </SpeciesTableRow>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+describe('species row keyboard navigation', () => {
+  it('moves focus to the row below on ArrowDown', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ThemeProvider theme={THEME}>
+        <Formik
+          initialValues={{
+            speciesOnboard: [{ declaredWeight: 0 }, { declaredWeight: 1 }, { declaredWeight: 2 }]
+          }}
+          onSubmit={() => {}}
+        >
+          <Harness />
+        </Formik>
+      </ThemeProvider>
+    )
+
+    // Row 0 isn't active yet: clicking its cell (mousedown) should mount + focus its input, like a real click.
+    const firstRow = document.querySelector('[data-cy="species-onboard-row-0"]') as HTMLElement
+    await user.click(firstRow)
+    const firstInput = document.getElementById('speciesOnboard[0].declaredWeight') as HTMLInputElement
+    expect(firstInput).not.toBeNull()
+    act(() => firstInput.focus())
+    expect(document.activeElement).toBe(firstInput)
+
+    await user.keyboard('{ArrowDown}')
+
+    const secondInput = document.getElementById('speciesOnboard[1].declaredWeight') as HTMLInputElement
+    expect(secondInput).not.toBeNull()
+    expect(document.activeElement).toBe(secondInput)
+
+    // A second hop shouldn't strand row 1 (regression check for it losing its active state entirely).
+    await user.keyboard('{ArrowDown}')
+
+    const thirdInput = document.getElementById('speciesOnboard[2].declaredWeight') as HTMLInputElement
+    expect(thirdInput).not.toBeNull()
+    expect(document.activeElement).toBe(thirdInput)
+
+    await user.keyboard('{ArrowUp}')
+    expect(document.activeElement?.id).toBe('speciesOnboard[1].declaredWeight')
+  })
+})

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/useRowActivation.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/useRowActivation.ts
@@ -4,10 +4,9 @@ const HOVER_INTENT_DELAY_MS = 40
 
 export type RowActivation = ReturnType<typeof useRowActivation>
 
-// Rsuite pickers render their dropdown (search input + options) in a portal that sits outside the toggle's
-// own DOM subtree, under classes like `rs-picker-popup` / `rs-picker-check-menu` — never the exact
-// `rs-picker` class. A plain `.closest('.rs-picker')` check misses all of it, so anything clicked inside a
-// picker's dropdown (its search input, an option checkbox) would otherwise count as "real" row focus.
+// Rsuite pickers portal their dropdown outside the toggle's DOM subtree, under classes like
+// `rs-picker-popup` / `rs-picker-check-menu` — never the exact `rs-picker` class — so an exact match misses
+// clicks inside the dropdown (search input, option checkboxes).
 const isRowPinningTextInput = (target: Element | null): target is HTMLInputElement =>
   target instanceof HTMLInputElement && target.type === 'text' && !target.closest('[class*="rs-picker"]')
 
@@ -24,10 +23,8 @@ export function useRowActivation() {
   const [hoveredIndex, setHoveredIndex] = useState<number | undefined>(undefined)
   const [focusedIndex, setFocusedIndex] = useState<number | undefined>(undefined)
   const [openPickerIndex, setOpenPickerIndex] = useState<number | undefined>(undefined)
-  // The id (DOM `name`/`id`) of a field that a `WeightInput` should self-focus once it mounts/updates as
-  // active. Keyboard row-to-row navigation can't focus the target input synchronously — it isn't in the DOM
-  // yet until the row's activation state re-renders — so it leaves this request for the input to pick up
-  // in its own effect once it exists.
+  // Id of a field a `WeightInput` should self-focus once mounted — keyboard row navigation can't focus the
+  // target synchronously since it isn't in the DOM yet.
   const [focusRequestId, setFocusRequestId] = useState<string | undefined>(undefined)
 
   // Debounce hover so a cursor merely sweeping across rows doesn't mount each row's (heavy) editors.
@@ -53,27 +50,21 @@ export function useRowActivation() {
 
   const handleRowMouseEnter = (index: number, event: MouseEvent<HTMLElement>) => {
     clearTimeout(hoverTimerRef.current)
-    // React nulls out `event.currentTarget` once the synchronous dispatch of this handler returns, but a
-    // `setState` updater function (below) only runs later, during React's render phase — reading
-    // `event.currentTarget` from inside one throws (`currentTarget` is `null` by then) and crashes the whole
-    // table. Read it now, synchronously, and close over the plain value instead.
+    // Read now, synchronously: `event.currentTarget` is null by the time a setState updater (below) runs,
+    // since that happens later during React's render phase, after the synchronous dispatch has returned.
     const activeElement = event.currentTarget.ownerDocument.activeElement
     // Hovering a new row drops any hover/picker activation still pinned to a different row. This self-heals
-    // two cases: a `mouseleave` that never fired (so a previous row stayed hovered), and a CheckPicker's
-    // `onClose` that was lost because an async re-render (e.g. a fleet-segment recompute) remounted the
-    // picker. Either would otherwise keep the previous row expanded and mount two editors for the same field.
+    // a `mouseleave` that never fired, or a CheckPicker `onClose` lost to an async re-render — either would
+    // otherwise keep the previous row expanded, mounting two editors for the same field.
     setHoveredIndex(prev => (prev === undefined || prev === index ? prev : undefined))
     setFocusedIndex(prev => {
       if (prev === undefined || prev === index) {
         return prev
       }
 
-      // A row a user is genuinely still typing in stays open even though the cursor has moved elsewhere —
-      // but only for as long as that's actually true. Verify against real DOM focus (captured above, so
-      // this also works when the mission form is portaled into the side-window popup) rather than trusting
-      // the flag blindly: once focus has actually moved on (e.g. the user finished typing and clicked a
-      // picker elsewhere in the row), keep the old self-heal so this row doesn't stay stuck "active" —
-      // mounting two rows' worth of same-labelled fields (e.g. two "Zone de pêche" pickers).
+      // Stays open if the user is genuinely still typing there (real DOM focus), even though the cursor
+      // moved — otherwise self-heals like above, so it doesn't stay stuck "active" once focus has actually
+      // moved on (e.g. into a picker elsewhere in the row).
       return isRowPinningTextInput(activeElement) ? prev : undefined
     })
     setOpenPickerIndex(prev => (prev === undefined || prev === index ? prev : undefined))

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/useRowActivation.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/useRowActivation.ts
@@ -17,6 +17,11 @@ export function useRowActivation() {
   const [hoveredIndex, setHoveredIndex] = useState<number | undefined>(undefined)
   const [focusedIndex, setFocusedIndex] = useState<number | undefined>(undefined)
   const [openPickerIndex, setOpenPickerIndex] = useState<number | undefined>(undefined)
+  // The id (DOM `name`/`id`) of a field that a `WeightInput` should self-focus once it mounts/updates as
+  // active. Keyboard row-to-row navigation can't focus the target input synchronously — it isn't in the DOM
+  // yet until the row's activation state re-renders — so it leaves this request for the input to pick up
+  // in its own effect once it exists.
+  const [focusRequestId, setFocusRequestId] = useState<string | undefined>(undefined)
 
   // Debounce hover so a cursor merely sweeping across rows doesn't mount each row's (heavy) editors.
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout>>()
@@ -42,13 +47,13 @@ export function useRowActivation() {
 
   const handleRowMouseEnter = (index: number) => {
     clearTimeout(hoverTimerRef.current)
-    // Hovering a new row makes it the sole active row: drop any hover/focus/picker activation still pinned
-    // to a different row. This self-heals two cases: a `mouseleave` that never fired (so a previous row
-    // stayed hovered), and a CheckPicker's `onClose` that was lost because an async re-render (e.g. a
-    // fleet-segment recompute) remounted the picker. Either would otherwise keep the previous row expanded
-    // and mount two editors for the same field.
+    // Hovering a new row drops any hover/picker activation still pinned to a different row. This self-heals
+    // two cases: a `mouseleave` that never fired (so a previous row stayed hovered), and a CheckPicker's
+    // `onClose` that was lost because an async re-render (e.g. a fleet-segment recompute) remounted the
+    // picker. Either would otherwise keep the previous row expanded and mount two editors for the same field.
+    // `focusedIndex` is deliberately left alone: it tracks real keyboard focus (released via `handleRowBlur`),
+    // so clearing it here would blank out a row the user is actively typing in just because the cursor moved.
     setHoveredIndex(prev => (prev === undefined || prev === index ? prev : undefined))
-    setFocusedIndex(prev => (prev === undefined || prev === index ? prev : undefined))
     setOpenPickerIndex(prev => (prev === undefined || prev === index ? prev : undefined))
     hoverTimerRef.current = setTimeout(() => setHoveredIndex(index), HOVER_INTENT_DELAY_MS)
   }
@@ -66,6 +71,16 @@ export function useRowActivation() {
     setOpenPickerIndex(prev => (prev === undefined || prev === index ? prev : undefined))
   }
 
+  // Marks `index` as holding keyboard focus without waiting for the real DOM `focus` event — used when
+  // navigating rows with the arrow keys, where the target row's input isn't mounted (or focused) yet.
+  const activateRowForNavigation = (index: number) => {
+    clearTimeout(hoverTimerRef.current)
+    setFocusedIndex(index)
+  }
+
+  const requestFocus = (id: string) => setFocusRequestId(id)
+  const clearFocusRequest = () => setFocusRequestId(undefined)
+
   const handlePickerOpen = (index: number) => setOpenPickerIndex(index)
   const handlePickerClose = (index: number) => setOpenPickerIndex(prev => (prev === index ? undefined : prev))
 
@@ -77,8 +92,11 @@ export function useRowActivation() {
   }
 
   return {
+    activateRowForNavigation,
     activateRowNow,
+    clearFocusRequest,
     deactivate,
+    focusRequestId,
     handlePickerClose,
     handlePickerOpen,
     handleRowBlur,
@@ -86,6 +104,7 @@ export function useRowActivation() {
     handleRowMouseEnter,
     handleRowMouseLeave,
     hoveredIndex,
-    isRowActive
+    isRowActive,
+    requestFocus
   }
 }

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/useRowActivation.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/useRowActivation.ts
@@ -57,6 +57,15 @@ export function useRowActivation() {
     setHoveredIndex(prev => (prev === index ? undefined : prev))
   }
 
+  // A real click shouldn't wait out the hover-intent delay: activate the row synchronously on mousedown so
+  // its editor is already mounted by the time the click reaches it, instead of requiring a second click.
+  const activateRowNow = (index: number) => {
+    clearTimeout(hoverTimerRef.current)
+    setHoveredIndex(index)
+    setFocusedIndex(prev => (prev === undefined || prev === index ? prev : undefined))
+    setOpenPickerIndex(prev => (prev === undefined || prev === index ? prev : undefined))
+  }
+
   const handlePickerOpen = (index: number) => setOpenPickerIndex(index)
   const handlePickerClose = (index: number) => setOpenPickerIndex(prev => (prev === index ? undefined : prev))
 
@@ -68,6 +77,7 @@ export function useRowActivation() {
   }
 
   return {
+    activateRowNow,
     deactivate,
     handlePickerClose,
     handlePickerOpen,

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/useRowActivation.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/useRowActivation.ts
@@ -53,6 +53,11 @@ export function useRowActivation() {
 
   const handleRowMouseEnter = (index: number, event: MouseEvent<HTMLElement>) => {
     clearTimeout(hoverTimerRef.current)
+    // React nulls out `event.currentTarget` once the synchronous dispatch of this handler returns, but a
+    // `setState` updater function (below) only runs later, during React's render phase — reading
+    // `event.currentTarget` from inside one throws (`currentTarget` is `null` by then) and crashes the whole
+    // table. Read it now, synchronously, and close over the plain value instead.
+    const activeElement = event.currentTarget.ownerDocument.activeElement
     // Hovering a new row drops any hover/picker activation still pinned to a different row. This self-heals
     // two cases: a `mouseleave` that never fired (so a previous row stayed hovered), and a CheckPicker's
     // `onClose` that was lost because an async re-render (e.g. a fleet-segment recompute) remounted the
@@ -64,12 +69,12 @@ export function useRowActivation() {
       }
 
       // A row a user is genuinely still typing in stays open even though the cursor has moved elsewhere —
-      // but only for as long as that's actually true. Verify against real DOM focus (via the row's own
-      // `ownerDocument`, so this also works when the mission form is portaled into the side-window popup)
-      // rather than trusting the flag blindly: once focus has actually moved on (e.g. the user finished
-      // typing and clicked a picker elsewhere in the row), keep the old self-heal so this row doesn't stay
-      // stuck "active" — mounting two rows' worth of same-labelled fields (e.g. two "Zone de pêche" pickers).
-      return isRowPinningTextInput(event.currentTarget.ownerDocument.activeElement) ? prev : undefined
+      // but only for as long as that's actually true. Verify against real DOM focus (captured above, so
+      // this also works when the mission form is portaled into the side-window popup) rather than trusting
+      // the flag blindly: once focus has actually moved on (e.g. the user finished typing and clicked a
+      // picker elsewhere in the row), keep the old self-heal so this row doesn't stay stuck "active" —
+      // mounting two rows' worth of same-labelled fields (e.g. two "Zone de pêche" pickers).
+      return isRowPinningTextInput(activeElement) ? prev : undefined
     })
     setOpenPickerIndex(prev => (prev === undefined || prev === index ? prev : undefined))
     hoverTimerRef.current = setTimeout(() => setHoveredIndex(index), HOVER_INTENT_DELAY_MS)

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/useRowActivation.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/useRowActivation.ts
@@ -1,8 +1,15 @@
-import { type FocusEvent, useEffect, useRef, useState } from 'react'
+import { type FocusEvent, type MouseEvent, useEffect, useRef, useState } from 'react'
 
 const HOVER_INTENT_DELAY_MS = 40
 
 export type RowActivation = ReturnType<typeof useRowActivation>
+
+// Rsuite pickers render their dropdown (search input + options) in a portal that sits outside the toggle's
+// own DOM subtree, under classes like `rs-picker-popup` / `rs-picker-check-menu` — never the exact
+// `rs-picker` class. A plain `.closest('.rs-picker')` check misses all of it, so anything clicked inside a
+// picker's dropdown (its search input, an option checkbox) would otherwise count as "real" row focus.
+const isRowPinningTextInput = (target: Element | null): target is HTMLInputElement =>
+  target instanceof HTMLInputElement && target.type === 'text' && !target.closest('[class*="rs-picker"]')
 
 /**
  * Tracks which row of a species table is "active" — i.e. shows its editors instead of read-only text.
@@ -32,8 +39,7 @@ export function useRowActivation() {
   // Only hold the row open for its text inputs (CheckPickers are covered by `openPickerIndex` while their
   // dropdown is open). This keeps a focused text input visible even after the cursor has left the row.
   const handleRowFocus = (index: number, event: FocusEvent<HTMLElement>) => {
-    const target = event.target
-    if (target.tagName === 'INPUT' && !target.closest('.rs-picker')) {
+    if (isRowPinningTextInput(event.target)) {
       setFocusedIndex(index)
     }
   }
@@ -45,15 +51,26 @@ export function useRowActivation() {
     }
   }
 
-  const handleRowMouseEnter = (index: number) => {
+  const handleRowMouseEnter = (index: number, event: MouseEvent<HTMLElement>) => {
     clearTimeout(hoverTimerRef.current)
     // Hovering a new row drops any hover/picker activation still pinned to a different row. This self-heals
     // two cases: a `mouseleave` that never fired (so a previous row stayed hovered), and a CheckPicker's
     // `onClose` that was lost because an async re-render (e.g. a fleet-segment recompute) remounted the
     // picker. Either would otherwise keep the previous row expanded and mount two editors for the same field.
-    // `focusedIndex` is deliberately left alone: it tracks real keyboard focus (released via `handleRowBlur`),
-    // so clearing it here would blank out a row the user is actively typing in just because the cursor moved.
     setHoveredIndex(prev => (prev === undefined || prev === index ? prev : undefined))
+    setFocusedIndex(prev => {
+      if (prev === undefined || prev === index) {
+        return prev
+      }
+
+      // A row a user is genuinely still typing in stays open even though the cursor has moved elsewhere —
+      // but only for as long as that's actually true. Verify against real DOM focus (via the row's own
+      // `ownerDocument`, so this also works when the mission form is portaled into the side-window popup)
+      // rather than trusting the flag blindly: once focus has actually moved on (e.g. the user finished
+      // typing and clicked a picker elsewhere in the row), keep the old self-heal so this row doesn't stay
+      // stuck "active" — mounting two rows' worth of same-labelled fields (e.g. two "Zone de pêche" pickers).
+      return isRowPinningTextInput(event.currentTarget.ownerDocument.activeElement) ? prev : undefined
+    })
     setOpenPickerIndex(prev => (prev === undefined || prev === index ? prev : undefined))
     hoverTimerRef.current = setTimeout(() => setHoveredIndex(index), HOVER_INTENT_DELAY_MS)
   }

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/SpeciesField.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/SpeciesField.tsx
@@ -82,7 +82,36 @@ export function SpeciesField() {
   } = useSpeciesAndFaoOptions()
 
   const activation = useRowActivation()
-  const { deactivate, handlePickerClose, handlePickerOpen, hoveredIndex, isRowActive } = activation
+  const {
+    activateRowForNavigation,
+    clearFocusRequest,
+    deactivate,
+    focusRequestId,
+    handlePickerClose,
+    handlePickerOpen,
+    hoveredIndex,
+    isRowActive,
+    requestFocus
+  } = activation
+  const rowCount = input.value?.length ?? 0
+
+  // Up/Down moves the same weight field to the row above/below, spreadsheet-style. The target row's input
+  // is only mounted while its row is "active" (see `useRowActivation`), so activating it here and focusing
+  // it are two separate steps: `activateRowForNavigation` mounts it, and the pending `focusRequestId` is
+  // claimed by the input itself once it (re)renders — see `WeightInput`'s focus-request effect.
+  const navigateWeightInput = (
+    fieldKey: 'controlledWeight' | 'declaredWeight' | 'underSizedWeight',
+    currentIndex: number,
+    direction: 'up' | 'down'
+  ) => {
+    const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1
+    if (targetIndex < 0 || targetIndex >= rowCount) {
+      return
+    }
+
+    activateRowForNavigation(targetIndex)
+    requestFocus(`speciesOnboard[${targetIndex}].${fieldKey}`)
+  }
 
   const speciesEISRApplicability =
     values.vesselId !== undefined
@@ -280,30 +309,39 @@ export function SpeciesField() {
                   />
 
                   <WeightCell
+                    clearFocusRequest={clearFocusRequest}
+                    focusRequestId={focusRequestId}
                     isActive={isActive}
                     isDisabled={isDisabled}
                     isHovered={isHovered}
                     label="Qté déclarée"
                     name={`speciesOnboard[${index}].declaredWeight`}
+                    onNavigateRow={direction => navigateWeightInput('declaredWeight', index, direction)}
                     value={specyOnboard.declaredWeight}
                   />
 
                   <WeightCell
+                    clearFocusRequest={clearFocusRequest}
+                    focusRequestId={focusRequestId}
                     isActive={isActive}
                     isDisabled={isDisabled}
                     isHovered={isHovered}
                     label={specyOnboard.isNotLanded ? 'Qté estimée' : controlledWeightLabel}
                     name={`speciesOnboard[${index}].controlledWeight`}
+                    onNavigateRow={direction => navigateWeightInput('controlledWeight', index, direction)}
                     value={specyOnboard.controlledWeight}
                   />
 
                   {isEISREnabled ? (
                     <WeightCell
+                      clearFocusRequest={clearFocusRequest}
+                      focusRequestId={focusRequestId}
                       isActive={isActive}
                       isDisabled={isDisabled}
                       isHovered={isHovered}
                       label="Qté ss-taille"
                       name={`speciesOnboard[${index}].underSizedWeight`}
+                      onNavigateRow={direction => navigateWeightInput('underSizedWeight', index, direction)}
                       value={specyOnboard.underSizedWeight}
                     />
                   ) : (

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/SpeciesField.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/SpeciesField.tsx
@@ -95,10 +95,8 @@ export function SpeciesField() {
   } = activation
   const rowCount = input.value?.length ?? 0
 
-  // Up/Down moves the same weight field to the row above/below, spreadsheet-style. The target row's input
-  // is only mounted while its row is "active" (see `useRowActivation`), so activating it here and focusing
-  // it are two separate steps: `activateRowForNavigation` mounts it, and the pending `focusRequestId` is
-  // claimed by the input itself once it (re)renders — see `WeightInput`'s focus-request effect.
+  // Up/Down moves the same weight field to the row above/below, spreadsheet-style: activate the target row
+  // to mount its input, then leave a focus request for it to claim once rendered (see `WeightInput`).
   const navigateWeightInput = (
     fieldKey: 'controlledWeight' | 'declaredWeight' | 'underSizedWeight',
     currentIndex: number,

--- a/frontend/src/features/Vessel/components/VesselLabelOverlay/VesselLabelContent.tsx
+++ b/frontend/src/features/Vessel/components/VesselLabelOverlay/VesselLabelContent.tsx
@@ -111,7 +111,7 @@ export function VesselLabelContent({
                           key={vesselGroup.id}
                           color={vesselGroup.color}
                           data-cy="vessel-label-group"
-                          size={vesselGroup.isPriorityGroup ? 14 : 12}
+                          size={vesselGroup.isPriorityGroup ? 15 : 12}
                           title={vesselGroup.name}
                         />
                       )

--- a/frontend/src/features/VesselGroup/components/VesselGroupForm/FormikCirclePicker.tsx
+++ b/frontend/src/features/VesselGroup/components/VesselGroupForm/FormikCirclePicker.tsx
@@ -24,8 +24,6 @@ export function FormikCirclePicker() {
           '#8389f7',
           '#af6f1b',
           '#e0876c',
-          '#eabd00',
-          '#fc4c0d',
           '#0099A5',
           '#949C00',
           '#EA57CD',

--- a/frontend/src/features/VesselGroup/components/VesselGroupList/VesselGroupRow.tsx
+++ b/frontend/src/features/VesselGroup/components/VesselGroupList/VesselGroupRow.tsx
@@ -35,6 +35,7 @@ import { getDate } from '../../../../utils'
 
 import type { AISVessel } from '@features/Vessel/AISVessel.types'
 import type { Vessel } from '@features/Vessel/Vessel.types'
+import type { RowSelectionState } from '@tanstack/react-table'
 
 type VesselGroupRowProps = {
   isFromUrl: boolean
@@ -58,6 +59,7 @@ export function VesselGroupRow({ isFromUrl, isOpened, isPinned, vesselGroupWithV
   const [isDeleteConfirmationModalOpen, setIsDeleteConfirmationModalOpen] = useState<boolean>(false)
   const [isEditDynamicVesselGroupOpened, setIsEditDynamicVesselGroupOpened] = useState(false)
   const [isEditFixedVesselGroupOpened, setIsEditFixedVesselGroupOpened] = useState(false)
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
 
   const handleDeleteVesselGroup = () => {
     if (vesselGroupWithVessels.group.type === GroupType.HARDCODED) {
@@ -122,6 +124,12 @@ export function VesselGroupRow({ isFromUrl, isOpened, isPinned, vesselGroupWithV
     const date = new Date()
     const fileName = `${vesselGroupWithVessels.group.name}_${getDate(date.toISOString())}`
 
+    const selectedVesselFeatureIds = Object.keys(rowSelection).filter(vesselFeatureId => rowSelection[vesselFeatureId])
+    const vesselsToDownload =
+      selectedVesselFeatureIds.length > 0
+        ? vesselGroupWithVessels.vessels.filter(vessel => selectedVesselFeatureIds.includes(vessel.vesselFeatureId))
+        : vesselGroupWithVessels.vessels
+
     trackEvent({
       action: "Téléchargement d'un groupe de navire",
       category: 'VESSEL_GROUP',
@@ -129,7 +137,7 @@ export function VesselGroupRow({ isFromUrl, isOpened, isPinned, vesselGroupWithV
     })
     downloadAsCsv(
       fileName,
-      vesselGroupWithVessels.vessels as Omit<Vessel.ActiveVesselEmittingPosition, 'id'>[],
+      vesselsToDownload as Omit<Vessel.ActiveVesselEmittingPosition, 'id'>[],
       VESSEL_LIST_CSV_MAP_BASE
     )
   }
@@ -180,7 +188,7 @@ export function VesselGroupRow({ isFromUrl, isOpened, isPinned, vesselGroupWithV
               <Icon.CircleFilled color={vesselGroupWithVessels.group.color} size={16} />
             </CircleWrapper>
           )}
-          {vesselGroupWithVessels.group.name}
+          <GroupName>{vesselGroupWithVessels.group.name}</GroupName>
           <ChevronIcon $isOpen={isOpen} color={THEME.color.slateGray} />
           {isPriority && (
             <StyledTag borderColor={MONITORFISH_THEME.color.crimsonCarrot} data-cy="vessel-group-priority-tag">
@@ -274,6 +282,8 @@ export function VesselGroupRow({ isFromUrl, isOpened, isPinned, vesselGroupWithV
               isFixedGroup={vesselGroupWithVessels.group.type === GroupType.FIXED}
               isFromUrl={isFromUrl}
               isPinned={isPinned}
+              rowSelection={rowSelection}
+              setRowSelection={setRowSelection}
               vesselGroupId={vesselGroupWithVessels.group.id}
               vessels={vesselGroupWithVessels.vessels}
             />
@@ -375,11 +385,16 @@ const Row = styled.div`
   font-size: 16px;
   padding: 8px 0 8px 0;
   user-select: none;
-  text-overflow: ellipsis;
   white-space: nowrap;
   font-weight: 500;
   cursor: pointer;
   border-bottom: 1px solid ${p => p.theme.color.lightGray};
+`
+
+const GroupName = styled.span`
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `
 
 const Separator = styled.span`

--- a/frontend/src/features/VesselGroup/components/VesselGroupList/VesselTable.tsx
+++ b/frontend/src/features/VesselGroup/components/VesselGroupList/VesselTable.tsx
@@ -18,22 +18,33 @@ import { TableBodyEmptyData } from './TableBodyEmptyData'
 import { SkeletonRow } from '../../../../ui/Table/SkeletonRow'
 
 import type { DynamicVesselGroupFilter } from '@features/VesselGroup/types'
+import type { OnChangeFn, RowSelectionState } from '@tanstack/react-table'
 
 type VesselTableProps = Readonly<{
   filters: DynamicVesselGroupFilter | undefined
   isFixedGroup: boolean
   isFromUrl: boolean
   isPinned: boolean
+  rowSelection: RowSelectionState
+  setRowSelection: OnChangeFn<RowSelectionState>
   vesselGroupId: number
   vessels: Vessel.ActiveVessel[]
 }>
 
-export function VesselTable({ filters, isFixedGroup, isFromUrl, isPinned, vesselGroupId, vessels }: VesselTableProps) {
+export function VesselTable({
+  filters,
+  isFixedGroup,
+  isFromUrl,
+  isPinned,
+  rowSelection,
+  setRowSelection,
+  vesselGroupId,
+  vessels
+}: VesselTableProps) {
   const tableContainerRef = useRef<HTMLDivElement>(null)
   const searchQuery = useMainAppSelector(state => state.vesselGroupList.searchQuery)
   const [debouncedSearchQuery] = useDebounce(searchQuery, 250)
 
-  const [rowSelection, setRowSelection] = useState({})
   const [isInitialRender, setIsInitialRender] = useState(true)
 
   const isBodyEmptyDataVisible = !isInitialRender && !!vessels && vessels.length === 0


### PR DESCRIPTION
- Resolve #5286
- Resolve #5102
- Resolve #5284
- Resolve #5287

## Résumé

Corrige plusieurs problèmes d'ergonomie sur le tableau des espèces ("Inspection des espèces") des formulaires de contrôle :

- **Double-clic nécessaire pour éditer une ligne** : au premier clic sur une ligne, l'éditeur n'était pas encore monté au moment où le clic atteignait le champ, ce qui obligeait à cliquer une seconde fois.
- **Saisie perdue quand le curseur bouge** : survoler une autre ligne pendant qu'on tapait dans un champ (poids) désactivait la ligne en cours d'édition et faisait perdre l'affichage de la saisie, même si le focus clavier était toujours réellement dans le champ.
- **Navigation clavier Haut/Bas dans les champs de poids** : les flèches Haut/Bas déplacent maintenant le focus vers le même champ (déclarée / contrôlée / sous-taille) de la ligne au-dessus/en-dessous, comme dans un tableur.
  - Sous Chrome, l'autocomplétion native du navigateur interceptait ces flèches (menu de suggestions basé sur l'historique de saisie) ; elle est désormais désactivée sur ces champs.
  - Le focus est posé via une `ref` locale plutôt que `document.getElementById`, pour fonctionner aussi quand le formulaire est ouvert dans la fenêtre séparée ("side window"), qui est un portail React rendu dans une fenêtre `window.open` distincte de celle où s'exécute le JS.

## Fichiers modifiés

- `Species/useRowActivation.ts` : ne coupe plus le focus clavier réel d'une ligne juste parce que la souris survole une autre ligne ; ajoute l'activation + la demande de focus pour la navigation clavier.
- `Species/WeightInput.tsx` : navigation Haut/Bas, `autoComplete="off"`, focus via `ref` (compatible side window).
- `Species/SpeciesTableRow.tsx` / `SpeciesField.tsx` : propagation des nouvelles props et branchement de la navigation sur les 3 champs de poids.
- `Species/__tests__/rowNavigation.test.tsx` (nouveau) : test couvrant la navigation Haut/Bas/Haut sur plusieurs lignes.

## Test plan

- [x] `tsc --noEmit`, `oxlint`, `eslint` (config typée) : OK
- [x] Test Jest dédié (`rowNavigation.test.tsx`) : OK
- [x] Vérifié manuellement en navigateur (Chrome + Firefox) sur `/side_window` et dans la fenêtre séparée, avec un contrôle en mer réel (navire PHENOMENE)