### PR TITLE
CR contrôle – Suivre les contrôles faits sur des cibles prioritaires

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/Constants.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/Constants.kt
@@ -1,3 +1,35 @@
 package fr.gouv.cnsp.monitorfish.domain
 
 val FRENCH_COUNTRY_CODES = listOf<String>("FR", "BL", "GF", "GP", "MF", "MQ", "NC", "PF", "PM", "RE", "TF", "WF", "YT")
+
+/** Kept in sync with `EU_COUNTRY_CODES` in the frontend `AlertManagementForm/constants.ts`. */
+val EU_COUNTRY_CODES =
+    listOf<String>(
+        "AT",
+        "BE",
+        "BG",
+        "HR",
+        "CY",
+        "CZ",
+        "DK",
+        "EE",
+        "FI",
+        "FR",
+        "DE",
+        "GR",
+        "HU",
+        "IE",
+        "IT",
+        "LV",
+        "LT",
+        "LU",
+        "MT",
+        "NL",
+        "PL",
+        "PT",
+        "RO",
+        "SK",
+        "SI",
+        "ES",
+        "SE",
+    )

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/mission/mission_actions/MissionAction.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/mission/mission_actions/MissionAction.kt
@@ -2,6 +2,8 @@ package fr.gouv.cnsp.monitorfish.domain.entities.mission.mission_actions
 
 import com.neovisionaries.i18n.CountryCode
 import fr.gouv.cnsp.monitorfish.config.Patchable
+import fr.gouv.cnsp.monitorfish.domain.EU_COUNTRY_CODES
+import fr.gouv.cnsp.monitorfish.domain.FRENCH_COUNTRY_CODES
 import fr.gouv.cnsp.monitorfish.domain.entities.control_unit.LegacyControlUnit
 import java.time.ZonedDateTime
 
