### PR TITLE
Désactiver l'affichage des groupes prioritaires pour les unités ext

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/vessel_groups/GetAllUserVesselGroups.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/vessel_groups/GetAllUserVesselGroups.kt
@@ -16,14 +16,18 @@ class GetAllUserVesselGroups(
     private val logger: Logger = LoggerFactory.getLogger(GetAllUserVesselGroups::class.java)
 
     fun execute(userEmail: String): List<VesselGroupBase> {
-        val userService = getAuthorizedUser.execute(userEmail).service
+        val authorizedUser = getAuthorizedUser.execute(userEmail)
 
         val userGroups =
             vesselGroupRepository.findAllByUserAndSharing(
                 user = userEmail,
-                service = userService,
+                service = authorizedUser.service,
             )
 
-        return PriorityVesselGroup.PRIORITY_GROUPS + userGroups
+        return if (authorizedUser.isSuperUser) {
+            PriorityVesselGroup.PRIORITY_GROUPS + userGroups
+        } else {
+            userGroups
+        }
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/vessel_groups/GetAllUserVesselGroupsUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/vessel_groups/GetAllUserVesselGroupsUTests.kt
@@ -25,12 +25,14 @@ class GetAllUserVesselGroupsUTests {
     @MockitoBean
     private lateinit var getAuthorizedUser: GetAuthorizedUser
 
-    private fun authorizedUser(service: CnspService? = null) =
-        AuthorizedUser(email = "dummy@email.gouv.fr", isSuperUser = false, service = service)
+    private fun authorizedUser(
+        service: CnspService? = null,
+        isSuperUser: Boolean = false,
+    ) = AuthorizedUser(email = "dummy@email.gouv.fr", isSuperUser = isSuperUser, service = service)
 
     @Test
-    fun `execute returns the union of priority groups and user groups`() {
-        given(getAuthorizedUser.execute(any())).willReturn(authorizedUser())
+    fun `execute returns the union of priority groups and user groups for a super user`() {
+        given(getAuthorizedUser.execute(any())).willReturn(authorizedUser(isSuperUser = true))
         given(vesselGroupRepository.findAllByUserAndSharing(any(), anyOrNull())).willReturn(getDynamicVesselGroups())
 
         val groups = GetAllUserVesselGroups(vesselGroupRepository, getAuthorizedUser).execute("dummy@email.gouv.fr")
@@ -40,13 +42,24 @@ class GetAllUserVesselGroupsUTests {
     }
 
     @Test
-    fun `execute returns only priority groups when the user has no groups`() {
-        given(getAuthorizedUser.execute(any())).willReturn(authorizedUser())
+    fun `execute returns only priority groups when a super user has no groups`() {
+        given(getAuthorizedUser.execute(any())).willReturn(authorizedUser(isSuperUser = true))
         given(vesselGroupRepository.findAllByUserAndSharing(any(), anyOrNull())).willReturn(emptyList())
 
         val groups = GetAllUserVesselGroups(vesselGroupRepository, getAuthorizedUser).execute("dummy@email.gouv.fr")
 
         assertThat(groups).containsExactlyInAnyOrderElementsOf(PriorityVesselGroup.PRIORITY_GROUPS)
+    }
+
+    @Test
+    fun `execute excludes priority groups for a non-super user`() {
+        given(getAuthorizedUser.execute(any())).willReturn(authorizedUser(isSuperUser = false))
+        given(vesselGroupRepository.findAllByUserAndSharing(any(), anyOrNull())).willReturn(getDynamicVesselGroups())
+
+        val groups = GetAllUserVesselGroups(vesselGroupRepository, getAuthorizedUser).execute("dummy@email.gouv.fr")
+
+        assertThat(groups).doesNotContainAnyElementsOf(PriorityVesselGroup.PRIORITY_GROUPS)
+        assertThat(groups).containsExactlyInAnyOrderElementsOf(getDynamicVesselGroups())
     }
 
     @Test

--- a/frontend/cypress/e2e/vessels/vessel_groups.spec.ts
+++ b/frontend/cypress/e2e/vessels/vessel_groups.spec.ts
@@ -285,6 +285,9 @@ context('Vessel groups', () => {
     cy.get('[title="#8c2c17"]').click()
     cy.fill('Nom du groupe', 'Dolor sit amet')
     cy.fill('Description du groupe', 'Consectetur adipiscing elit. Integer egestas pulvinar lacus quis fringilla.')
+    // The "Cibles prioritaires" checkbox is only displayed for shared groups
+    cy.fill('Partage du groupe', 'Groupe partagé')
+    cy.fill('Partager le groupe avec...', ['Pôle OPS métropole'])
     cy.fill('Cibles prioritaires', true)
     cy.clickButton('Créer le groupe')
     cy.contains('Le groupe de navires fixe "Dolor sit amet" a bien été créé.').should('be.visible')

--- a/frontend/src/features/VesselGroup/components/VesselGroupForm/index.tsx
+++ b/frontend/src/features/VesselGroup/components/VesselGroupForm/index.tsx
@@ -7,6 +7,7 @@ import {
   CreateOrUpdateFixedVesselGroupSchema,
   type DynamicVesselGroupFilter,
   GroupType,
+  Sharing,
   type CreateOrUpdateDynamicVesselGroup,
   type CreateOrUpdateVesselGroup,
   type VesselIdentityForVesselGroup
@@ -95,7 +96,7 @@ export function VesselGroupForm({
         onSubmit={handleOnSubmit}
         validate={validationSchema}
       >
-        {({ errors }) => (
+        {({ errors, values }) => (
           <>
             {isMainWindow && groupType === GroupType.DYNAMIC && (
               <FormikEffect
@@ -138,14 +139,16 @@ export function VesselGroupForm({
               </Column>
             </Columns>
             <FormikSharingOptions />
-            <PriorityGroup>
-              <FormikCheckbox label="Cibles prioritaires" name="isPriorityGroup" />
-              <Icon.Info
-                color={THEME.color.blueYonder}
-                size={18}
-                title="Les navires appartenant à ce groupe seront à contrôler en priorité. Dans le CR de contrôle (et donc dans les statistiques), ils seront identifiés comme des cibles prioritaires. "
-              />
-            </PriorityGroup>
+            {values.sharing === Sharing.SHARED && (
+              <PriorityGroup>
+                <FormikCheckbox label="Cibles prioritaires" name="isPriorityGroup" />
+                <Icon.Info
+                  color={THEME.color.blueYonder}
+                  size={18}
+                  title="Les navires appartenant à ce groupe seront à contrôler en priorité. Dans le CR de contrôle (et donc dans les statistiques), ils seront identifiés comme des cibles prioritaires. "
+                />
+              </PriorityGroup>
+            )}
           </>
         )}
       </Formik>


### PR DESCRIPTION
## Linked issues

- Resolve #5312
- #4792: Affichage du checkbox uniquement pour les groupes partagés

----

- [ ] Tests E2E (Cypress)
