### PR TITLE
Profil de navires & Signalements - Corrections

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/alerts/type/Alert.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/alerts/type/Alert.kt
@@ -15,6 +15,7 @@ class Alert(
     val alertId: Int? = null,
     val name: String,
     val description: String? = null,
+    val depth: Double? = null,
 ) {
     init {
         if (this.type == AlertType.POSITION_ALERT) {

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/reporting/Reporting.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/reporting/Reporting.kt
@@ -87,6 +87,7 @@ sealed class Reporting {
         val alertId: Int? = null,
         val name: String,
         val alertDescription: String? = null,
+        val depth: Double? = null,
     ) : Reporting() {
         init {
             if (this.alertType == AlertType.POSITION_ALERT) {

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/mappers/ReportingMapper.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/mappers/ReportingMapper.kt
@@ -71,6 +71,7 @@ object ReportingMapper {
                         alertId = alertValue.alertId,
                         name = alertValue.name,
                         alertDescription = alertValue.description,
+                        depth = alertValue.depth,
                     )
                 }
 
@@ -207,6 +208,7 @@ object ReportingMapper {
                     alertId = reporting.alertId,
                     name = reporting.name,
                     description = reporting.alertDescription,
+                    depth = reporting.depth,
                 )
 
             is Reporting.InfractionSuspicion ->

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/serialization/AlertValueDto.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/serialization/AlertValueDto.kt
@@ -20,6 +20,7 @@ data class AlertValueDto(
     val alertId: Int? = null,
     val name: String,
     val description: String? = null,
+    val depth: Double? = null,
 ) {
     fun toAlert(): Alert =
         Alert(
@@ -33,5 +34,6 @@ data class AlertValueDto(
             alertId = alertId,
             name = name,
             description = description,
+            depth = depth,
         )
 }

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/mappers/ReportingMapperUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/mappers/ReportingMapperUTests.kt
@@ -83,6 +83,7 @@ class ReportingMapperUTests {
                 threatCharacterization = "DEP",
                 riskFactor = 2.356,
                 name = "Chalutage dans les 3 milles",
+                depth = 123.4,
             )
 
         // When
@@ -100,6 +101,7 @@ class ReportingMapperUTests {
         parsedReporting as Reporting.Alert
         Assertions.assertThat(parsedReporting.seaFront).isEqualTo("NAMO")
         Assertions.assertThat(parsedReporting.riskFactor).isEqualTo(2.356)
+        Assertions.assertThat(parsedReporting.depth).isEqualTo(123.4)
     }
 
     @Test
@@ -258,6 +260,7 @@ class ReportingMapperUTests {
                 threat = "Obligations déclaratives",
                 threatCharacterization = "DEP",
                 name = "Chalutage dans les 3 milles",
+                depth = 123.4,
             )
 
         // When
@@ -271,6 +274,7 @@ class ReportingMapperUTests {
         Assertions.assertThat(alertValue.alertId).isEqualTo(1)
         Assertions.assertThat(alertValue.natinfCode).isEqualTo(7059)
         Assertions.assertThat(alertValue.name).isEqualTo("Chalutage dans les 3 milles")
+        Assertions.assertThat(alertValue.depth).isEqualTo(123.4)
     }
 
     @Test

--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -764,11 +764,6 @@
       "count": 6
     }
   },
-  "src/features/Vessel/components/VesselSidebar/components/VesselProfile/__tests__/utils.test.ts": {
-    "@typescript-eslint/require-await": {
-      "count": 1
-    }
-  },
   "src/features/Vessel/layers/utils/utils.ts": {
     "@typescript-eslint/prefer-nullish-coalescing": {
       "count": 4

--- a/frontend/src/features/Vessel/components/VesselSidebar/components/VesselProfile/ProfileBarChart.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/components/VesselProfile/ProfileBarChart.tsx
@@ -43,6 +43,7 @@ const Header = styled.span`
 const Chart = styled.div`
   display: flex;
   flex-direction: row;
+  overflow: hidden;
 `
 
 const Bar = styled.div<{

--- a/frontend/src/features/Vessel/components/VesselSidebar/components/VesselProfile/__tests__/utils.test.ts
+++ b/frontend/src/features/Vessel/components/VesselSidebar/components/VesselProfile/__tests__/utils.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from '@jest/globals'
 import { getSortedProfileBarsByDesc } from '../utils'
 
 describe('utils', () => {
-  it('getSortedProfileBarsByDesc Should return the percent of each bar', async () => {
+  it('getSortedProfileBarsByDesc Should return the percent of each bar', () => {
     const profile = {
       ANF: 0.0014431550681949913,
       BIB: 0.020464412032601107,
@@ -34,6 +34,24 @@ describe('utils', () => {
       { color: '#C9EEE8', key: 'SYC', value: '4.3' },
       { color: '#C5DADE', key: 'MUR', value: '3.3' },
       { color: '#E1F2F5', key: 'Autres', value: '17.1' }
+    ])
+  })
+
+  it('getSortedProfileBarsByDesc Should not return bars whose rounded percentage is 0.0', () => {
+    const profile = {
+      ANF: 0.0001,
+      BIB: 0.0002,
+      HKE: 0.976,
+      JOD: 0.0003
+    }
+
+    // When
+    const bars = getSortedProfileBarsByDesc(profile)
+
+    // Then
+    expect(bars).toStrictEqual([
+      { color: '#A6E3DD', key: 'HKE', value: '97.6' },
+      { color: '#E1F2F5', key: 'Autres', value: '2.4' }
     ])
   })
 })

--- a/frontend/src/features/Vessel/components/VesselSidebar/components/VesselProfile/index.tsx
+++ b/frontend/src/features/Vessel/components/VesselSidebar/components/VesselProfile/index.tsx
@@ -20,7 +20,7 @@ export function VesselProfile() {
     <Wrapper data-cy="vessel-profile">
       <Header>
         Profil du navire{' '}
-        <StyledIcon size={16} title="Le profile de navire est calculé sur 1 an de déclarations de captures." />
+        <StyledIcon size={16} title="Le profil de navire est calculé sur 1 an de déclarations de captures." />
       </Header>
       {!selectedVessel?.profile?.gears &&
         !selectedVessel?.profile?.species &&

--- a/frontend/src/features/Vessel/components/VesselSidebar/components/VesselProfile/utils.ts
+++ b/frontend/src/features/Vessel/components/VesselSidebar/components/VesselProfile/utils.ts
@@ -9,7 +9,7 @@ export function getSortedProfileBarsByDesc(profile: Record<string, number>) {
       key,
       value: (profile[key] && profile[key] * 100)?.toFixed(1) ?? 0
     }))
-    .filter(bar => !!bar.value)
+    .filter(bar => Number(bar.value) > 0)
 
   const total = filteredSortedByDesc.reduce((acc, current) => acc + Number(current.value), 0)
 


### PR DESCRIPTION
- Propagate `depth` from PendingAlert through Alert/AlertValueDto/Reporting so it is no longer silently dropped when an alert becomes a reporting (#4841)
- Fix profile gauge bars overflowing past the card edge: the zero-value bar filter compared a formatted string ("0.0") which is always truthy, so near-zero bars still rendered and crowded past the right margin; also clip the chart row and fix the "profile" -> "profil" tooltip typo (#5143)

## Linked issues

- Resolve #4841
- Resolve #5143

----

- [ ] Tests E2E (Cypress)