@@ -117,9 +119,29 @@ data class MissionAction(
 
     /**
      * A control targets a prioritized vessel when, at the moment of control, the vessel belonged to a
-     * priority group or had a reporting opened during its current trip. Derived from the snapshot.
+     * priority group or had a reporting opened during its current trip (both derived from the snapshot),
+     * when the control is an INN one, or when a third country vessel lands in a French port.
+     *
+     * /!\ Kept in sync with `getPriorityTargetReasons()` in the frontend, which displays the reasons.
      */
-    fun computeIsPrioritized(): Boolean = vesselGroups.any { it.isPriorityGroup } || tripReportings.isNotEmpty()
+    fun computeIsPrioritized(): Boolean =
+        vesselGroups.any { it.isPriorityGroup } ||
+            tripReportings.isNotEmpty() ||
+            isINNControl ||
+            isThirdCountryVesselLandingInFrance()
+
+    /**
+     * A UN/LOCODE is prefixed with the ISO alpha-2 code of the territory the port belongs to, so overseas
+     * ports carry their own code (`RE`, `GF`...) rather than `FR`.
+     */
+    private fun isThirdCountryVesselLandingInFrance(): Boolean {
+        val portCountryCode = portLocode?.take(2) ?: return false
+
+        return actionType == MissionActionType.LAND_CONTROL &&
+            FRENCH_COUNTRY_CODES.contains(portCountryCode) &&
+            flagState != CountryCode.UNDEFINED &&
+            !EU_COUNTRY_CODES.contains(flagState.alpha2)
+    }
 
     fun containsNoInfractions(): Boolean = infractions.isEmpty()
 

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/mission/mission_actions/MissionActionUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/mission/mission_actions/MissionActionUTests.kt
@@ -181,21 +181,7 @@ class MissionActionUTests {
     @Test
     fun `computeIsPrioritized Should be true When the vessel is in a priority group or has a current trip reporting`() {
         // Given
-        val baseAction =
-            MissionAction(
-                id = null,
-                vesselId = 1,
-                missionId = 1,
-                actionDatetimeUtc = ZonedDateTime.now(),
-                actionType = MissionActionType.SEA_CONTROL,
-                isDeleted = false,
-                userTrigram = "LTH",
-                hasSomeGearsSeized = false,
-                hasSomeSpeciesSeized = false,
-                isFromPoseidon = false,
-                completion = Completion.TO_COMPLETE,
-                flagState = CountryCode.FR,
-            )
+        val baseAction = getBaseAction()
         val priorityGroup =
             MissionActionVesselGroup(
                 id = 1,
@@ -220,4 +206,65 @@ class MissionActionUTests {
         assertThat(baseAction.copy(vesselGroups = listOf(nonPriorityGroup)).computeIsPrioritized()).isFalse()
         assertThat(baseAction.computeIsPrioritized()).isFalse()
     }
+
+    @Test
+    fun `computeIsPrioritized Should be true When the control is an INN control`() {
+        // Given
+        val baseAction = getBaseAction()
+
+        // When / Then
+        assertThat(baseAction.copy(isINNControl = true).computeIsPrioritized()).isTrue()
+        assertThat(baseAction.computeIsPrioritized()).isFalse()
+    }
+
+    @Test
+    fun `computeIsPrioritized Should be true When a third country vessel lands in a French port`() {
+        // Given
+        val landControl =
+            getBaseAction().copy(
+                actionType = MissionActionType.LAND_CONTROL,
+                flagState = CountryCode.MA,
+                portLocode = "FRAUR",
+            )
+
+        // When / Then
+        assertThat(landControl.computeIsPrioritized()).isTrue()
+        // Overseas French ports carry their own country code in the LOCODE prefix
+        assertThat(landControl.copy(portLocode = "REPTP").computeIsPrioritized()).isTrue()
+        assertThat(landControl.copy(portLocode = "GFCAY").computeIsPrioritized()).isTrue()
+    }
+
+    @Test
+    fun `computeIsPrioritized Should be false When the third country landing conditions are not met`() {
+        // Given
+        val landControl =
+            getBaseAction().copy(
+                actionType = MissionActionType.LAND_CONTROL,
+                flagState = CountryCode.MA,
+                portLocode = "FRAUR",
+            )
+
+        // When / Then
+        assertThat(landControl.copy(flagState = CountryCode.ES).computeIsPrioritized()).isFalse()
+        assertThat(landControl.copy(flagState = CountryCode.UNDEFINED).computeIsPrioritized()).isFalse()
+        assertThat(landControl.copy(portLocode = "ESVGO").computeIsPrioritized()).isFalse()
+        assertThat(landControl.copy(portLocode = null).computeIsPrioritized()).isFalse()
+        assertThat(landControl.copy(actionType = MissionActionType.SEA_CONTROL).computeIsPrioritized()).isFalse()
+    }
+
+    private fun getBaseAction(): MissionAction =
+        MissionAction(
+            id = null,
+            vesselId = 1,
+            missionId = 1,
+            actionDatetimeUtc = ZonedDateTime.now(),
+            actionType = MissionActionType.SEA_CONTROL,
+            isDeleted = false,
+            userTrigram = "LTH",
+            hasSomeGearsSeized = false,
+            hasSomeSpeciesSeized = false,
+            isFromPoseidon = false,
+            completion = Completion.TO_COMPLETE,
+            flagState = CountryCode.FR,
+        )
 }

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -27,3 +27,6 @@ export const COUNTRIES_AS_ALPHA3_OPTIONS: Option<string>[] = Object.keys(Countri
 }))
 
 export const UNKNOWN_COUNTRY_CODE = 'UNKNOWN'
+
+/** Metropolitan France and its overseas territories. Kept in sync with `FRENCH_COUNTRY_CODES` in the backend `Constants.kt`. */
+export const FRENCH_COUNTRY_CODES = ['FR', 'BL', 'GF', 'GP', 'MF', 'MQ', 'NC', 'PF', 'PM', 'RE', 'TF', 'WF', 'YT']

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/ControlQualityField.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/ControlQualityField.tsx
@@ -34,7 +34,7 @@ export function ControlQualityField({ withLastHaul = false }: ControlQualityFiel
               {joinReasons(reasons)}.
             </>
           ) : (
-            <strong>Le navire n’est pas considéré comme une cible prioritaire.</strong>
+            'Le navire n’est pas considéré comme une cible prioritaire.'
           )}
         </PriorityTarget>
       )}
@@ -74,9 +74,4 @@ const Wrapper = styled(FieldsetGroup)`
 const PriorityTarget = styled.div`
   color: ${p => p.theme.color.slateGray};
   font-style: italic;
