### PR TITLE
L'archivage automatique est dysfonctionnel sur les alertes de position

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/reporting/ArchiveOutdatedReportings.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/reporting/ArchiveOutdatedReportings.kt
@@ -36,7 +36,8 @@ class ArchiveOutdatedReportings(
         val filteredReportingIdsToArchive =
             reportingCandidatesToArchive
                 .filter {
-                    extraAlertsToArchive.contains(it.second.type) || alertSpecificationsToArchive.contains(it.first)
+                    extraAlertsToArchive.contains(it.second.type) ||
+                        alertSpecificationsToArchive.contains(it.second.alertId)
                 }.map { it.first }
 
         logger.info("Found ${filteredReportingIdsToArchive.size} alert reportings to archive after new voyage.")

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/interfaces/DBReportingRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/interfaces/DBReportingRepository.kt
@@ -108,8 +108,10 @@ interface DBReportingRepository : CrudRepository<ReportingEntity, Int> {
     fun archiveReporting(id: Int)
 
     /**
-     * Search for unarchived reportings (created for max 1 hour ago) after vessels' have started a new trip.
+     * Search for unarchived ALERT reportings after vessels' have started a new trip.
      * (a DEP logbook message is received after the reporting validation_date)
+     *
+     * Only ALERT reportings are returned: the `value` column is deserialized as an alert by the caller.
      */
     @Query(
         value = """
@@ -147,6 +149,7 @@ interface DBReportingRepository : CrudRepository<ReportingEntity, Int> {
         WHERE
             r.archived is false AND
             r.deleted is false AND
+            r.type = 'ALERT' AND
             rdp.last_dep_date_time >= r.validation_date AT TIME ZONE 'UTC' AND
             rdp.operation_number IN (SELECT referenced_report_id FROM acknowledged_report_ids)
         """,

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/reporting/ArchiveOutdatedReportingsUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/reporting/ArchiveOutdatedReportingsUTests.kt
@@ -25,14 +25,16 @@ class ArchiveOutdatedReportingsUTests {
     @Test
     fun `execute Should archive outdated reportings`() {
         // Given
+        // The reporting ids are intentionally different from the alert specification ids: the archiving
+        // decision must be taken on the alert id carried by the reporting value, not on the reporting id.
         given(reportingRepository.findUnarchivedReportingsAfterNewVoyage()).willReturn(
             listOf(
                 Pair(
-                    1,
+                    100,
                     Alert(
                         type = AlertType.POSITION_ALERT,
                         seaFront = NAMO.toString(),
-                        alertId = 1,
+                        alertId = DUMMY_POSITION_ALERT.id,
                         natinfCode = 7059,
                         threat = "Obligations déclaratives",
                         threatCharacterization = "DEP",
@@ -40,18 +42,18 @@ class ArchiveOutdatedReportingsUTests {
                     ),
                 ),
                 Pair(
-                    2,
+                    101,
                     Alert(
                         type = AlertType.POSITION_ALERT,
                         seaFront = NAMO.toString(),
-                        alertId = 2,
+                        alertId = 999,
                         natinfCode = 7059,
                         threat = "Obligations déclaratives",
                         threatCharacterization = "DEP",
                         name = "Pêche en zone RTC",
                     ),
                 ),
-                Pair(3, AlertType.MISSING_FAR_48_HOURS_ALERT.getValue()),
+                Pair(102, AlertType.MISSING_FAR_48_HOURS_ALERT.getValue()),
             ),
         )
         given(positionAlertSpecification.findAllByIsDeletedIsFalse())
@@ -64,7 +66,39 @@ class ArchiveOutdatedReportingsUTests {
         ArchiveOutdatedReportings(reportingRepository, positionAlertSpecification).execute()
 
         // Then
-        verify(reportingRepository).archiveReportings(eq(listOf(1, 3, 4, 5)))
+        verify(reportingRepository).archiveReportings(eq(listOf(100, 102, 4, 5)))
+    }
+
+    @Test
+    fun `execute Should not archive a position alert reporting when its specification has no automatic archiving`() {
+        // Given
+        given(reportingRepository.findUnarchivedReportingsAfterNewVoyage()).willReturn(
+            listOf(
+                Pair(
+                    100,
+                    Alert(
+                        type = AlertType.POSITION_ALERT,
+                        seaFront = NAMO.toString(),
+                        alertId = DUMMY_POSITION_ALERT.id,
+                        natinfCode = 7059,
+                        threat = "Obligations déclaratives",
+                        threatCharacterization = "DEP",
+                        name = "Chalutage dans les 3 milles",
+                    ),
+                ),
+            ),
+        )
+        given(positionAlertSpecification.findAllByIsDeletedIsFalse())
+            .willReturn(listOf(DUMMY_POSITION_ALERT.copy(hasAutomaticArchiving = false)))
+        given(reportingRepository.findExpiredReportings()).willReturn(emptyList())
+        given(reportingRepository.findUnarchivedNonAlertReportingsWithDepValidityAfterNewVoyage())
+            .willReturn(emptyList())
+
+        // When
+        ArchiveOutdatedReportings(reportingRepository, positionAlertSpecification).execute()
+
+        // Then
+        verify(reportingRepository).archiveReportings(eq(emptyList()))
     }
 
     @Test
@@ -89,11 +123,11 @@ class ArchiveOutdatedReportingsUTests {
         given(reportingRepository.findUnarchivedReportingsAfterNewVoyage()).willReturn(
             listOf(
                 Pair(
-                    1,
+                    100,
                     Alert(
                         type = AlertType.POSITION_ALERT,
                         seaFront = NAMO.toString(),
-                        alertId = 1,
+                        alertId = DUMMY_POSITION_ALERT.id,
                         natinfCode = 7059,
                         threat = "Obligations déclaratives",
                         threatCharacterization = "DEP",
@@ -112,6 +146,6 @@ class ArchiveOutdatedReportingsUTests {
         ArchiveOutdatedReportings(reportingRepository, positionAlertSpecification).execute()
 
         // Then
-        verify(reportingRepository).archiveReportings(eq(listOf(1, 2, 3, 4)))
+        verify(reportingRepository).archiveReportings(eq(listOf(100, 2, 3, 4)))
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaReportingRepositoryITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaReportingRepositoryITests.kt
@@ -560,6 +560,55 @@ class JpaReportingRepositoryITests : AbstractDBTests() {
         assertThat(reportings).hasSize(1)
         assertThat(reportings.first().first).isEqualTo(1)
         assertThat(reportings.first().second.type).isEqualTo(AlertType.POSITION_ALERT)
+        assertThat(reportings.first().second.alertId).isEqualTo(1)
+    }
+
+    @Test
+    @Transactional
+    fun `findUnarchivedReportings Should not return non-alert reportings`() {
+        // Given - An INFRACTION_SUSPICION reporting for vessel ABC000180832, which already has a recent
+        // acknowledged DEP logbook message (FAKE_OPERATION_121) in the test fixtures (V666.5.2).
+        // Its `value` column can't be deserialized as an alert, so returning it would break the whole archiving.
+        jpaReportingRepository.save(
+            Reporting.InfractionSuspicion(
+                cfr = "ABC000180832",
+                externalMarker = "VP374069",
+                ircs = "CG1312",
+                vesselId = 123456,
+                vesselName = "MARIAGE ÎLE HASARD",
+                creationDate = ZonedDateTime.now().minusDays(1),
+                validationDate = ZonedDateTime.now().minusHours(1),
+                reportingDate = ZonedDateTime.now(),
+                lastUpdateDate = ZonedDateTime.now(),
+                flagState = CountryCode.FR,
+                isDeleted = false,
+                isArchived = false,
+                vesselIdentifier = VesselIdentifier.INTERNAL_REFERENCE_NUMBER,
+                reportingSource = ReportingSource.UNIT,
+                controlUnitId = 1,
+                authorContact = "Jean Bon",
+                title = "Pêche IUU",
+                infractions =
+                    listOf(
+                        InfractionSuspicionThreat(
+                            natinfCode = 27689,
+                            threat = "Obligations déclaratives",
+                            threatCharacterization = "DEP",
+                        ),
+                    ),
+                seaFront = "NAMO",
+                dml = "DML 29",
+                validityOption = ReportingValidityOption.UNTIL_NEXT_DEP,
+                createdBy = "test@example.gouv.fr",
+            ),
+        )
+
+        // When
+        val reportings = jpaReportingRepository.findUnarchivedReportingsAfterNewVoyage()
+
+        // Then
+        assertThat(reportings).hasSize(1)
+        assertThat(reportings.first().first).isEqualTo(1)
     }
 
     @Test


### PR DESCRIPTION
Deux bugs empêchaient l'archivage automatique des signalements :

- `ArchiveOutdatedReportings` comparait l'id du signalement à la liste des ids de spécifications d'alerte. Un signalement d'alerte de position n'était donc archivé que si son id correspondait par hasard à celui d'une alerte avec archivage automatique. On utilise désormais l'`alertId` porté par la valeur du signalement.

- `findAllUnarchivedAfterDEPLogbookMessage` ne filtrait pas sur le type de signalement. La valeur JSONB d'un signalement OBSERVATION ou INFRACTION_SUSPICION étant désérialisée en alerte par l'appelant, une exception interrompait toute la tâche planifiée : plus aucun signalement n'était archivé.

## Linked issues

- Resolve #5321

----

- [ ] Tests E2E (Cypress)