-
-  > ul {
-    margin: 4px 0 0;
-    padding-left: 20px;
-  }
 `

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/__tests__/ControlQualityField.test.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/__tests__/ControlQualityField.test.tsx
@@ -191,6 +191,25 @@ describe('ControlQualityField', () => {
     )
   })
 
+  it.each(['REPTP', 'GFCAY', 'GPPTP', 'MQFDF', 'YTMAM', 'PMFSP', 'NCNOU', 'PFPPT', 'WFMAU', 'TFPFR', 'BLGUS', 'MFMAR'])(
+    'renders the third-country landing sentence for a non-EU flag landing at the overseas French port %p',
+    portLocode => {
+      renderControlQualityField({
+        actionType: MissionAction.MissionActionType.LAND_CONTROL,
+        flagState: 'MA',
+        portLocode,
+        tripReportings: [],
+        vesselGroups: [],
+        vesselId: 123
+      })
+
+      const target = getPriorityTarget()
+      expect(target.textContent).toBe(
+        'Le navire est une cible prioritaire car c’est un navire tiers débarquant dans un port français.'
+      )
+    }
+  )
+
   it('does not render the third-country landing sentence for an EU flag', () => {
     renderControlQualityField({
       actionType: MissionAction.MissionActionType.LAND_CONTROL,

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/utils.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/utils.ts
@@ -1,3 +1,4 @@
+import { FRENCH_COUNTRY_CODES } from '@constants/index'
 import { EU_COUNTRY_CODES } from '@features/Alert/components/SideWindowAlerts/AlertManagementForm/constants'
 import { MissionAction } from '@features/Mission/missionAction.types'
 import { getLocalizedDayjs, pluralize } from '@mtes-mct/monitor-ui'
@@ -68,7 +69,7 @@ export function getPriorityTargetReasons(
   const hasGroupOrReportingReason = priorityGroups.length > 0 || currentTripReportingLength > 0
   const isThirdCountryVesselLandingInFrance =
     values.actionType === MissionAction.MissionActionType.LAND_CONTROL &&
-    !!values.portLocode?.startsWith('FR') &&
+    FRENCH_COUNTRY_CODES.includes(values.portLocode?.slice(0, 2) ?? '') &&
     !!values.flagState &&
     values.flagState !== 'UNDEFINED' &&
     !EU_COUNTRY_CODES.includes(values.flagState)

--- a/frontend/src/features/VesselGroup/components/VesselGroupList/index.tsx
+++ b/frontend/src/features/VesselGroup/components/VesselGroupList/index.tsx
@@ -107,15 +107,15 @@ export function VesselGroupList({ isFromUrl }: VesselListProps) {
                 placeholder="Groupes partagés et personnels"
                 value={filteredSharing}
               />
+              <StyledCheckbox
+                checked={filteredPriority}
+                label="Groupes de cibles prioritaires"
+                name="priority"
+                onChange={updateFilteredPriority}
+                title="Groupes de cibles prioritaires"
+              />
             </>
           )}
-          <StyledCheckbox
-            checked={filteredPriority}
-            label="Groupes de cibles prioritaires"
-            name="priority"
-            onChange={updateFilteredPriority}
-            title="Groupes de cibles prioritaires"
-          />
           <StyledCheckbox
             checked={filteredExpired}
             label="Groupes expirés"

--- a/frontend/src/features/VesselGroup/components/VesselGroupMenuDialog/index.tsx
+++ b/frontend/src/features/VesselGroup/components/VesselGroupMenuDialog/index.tsx
@@ -117,15 +117,17 @@ export function VesselGroupMenuDialog() {
               />
             </FilterRow>
           )}
-          <FilterRow>
-            <Checkbox
-              checked={filteredPriority}
-              label="Afficher uniquement les groupes prioritaires"
-              name="priority"
-              onChange={updateFilteredPriority}
-              title="Afficher uniquement les groupes prioritaires"
-            />
-          </FilterRow>
+          {isSuperUser && (
+            <FilterRow>
+              <Checkbox
+                checked={filteredPriority}
+                label="Afficher uniquement les groupes prioritaires"
+                name="priority"
+                onChange={updateFilteredPriority}
+                title="Afficher uniquement les groupes prioritaires"
+              />
+            </FilterRow>
+          )}
           <VesselGroupList data-cy="vessel-groups-list">
             {priorityVesselGroups.map((vesselGroup: VesselGroup, index: number) => (
               <VesselGroupRow


### PR DESCRIPTION
- Display the "not a priority target" sentence in Slate Gray Regular Italic instead of bold
- Include French overseas ports in the third-country landing rule, as a LOCODE is prefixed with the code of its own territory and not "FR"
- Hide the priority group filters for non-superusers, since the priority groups themselves are already hidden
- Store `is_prioritized` for the INN and third-country rules, which were only computed in the frontend

## Linked issues

- Resolve #4789
- Resolve #5312

----

- [ ] Tests E2E (Cypress)
