### PR TITLE
Corrige plusieurs bugs des use-cases backend et assainit ControllersExceptionHandler

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/exceptions/BackendInternalException.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/exceptions/BackendInternalException.kt
@@ -1,8 +1,5 @@
 package fr.gouv.cnsp.monitorfish.domain.exceptions
 
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-
 /**
  * Exception to throw when the request is valid but the Backend failed while processing it.
  *
@@ -13,14 +10,11 @@ import org.slf4j.LoggerFactory
  * - Database data is unprocessable.
  */
 open class BackendInternalException(
-    final override val message: String = "An internal error occurred.",
-    originalException: Exception? = null,
+    final override val message: String = DEFAULT_MESSAGE,
+    cause: Throwable? = null,
     val code: BackendInternalErrorCode? = null,
-) : RuntimeException(message) {
-    private val logger: Logger = LoggerFactory.getLogger(BackendInternalException::class.java)
-
-    init {
-        logger.error("BackendInternalException: $message")
-        originalException?.let { logger.error("${it::class.simpleName}: ${it.message}") }
+) : RuntimeException(message, cause) {
+    companion object {
+        const val DEFAULT_MESSAGE = "An internal error occurred."
     }
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/alert/GetPendingAlerts.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/alert/GetPendingAlerts.kt
@@ -43,22 +43,29 @@ class GetPendingAlerts(
             }
     }
 
+    /**
+     * Specifications are matched on identity rather than on `name`: names are user-editable, so two
+     * specifications may share one.
+     */
     private fun getSpecification(
         alertSpecifications: List<PositionAlertSpecification>,
         pendingAlertWithInfraction: PendingAlert,
-    ): PositionAlertSpecification =
-        alertSpecifications.singleOrNull {
-            if (pendingAlertWithInfraction.value.alertId != null) {
-                return@singleOrNull it.id == pendingAlertWithInfraction.value.alertId
-            }
+    ): PositionAlertSpecification {
+        val alertId = pendingAlertWithInfraction.value.alertId
+        val alertTypeName = pendingAlertWithInfraction.value.type.name
 
-            return@singleOrNull it.name == pendingAlertWithInfraction.value.name
+        return alertSpecifications.firstOrNull {
+            when (alertId) {
+                null -> it.type == alertTypeName
+                else -> it.id == alertId
+            }
         } ?: throw BackendInternalException(
             message =
-                "Could not find alert specification of alertId: ${pendingAlertWithInfraction.value.alertId} " +
-                    "and alertName: ${pendingAlertWithInfraction.value.name}",
+                "Could not find alert specification of alertId: $alertId " +
+                    "and alertType: $alertTypeName",
             code = BackendInternalErrorCode.UNPROCESSABLE_RESOURCE_DATA,
         )
+    }
 
     private fun getInfraction(pendingAlert: PendingAlert): Infraction? {
         return pendingAlert.value.natinfCode?.let {

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission/mission_actions/GetMissionActionFacade.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission/mission_actions/GetMissionActionFacade.kt
@@ -4,16 +4,20 @@ import fr.gouv.cnsp.monitorfish.config.UseCase
 import fr.gouv.cnsp.monitorfish.domain.entities.facade.Seafront
 import fr.gouv.cnsp.monitorfish.domain.entities.mission.mission_actions.MissionAction
 import fr.gouv.cnsp.monitorfish.domain.entities.mission.mission_actions.MissionActionType
+import fr.gouv.cnsp.monitorfish.domain.exceptions.CodeNotFoundException
 import fr.gouv.cnsp.monitorfish.domain.repositories.FacadeAreasRepository
 import fr.gouv.cnsp.monitorfish.domain.repositories.PortRepository
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.GeometryFactory
+import org.slf4j.LoggerFactory
 
 @UseCase
 class GetMissionActionFacade(
     private val portsRepository: PortRepository,
     private val facadeAreasRepository: FacadeAreasRepository,
 ) {
+    private val logger = LoggerFactory.getLogger(GetMissionActionFacade::class.java)
+
     fun execute(action: MissionAction): Seafront? =
         when (action.actionType) {
             MissionActionType.SEA_CONTROL -> getFacadeFromCoordinates(action)
@@ -35,12 +39,18 @@ class GetMissionActionFacade(
     }
 
     private fun getFacadeFromPort(action: MissionAction): Seafront? {
-        if (action.portLocode == null) {
-            return null
-        }
-
-        val facade = portsRepository.findByLocode(action.portLocode).facade ?: return null
+        val portLocode = action.portLocode ?: return null
+        val facade = findPortFacade(portLocode) ?: return null
 
         return Seafront.from(facade)
     }
+
+    private fun findPortFacade(portLocode: String): String? =
+        try {
+            portsRepository.findByLocode(portLocode).facade
+        } catch (e: CodeNotFoundException) {
+            logger.warn(e.message)
+
+            null
+        }
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/ComputeRiskFactor.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/ComputeRiskFactor.kt
@@ -9,9 +9,11 @@ import fr.gouv.cnsp.monitorfish.domain.entities.risk_factor.defaultInfractionRat
 import fr.gouv.cnsp.monitorfish.domain.entities.risk_factor.defaultInfringementRiskLevel
 import fr.gouv.cnsp.monitorfish.domain.entities.risk_factor.impactRiskFactorCoefficient
 import fr.gouv.cnsp.monitorfish.domain.entities.risk_factor.probabilityRiskFactorCoefficient
+import fr.gouv.cnsp.monitorfish.domain.exceptions.CodeNotFoundException
 import fr.gouv.cnsp.monitorfish.domain.repositories.ControlObjectivesRepository
 import fr.gouv.cnsp.monitorfish.domain.repositories.PortRepository
 import fr.gouv.cnsp.monitorfish.domain.repositories.RiskFactorRepository
+import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.time.ZonedDateTime
 import kotlin.math.pow
@@ -26,6 +28,8 @@ class ComputeRiskFactor(
     private val controlObjectivesRepository: ControlObjectivesRepository,
     private val clock: Clock,
 ) {
+    private val logger = LoggerFactory.getLogger(ComputeRiskFactor::class.java)
+
     fun execute(
         portLocode: String,
         fleetSegments: List<FleetSegment>,
@@ -36,7 +40,7 @@ class ComputeRiskFactor(
         }
 
         val currentYear = ZonedDateTime.now(clock).year
-        val facade = portRepository.findByLocode(portLocode).facade
+        val facade = findPortFacade(portLocode)
         val storedRiskFactor = riskFactorRepository.findByInternalReferenceNumber(vesselCfr)
 
         val highestImpactRiskFactor =
@@ -61,4 +65,17 @@ class ComputeRiskFactor(
 
         return computedRiskFactor
     }
+
+    /**
+     * An unknown port only costs us the facade-specific control objectives, so the risk factor is still
+     * computed with its default infringement risk level rather than failing the whole prior notification.
+     */
+    private fun findPortFacade(portLocode: String): String? =
+        try {
+            portRepository.findByLocode(portLocode).facade
+        } catch (e: CodeNotFoundException) {
+            logger.warn(e.message)
+
+            null
+        }
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/InvalidateOutdatedBFTSWOZeroPNOs.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/InvalidateOutdatedBFTSWOZeroPNOs.kt
@@ -31,7 +31,7 @@ class InvalidateOutdatedBFTSWOZeroPNOs(
             ).forEach {
                 if (it.reportId == null) {
                     logger.warn("Ignoring manual prior notification with no report id")
-                    return
+                    return@forEach
                 }
 
                 manualPriorNotificationRepository.invalidate(it.reportId)

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/reporting/GetVesselReportings.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/reporting/GetVesselReportings.kt
@@ -19,6 +19,13 @@ import java.time.ZonedDateTime
 import kotlin.collections.map
 import kotlin.time.measureTimedValue
 
+/**
+ * Date at which a reporting occurred: alerts and infraction suspicions are dated by their validation,
+ * and reportings still awaiting validation fall back to their creation.
+ */
+private val Reporting.occurrenceDate: ZonedDateTime
+    get() = validationDate ?: creationDate
+
 @UseCase
 class GetVesselReportings(
     private val reportingRepository: ReportingRepository,
@@ -57,7 +64,7 @@ class GetVesselReportings(
         val (current, currentTimeTaken) =
             measureTimedValue {
                 getReportingsAndOccurrences(reportings.filter { !it.isArchived })
-                    .sortedWith(compareByDescending { it.reporting.validationDate ?: it.reporting.creationDate })
+                    .sortedWith(compareByDescending { it.reporting.occurrenceDate })
                     .map { reportingAndOccurrences ->
                         enrichWithInfractionAndControlUnit(reportingAndOccurrences, controlUnits)
                     }
@@ -71,10 +78,10 @@ class GetVesselReportings(
                     val reportingsOfYear =
                         reportings
                             .filter { it.isArchived }
-                            .filter { filterByYear(it, year) }
+                            .filter { it.occurrenceDate.year == year }
 
                     return@associateWith getReportingsAndOccurrences(reportingsOfYear)
-                        .sortedWith(compareByDescending { it.reporting.validationDate ?: it.reporting.creationDate })
+                        .sortedWith(compareByDescending { it.reporting.occurrenceDate })
                         .map { reportingAndOccurrences ->
                             enrichWithInfractionAndControlUnit(reportingAndOccurrences, controlUnits)
                         }
@@ -84,10 +91,7 @@ class GetVesselReportings(
 
         val twelveMonthsAgo = ZonedDateTime.now().minusMonths(12)
         val lastTwelveMonthsReportings =
-            reportings.filter { reporting ->
-                reporting.validationDate?.isAfter(twelveMonthsAgo)
-                    ?: reporting.creationDate.isAfter(twelveMonthsAgo)
-            }
+            reportings.filter { reporting -> reporting.occurrenceDate.isAfter(twelveMonthsAgo) }
 
         val infractionSuspicionsSummary =
             getThreatSummary(lastTwelveMonthsReportings.filter { it.isArchived })
@@ -153,18 +157,6 @@ class GetVesselReportings(
                         )
                     }
             }
-    }
-
-    private fun filterByYear(
-        reporting: Reporting,
-        year: Int,
-    ): Boolean {
-        val validationDate = reporting.validationDate
-        if (validationDate != null) {
-            return validationDate.year == year
-        }
-
-        return reporting.creationDate.year == year
     }
 
     private fun enrichWithInfractionAndControlUnit(
@@ -257,20 +249,12 @@ class GetVesselReportings(
                         return@flatMap listOf()
                     }
 
-                    val lastAlert =
-                        alerts.maxByOrNull { alert ->
-                            val validationDate = alert.validationDate
-                            checkNotNull(validationDate) {
-                                "An alert must have a validation date: alert ${alert.id} has no validation date ($alert)."
-                            }
-
-                            validationDate
-                        }
+                    val lastAlert = alerts.maxByOrNull { it.occurrenceDate }
                     checkNotNull(lastAlert) { "Last alert cannot be null" }
                     val otherOccurrencesOfSameAlert =
                         alerts
                             .filter { it.id != lastAlert.id }
-                            .sortedWith(compareByDescending { it.validationDate ?: it.creationDate })
+                            .sortedWith(compareByDescending { it.occurrenceDate })
 
                     return@flatMap listOf(
                         ReportingAndOccurrences(

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/ControllersExceptionHandler.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/ControllersExceptionHandler.kt
@@ -10,9 +10,7 @@ import fr.gouv.cnsp.monitorfish.infrastructure.api.outputs.ApiError
 import fr.gouv.cnsp.monitorfish.infrastructure.api.outputs.BackendInternalErrorDataOutput
 import fr.gouv.cnsp.monitorfish.infrastructure.api.outputs.BackendRequestErrorDataOutput
 import fr.gouv.cnsp.monitorfish.infrastructure.api.outputs.BackendUsageErrorDataOutput
-import fr.gouv.cnsp.monitorfish.infrastructure.api.outputs.MissingParameterApiError
 import fr.gouv.cnsp.monitorfish.infrastructure.exceptions.BackendRequestException
-import jakarta.annotation.Priority
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.core.annotation.Order
@@ -23,77 +21,107 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
+/**
+ * Maps exceptions thrown by controllers to API responses.
+ *
+ * Failures the Backend knows how to describe carry an explicit error code: [BackendUsageException],
+ * [BackendRequestException] and [BackendInternalException]. Anything else is unexpected: it is logged in full
+ * and answered with a generic message, because an exception message is written for developers, not for API
+ * consumers, and may disclose internal details.
+ *
+ * `IllegalStateException` is deliberately absent from the client-error group: `check()` and `checkNotNull()`
+ * assert Backend invariants, so breaking one is a Backend bug (500) rather than a malformed request (400).
+ *
+ * Every handler logs exactly once, and it is the only place that does so: exceptions carry data, they don't
+ * report themselves.
+ */
 @RestControllerAdvice
-@Priority(1)
 @Order(1)
 class ControllersExceptionHandler {
     private val logger: Logger = LoggerFactory.getLogger(ControllersExceptionHandler::class.java)
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(BackendInternalException::class)
-    fun handleBackendInternalException(e: BackendInternalException): BackendInternalErrorDataOutput =
-        BackendInternalErrorDataOutput(code = e.code, message = e.message)
+    fun handleBackendInternalException(e: BackendInternalException): BackendInternalErrorDataOutput {
+        logger.error("${e.code ?: "BACKEND_INTERNAL_ERROR"}: ${e.message}", e)
+
+        return BackendInternalErrorDataOutput(code = e.code, message = e.message)
+    }
 
     @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
     @ExceptionHandler(BackendRequestException::class)
-    fun handleBackendRequestException(e: BackendRequestException): BackendRequestErrorDataOutput =
-        BackendRequestErrorDataOutput(code = e.code, data = e.data, message = e.message)
+    fun handleBackendRequestException(e: BackendRequestException): BackendRequestErrorDataOutput {
+        logger.warn("${e.code}: ${e.message ?: "No message."}", e)
 
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    @ExceptionHandler(RuntimeException::class)
-    fun handleBackendRuntimeException(e: RuntimeException): BackendInternalErrorDataOutput {
-        logger.error("Runtime exception: ${e.message}", e)
-
-        return BackendInternalErrorDataOutput(code = null, message = e.message ?: BackendInternalException().message)
+        return BackendRequestErrorDataOutput(code = e.code, data = e.data, message = e.message)
     }
 
     @ExceptionHandler(BackendUsageException::class)
     fun handleBackendUsageException(e: BackendUsageException): ResponseEntity<BackendUsageErrorDataOutput> {
-        val responseBody = BackendUsageErrorDataOutput(code = e.code, data = e.data, message = e.message)
-
-        return when (e.code) {
-            BackendUsageErrorCode.NOT_FOUND -> {
-                ResponseEntity(responseBody, HttpStatus.NOT_FOUND)
-            }
-            BackendUsageErrorCode.NOT_FOUND_BUT_OK -> {
-                ResponseEntity(responseBody, HttpStatus.OK)
-            }
-            else -> {
-                ResponseEntity(responseBody, HttpStatus.BAD_REQUEST)
-            }
+        val status = statusOf(e.code)
+        if (status.isError) {
+            logger.warn("${e.code}: ${e.message ?: "No message."}", e)
         }
+
+        return ResponseEntity(BackendUsageErrorDataOutput(code = e.code, data = e.data, message = e.message), status)
+    }
+
+    /**
+     * `NOT_FOUND_BUT_OK` answers `200` on purpose: the Frontend reads its `code` to turn an expected absence into
+     * an empty result rather than into an error. See `valueOrUndefinedIfNotFoundOrThrow` in the Frontend.
+     */
+    private fun statusOf(code: BackendUsageErrorCode): HttpStatus =
+        when (code) {
+            BackendUsageErrorCode.NOT_FOUND -> HttpStatus.NOT_FOUND
+            BackendUsageErrorCode.NOT_FOUND_BUT_OK -> HttpStatus.OK
+            else -> HttpStatus.BAD_REQUEST
+        }
+
+    /**
+     * Last-resort handler for exceptions no other handler claimed. Reaching it means the Backend failed in a way
+     * nobody described, so the cause belongs in the logs and never in the response body.
+     */
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(RuntimeException::class)
+    fun handleUnexpectedException(e: RuntimeException): BackendInternalErrorDataOutput {
+        logger.error("Unexpected exception.", e)
+
+        return BackendInternalErrorDataOutput(code = null, message = BackendInternalException.DEFAULT_MESSAGE)
     }
 
     // -------------------------------------------------------------------------
     // Legacy exceptions
 
+    /**
+     * A malformed NAF message answers `200` on purpose: the position sender cannot fix the message it already
+     * sent, so failing the request would only make it retry forever.
+     */
     @ResponseStatus(HttpStatus.OK)
     @ExceptionHandler(NAFMessageParsingException::class)
-    fun handleNAFMessageParsingException(e: Exception): ApiError {
-        logger.error(e.message, e.cause)
+    fun handleNAFMessageParsingException(e: NAFMessageParsingException): ApiError {
+        logger.error("Could not parse NAF message.", e)
 
-        return ApiError(IllegalArgumentException(e.message.toString(), e))
+        return ApiError(e)
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(
         IllegalArgumentException::class,
-        // IllegalStateException::class,
         CouldNotUpdateControlObjectiveException::class,
         CouldNotFindException::class,
         NoSuchElementException::class,
     )
-    fun handleIllegalArgumentException(e: Exception): ApiError {
-        logger.error(e.message, e.cause)
+    fun handleInvalidRequestException(e: RuntimeException): ApiError {
+        logger.warn("Invalid request.", e)
 
-        return ApiError(IllegalArgumentException(e.message.toString(), e))
+        return ApiError(e)
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MissingServletRequestParameterException::class)
-    fun handleNoParameter(e: MissingServletRequestParameterException): MissingParameterApiError {
-        logger.error(e.message, e.cause)
+    fun handleMissingParameter(e: MissingServletRequestParameterException): ApiError {
+        logger.warn("Missing request parameter.", e)
 
-        return MissingParameterApiError("Parameter \"${e.parameterName}\" is missing.")
+        return ApiError(error = "Parameter \"${e.parameterName}\" is missing.", type = e::class.simpleName!!)
     }
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/outputs/ApiError.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/outputs/ApiError.kt
@@ -1,15 +1,11 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.outputs
 
-class ApiError(
+data class ApiError(
     val error: String,
     val type: String,
 ) {
     constructor(exception: Throwable) : this(
-        exception.cause?.message
-            ?: "",
-        exception.cause
-            ?.javaClass
-            ?.simpleName
-            .toString(),
+        error = exception.message ?: "",
+        type = exception::class.simpleName ?: exception::class.java.name,
     )
 }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/outputs/MissingParameterApiError.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/outputs/MissingParameterApiError.kt
@@ -1,5 +1,0 @@
-package fr.gouv.cnsp.monitorfish.infrastructure.api.outputs
-
-data class MissingParameterApiError(
-    val error: String,
-)

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/exceptions/BackendRequestException.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/exceptions/BackendRequestException.kt
@@ -1,8 +1,5 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.exceptions
 
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-
 /**
  * Infrastructure exception to throw when the request is invalid.
  *
@@ -15,10 +12,4 @@ open class BackendRequestException(
     val code: BackendRequestErrorCode,
     final override val message: String? = null,
     val data: Any? = null,
-) : RuntimeException(code.name) {
-    private val logger: Logger = LoggerFactory.getLogger(BackendRequestException::class.java)
-
-    init {
-        logger.warn("$code: ${message ?: "No message."}")
-    }
-}
+) : RuntimeException(code.name)

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/alert/GetPendingAlertsUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/alert/GetPendingAlertsUTests.kt
@@ -97,4 +97,44 @@ class GetPendingAlertsUTests {
         )
         Mockito.verify(infractionRepository, Mockito.times(1)).findInfractionByNatinfCode(eq(7059))
     }
+
+    @Test
+    fun `execute Should resolve a built-in alert specification When a user-defined alert shares its name`() {
+        // Given
+        val builtInSpecification = AlertType.MISSING_DEP_ALERT.specification!!
+        val pendingMissingDepAlert =
+            PendingAlert(
+                internalReferenceNumber = "FRFGRGR",
+                externalReferenceNumber = "RGD",
+                ircs = "6554fEE",
+                vesselId = 123,
+                vesselIdentifier = VesselIdentifier.INTERNAL_REFERENCE_NUMBER,
+                flagState = CountryCode.FR,
+                tripNumber = "123456",
+                creationDate = ZonedDateTime.now(),
+                value = AlertType.MISSING_DEP_ALERT.getValue(),
+            )
+        val userDefinedAlertWithSameName =
+            DUMMY_POSITION_ALERT.copy(id = 42, name = builtInSpecification.name, isUserDefined = true)
+        given(pendingAlertRepository.findAlertsOfTypes(any())).willReturn(listOf(pendingMissingDepAlert))
+        given(getPositionAlertSpecifications.execute()).willReturn(
+            listOf(userDefinedAlertWithSameName) +
+                AlertType.entries
+                    .filter { it != AlertType.POSITION_ALERT }
+                    .mapNotNull { it.specification?.copy(type = it.name) },
+        )
+
+        // When
+        val alerts =
+            GetPendingAlerts(
+                getPositionAlertSpecifications = getPositionAlertSpecifications,
+                pendingAlertRepository = pendingAlertRepository,
+                infractionRepository = infractionRepository,
+            ).execute()
+
+        // Then
+        val alertSpecification = alerts.first().second
+        assertThat(alertSpecification.type).isEqualTo(AlertType.MISSING_DEP_ALERT.name)
+        assertThat(alertSpecification.isUserDefined).isFalse()
+    }
 }

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission/mission_actions/GetMissionActionSeafrontUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/mission/mission_actions/GetMissionActionSeafrontUTests.kt
@@ -8,6 +8,7 @@ import fr.gouv.cnsp.monitorfish.domain.entities.facade.Seafront
 import fr.gouv.cnsp.monitorfish.domain.entities.mission.mission_actions.Completion
 import fr.gouv.cnsp.monitorfish.domain.entities.mission.mission_actions.MissionAction
 import fr.gouv.cnsp.monitorfish.domain.entities.mission.mission_actions.MissionActionType
+import fr.gouv.cnsp.monitorfish.domain.exceptions.CodeNotFoundException
 import fr.gouv.cnsp.monitorfish.domain.repositories.FacadeAreasRepository
 import fr.gouv.cnsp.monitorfish.domain.repositories.PortRepository
 import fr.gouv.cnsp.monitorfish.fakers.PortFaker
@@ -62,6 +63,36 @@ class GetMissionActionSeafrontUTests {
 
         // Then
         assertThat(facade).isEqualTo(Seafront.NAMO)
+    }
+
+    @Test
+    fun `execute Should return null for a land control with a port missing from the referential`() {
+        // Given
+        val action =
+            MissionAction(
+                id = null,
+                vesselId = null,
+                missionId = 1,
+                actionDatetimeUtc = ZonedDateTime.now(),
+                portLocode = "UNKNOWN",
+                actionType = MissionActionType.LAND_CONTROL,
+                gearOnboard = listOf(),
+                seizureAndDiversion = true,
+                isDeleted = false,
+                hasSomeGearsSeized = false,
+                hasSomeSpeciesSeized = false,
+                isFromPoseidon = false,
+                flagState = CountryCode.FR,
+                userTrigram = "LTH",
+                completion = Completion.TO_COMPLETE,
+            )
+        given(portRepository.findByLocode(any())).willThrow(CodeNotFoundException("Port UNKNOWN not found."))
+
+        // When
+        val facade = GetMissionActionFacade(portRepository, facadeAreasRepository).execute(action)
+
+        // Then
+        assertThat(facade).isNull()
     }
 
     @Test

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/ComputeRiskFactorUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/ComputeRiskFactorUTests.kt
@@ -8,6 +8,7 @@ import fr.gouv.cnsp.monitorfish.domain.entities.risk_factor.defaultControlRateRi
 import fr.gouv.cnsp.monitorfish.domain.entities.risk_factor.defaultImpactRiskFactor
 import fr.gouv.cnsp.monitorfish.domain.entities.risk_factor.defaultInfractionRateRiskFactor
 import fr.gouv.cnsp.monitorfish.domain.entities.risk_factor.defaultInfringementRiskLevel
+import fr.gouv.cnsp.monitorfish.domain.exceptions.CodeNotFoundException
 import fr.gouv.cnsp.monitorfish.domain.repositories.ControlObjectivesRepository
 import fr.gouv.cnsp.monitorfish.domain.repositories.PortRepository
 import fr.gouv.cnsp.monitorfish.domain.repositories.RiskFactorRepository
@@ -329,6 +330,31 @@ class ComputeRiskFactorUTests {
             2.5.pow(0.2) *
                 (1.7 * 2.0).pow(0.3) *
                 0.7.pow(0.25),
+        )
+    }
+
+    @Test
+    fun `execute Should use the default infringement risk level When the port is missing from the referential`() {
+        // Given
+        val portLocode = "UNKNOWN"
+        val vesselCfr = "CFR"
+        given(portRepository.findByLocode(portLocode)).willThrow(CodeNotFoundException("Port UNKNOWN not found."))
+        given(riskFactorRepository.findByInternalReferenceNumber(vesselCfr)).willReturn(null)
+        given(controlObjectivesRepository.findAllByYear(anyInt())).willReturn(listOf())
+
+        // When
+        val result =
+            ComputeRiskFactor(riskFactorRepository, portRepository, controlObjectivesRepository, FIXED_CLOCK).execute(
+                portLocode,
+                listOf(),
+                vesselCfr,
+            )
+
+        // Then
+        assertThat(result).isEqualTo(
+            defaultImpactRiskFactor.pow(0.2) *
+                (defaultInfractionRateRiskFactor * defaultInfringementRiskLevel).pow(0.3) *
+                defaultControlRateRiskFactor.pow(0.25),
         )
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/InvalidateOutdatedBFTSWOZeroPNOsUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/prior_notification/InvalidateOutdatedBFTSWOZeroPNOsUTests.kt
@@ -32,4 +32,22 @@ class InvalidateOutdatedBFTSWOZeroPNOsUTests {
             eq(fakePriorNotification.reportId!!),
         )
     }
+
+    @Test
+    fun `execute Should invalidate the next pnos When a pno has no report id`() {
+        val priorNotificationWithoutReportId = PriorNotificationFaker.fakePriorNotification(1).copy(reportId = null)
+        val nextPriorNotification = PriorNotificationFaker.fakePriorNotification(2)
+
+        // Given
+        given(manualPriorNotificationRepository.findAll(any()))
+            .willReturn(listOf(priorNotificationWithoutReportId, nextPriorNotification))
+
+        // When
+        InvalidateOutdatedBFTSWOZeroPNOs(manualPriorNotificationRepository).execute()
+
+        // Then
+        verify(manualPriorNotificationRepository).invalidate(
+            eq(nextPriorNotification.reportId!!),
+        )
+    }
 }

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/reporting/GetVesselReportingsUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/reporting/GetVesselReportingsUTests.kt
@@ -1,5 +1,6 @@
 package fr.gouv.cnsp.monitorfish.domain.use_cases.reporting
 
+import com.neovisionaries.i18n.CountryCode
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
 import fr.gouv.cnsp.monitorfish.domain.entities.alerts.type.AlertType
@@ -421,4 +422,72 @@ class GetVesselReportingsUTests {
         )
         assertThat(secondSummary.numberOfOccurrences).isEqualTo(3)
     }
+
+    @Test
+    fun `execute Should order alerts by creation date When an alert has no validation date`() {
+        // Given
+        val alertWithoutValidationDate =
+            createAlert(id = 1, creationDate = ZonedDateTime.now().minusDays(3), validationDate = null)
+        val validatedAlert =
+            createAlert(
+                id = 2,
+                creationDate = ZonedDateTime.now().minusDays(2),
+                validationDate = ZonedDateTime.now().minusDays(1),
+            )
+        given(reportingRepository.findCurrentAndArchivedByVesselIdentifierEquals(any(), any(), any())).willReturn(
+            listOf(alertWithoutValidationDate, validatedAlert),
+        )
+
+        // When
+        val result =
+            GetVesselReportings(
+                reportingRepository,
+                infractionRepository,
+                getAllLegacyControlUnits,
+            ).execute(
+                vesselId = null,
+                internalReferenceNumber = "FR224226850",
+                externalReferenceNumber = "1236514",
+                ircs = "IRCS",
+                vesselIdentifier = VesselIdentifier.INTERNAL_REFERENCE_NUMBER,
+                fromDate = ZonedDateTime.now().minusYears(1),
+            )
+
+        // Then
+        assertThat(result.current).hasSize(1)
+        assertThat(
+            result.current
+                .first()
+                .reporting.id,
+        ).isEqualTo(2)
+        assertThat(
+            result.current
+                .first()
+                .otherOccurrencesOfSameAlert
+                .map { it.id },
+        ).isEqualTo(listOf(1))
+    }
+
+    private fun createAlert(
+        id: Int,
+        creationDate: ZonedDateTime,
+        validationDate: ZonedDateTime?,
+    ) = Reporting.Alert(
+        id = id,
+        cfr = "FR224226850",
+        vesselIdentifier = VesselIdentifier.INTERNAL_REFERENCE_NUMBER,
+        flagState = CountryCode.FR,
+        creationDate = creationDate,
+        lastUpdateDate = creationDate,
+        validationDate = validationDate,
+        alertType = AlertType.POSITION_ALERT,
+        alertId = 1,
+        natinfCode = 7059,
+        threat = "Obligations déclaratives",
+        threatCharacterization = "DEP",
+        name = "Chalutage dans les 3 milles",
+        isArchived = false,
+        isDeleted = false,
+        createdBy = "test@example.gouv.fr",
+    )
 }

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/ControllersExceptionHandlerITests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/ControllersExceptionHandlerITests.kt
@@ -1,0 +1,164 @@
+package fr.gouv.cnsp.monitorfish.infrastructure.api
+
+import fr.gouv.cnsp.monitorfish.config.MapperConfiguration
+import fr.gouv.cnsp.monitorfish.config.SentryConfig
+import fr.gouv.cnsp.monitorfish.domain.exceptions.BackendInternalErrorCode
+import fr.gouv.cnsp.monitorfish.domain.exceptions.BackendInternalException
+import fr.gouv.cnsp.monitorfish.domain.exceptions.BackendUsageErrorCode
+import fr.gouv.cnsp.monitorfish.domain.exceptions.BackendUsageException
+import fr.gouv.cnsp.monitorfish.domain.exceptions.CouldNotFindException
+import fr.gouv.cnsp.monitorfish.domain.exceptions.NAFMessageParsingException
+import fr.gouv.cnsp.monitorfish.infrastructure.exceptions.BackendRequestErrorCode
+import fr.gouv.cnsp.monitorfish.infrastructure.exceptions.BackendRequestException
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.nullValue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+private const val LEAKY_MESSAGE = "jdbc://user:hunter2@db/monitorfishdb violates constraint pnos_pkey"
+
+/** Raises each kind of failure the handler is expected to translate, through the real Spring MVC stack. */
+@RestController
+@RequestMapping("/test/errors")
+class ThrowingController {
+    @GetMapping("/usage/{code}")
+    fun throwUsageException(
+        @PathVariable code: BackendUsageErrorCode,
+    ): Nothing = throw BackendUsageException(code, message = "Usage failure.", data = listOf(1, 2))
+
+    @GetMapping("/internal")
+    fun throwInternalException(): Nothing =
+        throw BackendInternalException(
+            message = "Unprocessable resource.",
+            code = BackendInternalErrorCode.UNPROCESSABLE_RESOURCE_DATA,
+        )
+
+    @GetMapping("/request")
+    fun throwRequestException(): Nothing =
+        throw BackendRequestException(BackendRequestErrorCode.EMPTY_UPLOADED_FILE, message = "Empty file.")
+
+    @GetMapping("/unexpected")
+    fun throwUnexpectedException(): Nothing = throw IllegalStateException(LEAKY_MESSAGE)
+
+    @GetMapping("/could-not-find")
+    fun throwCouldNotFindException(): Nothing = throw CouldNotFindException("Vessel 123 not found.")
+
+    @GetMapping("/naf")
+    fun throwNafParsingException(): Nothing = throw NAFMessageParsingException("Invalid NAF format", "//SR//AD/FRA")
+
+    @GetMapping("/required-parameter")
+    fun requireParameter(
+        @RequestParam(name = "vesselId") vesselId: Int,
+    ) = vesselId
+}
+
+@Import(
+    MapperConfiguration::class,
+    SentryConfig::class,
+    ControllersExceptionHandler::class,
+    ThrowingController::class,
+)
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(value = [ThrowingController::class])
+class ControllersExceptionHandlerITests {
+    @Autowired
+    private lateinit var api: MockMvc
+
+    /**
+     * The Frontend turns this body into an empty result instead of an error,
+     * see `valueOrUndefinedIfNotFoundOrThrow()`.
+     */
+    @Test
+    fun `Should return OK with the code When the resource may legitimately be missing`() {
+        api
+            .perform(get("/test/errors/usage/NOT_FOUND_BUT_OK"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.code", equalTo("NOT_FOUND_BUT_OK")))
+    }
+
+    @Test
+    fun `Should return NOT_FOUND When the resource is expected to exist`() {
+        api
+            .perform(get("/test/errors/usage/NOT_FOUND"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.code", equalTo("NOT_FOUND")))
+    }
+
+    @Test
+    fun `Should return BAD_REQUEST with the data When the request cannot be processed`() {
+        api
+            .perform(get("/test/errors/usage/COULD_NOT_UPDATE"))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code", equalTo("COULD_NOT_UPDATE")))
+            .andExpect(jsonPath("$.message", equalTo("Usage failure.")))
+            .andExpect(jsonPath("$.data", equalTo(listOf(1, 2))))
+    }
+
+    @Test
+    fun `Should return INTERNAL_SERVER_ERROR with the code When the Backend failed`() {
+        api
+            .perform(get("/test/errors/internal"))
+            .andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.code", equalTo("UNPROCESSABLE_RESOURCE_DATA")))
+            .andExpect(jsonPath("$.message", equalTo("Unprocessable resource.")))
+    }
+
+    @Test
+    fun `Should return UNPROCESSABLE_ENTITY When the request is invalid`() {
+        api
+            .perform(get("/test/errors/request"))
+            .andExpect(status().isUnprocessableEntity)
+            .andExpect(jsonPath("$.code", equalTo("EMPTY_UPLOADED_FILE")))
+            .andExpect(jsonPath("$.message", equalTo("Empty file.")))
+    }
+
+    @Test
+    fun `Should not disclose the exception message When the exception is unexpected`() {
+        api
+            .perform(get("/test/errors/unexpected"))
+            .andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.code", nullValue()))
+            .andExpect(jsonPath("$.message", equalTo(BackendInternalException.DEFAULT_MESSAGE)))
+            .andExpect(jsonPath("$.message", not(containsString("hunter2"))))
+    }
+
+    @Test
+    fun `Should return BAD_REQUEST with the thrown exception type When a resource could not be found`() {
+        api
+            .perform(get("/test/errors/could-not-find"))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error", equalTo("Vessel 123 not found.")))
+            .andExpect(jsonPath("$.type", equalTo("CouldNotFindException")))
+    }
+
+    @Test
+    fun `Should return OK When a NAF message could not be parsed`() {
+        api
+            .perform(get("/test/errors/naf"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.error", equalTo("Invalid NAF format for NAF message \"//SR//AD/FRA\"")))
+            .andExpect(jsonPath("$.type", equalTo("NAFMessageParsingException")))
+    }
+
+    @Test
+    fun `Should return BAD_REQUEST naming the parameter When a required parameter is missing`() {
+        api
+            .perform(get("/test/errors/required-parameter"))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error", equalTo("Parameter \"vesselId\" is missing.")))
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/ControllersExceptionHandlerUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/ControllersExceptionHandlerUTests.kt
@@ -1,0 +1,127 @@
+package fr.gouv.cnsp.monitorfish.infrastructure.api
+
+import fr.gouv.cnsp.monitorfish.domain.exceptions.BackendInternalErrorCode
+import fr.gouv.cnsp.monitorfish.domain.exceptions.BackendInternalException
+import fr.gouv.cnsp.monitorfish.domain.exceptions.BackendUsageErrorCode
+import fr.gouv.cnsp.monitorfish.domain.exceptions.BackendUsageException
+import fr.gouv.cnsp.monitorfish.domain.exceptions.CouldNotFindException
+import fr.gouv.cnsp.monitorfish.infrastructure.api.outputs.ApiError
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.MissingServletRequestParameterException
+
+class ControllersExceptionHandlerUTests {
+    private val handler = ControllersExceptionHandler()
+
+    @Test
+    fun `handleBackendUsageException Should answer OK with the code When the resource may legitimately be missing`() {
+        // Given
+        val exception = BackendUsageException(BackendUsageErrorCode.NOT_FOUND_BUT_OK)
+
+        // When
+        val response = handler.handleBackendUsageException(exception)
+
+        // Then
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.code).isEqualTo(BackendUsageErrorCode.NOT_FOUND_BUT_OK)
+    }
+
+    @Test
+    fun `handleBackendUsageException Should answer NOT_FOUND When the resource is expected to exist`() {
+        // Given
+        val exception = BackendUsageException(BackendUsageErrorCode.NOT_FOUND)
+
+        // When
+        val response = handler.handleBackendUsageException(exception)
+
+        // Then
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(response.body?.code).isEqualTo(BackendUsageErrorCode.NOT_FOUND)
+    }
+
+    @Test
+    fun `handleBackendUsageException Should answer BAD_REQUEST for any other usage error`() {
+        // Given
+        val exception = BackendUsageException(BackendUsageErrorCode.COULD_NOT_UPDATE, message = "Nope.", data = 42)
+
+        // When
+        val response = handler.handleBackendUsageException(exception)
+
+        // Then
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(response.body?.code).isEqualTo(BackendUsageErrorCode.COULD_NOT_UPDATE)
+        assertThat(response.body?.message).isEqualTo("Nope.")
+        assertThat(response.body?.data).isEqualTo(42)
+    }
+
+    @Test
+    fun `handleUnexpectedException Should not disclose the exception message`() {
+        // Given
+        val exception = IllegalStateException("jdbc://user:hunter2@db/monitorfishdb constraint pnos_pkey")
+
+        // When
+        val output = handler.handleUnexpectedException(exception)
+
+        // Then
+        assertThat(output.code).isNull()
+        assertThat(output.message).isEqualTo(BackendInternalException.DEFAULT_MESSAGE)
+    }
+
+    @Test
+    fun `handleBackendInternalException Should keep the authored message and code`() {
+        // Given
+        val exception =
+            BackendInternalException(
+                message = "Database data is unprocessable.",
+                code = BackendInternalErrorCode.UNPROCESSABLE_RESOURCE_DATA,
+            )
+
+        // When
+        val output = handler.handleBackendInternalException(exception)
+
+        // Then
+        assertThat(output.code).isEqualTo(BackendInternalErrorCode.UNPROCESSABLE_RESOURCE_DATA)
+        assertThat(output.message).isEqualTo("Database data is unprocessable.")
+    }
+
+    @Test
+    fun `handleInvalidRequestException Should report the thrown exception rather than a wrapper`() {
+        // Given
+        val exception = CouldNotFindException("Vessel 123 not found.")
+
+        // When
+        val output = handler.handleInvalidRequestException(exception)
+
+        // Then
+        assertThat(output.error).isEqualTo("Vessel 123 not found.")
+        assertThat(output.type).isEqualTo("CouldNotFindException")
+    }
+
+    @Test
+    fun `handleInvalidRequestException Should report an empty error When the exception has no message`() {
+        // When
+        val output = handler.handleInvalidRequestException(IllegalArgumentException())
+
+        // Then
+        assertThat(output.error).isEmpty()
+        assertThat(output.type).isEqualTo("IllegalArgumentException")
+    }
+
+    @Test
+    fun `handleMissingParameter Should name the missing parameter`() {
+        // Given
+        val exception = MissingServletRequestParameterException("vesselId", "Int")
+
+        // When
+        val output = handler.handleMissingParameter(exception)
+
+        // Then
+        assertThat(output).isEqualTo(
+            ApiError(
+                error = "Parameter \"vesselId\" is missing.",
+                type = "MissingServletRequestParameterException",
+            ),
+        )
+    }
+}


### PR DESCRIPTION

Resolve #5328

## Contexte

Revue des use-cases du domaine backend (`domain/use_cases`, 141 fichiers). Quatre bugs confirmés y ont été corrigés, puis `ControllersExceptionHandler` a été assaini — c'est lui qui transformait deux de ces bugs en erreurs 500.

Chaque correction est couverte par un test écrit **rouge d'abord** : le test a été vérifié en échec sur le code actuel, avec l'erreur attendue, avant d'être repassé au vert.

## Bugs corrigés

### 1. `InvalidateOutdatedBFTSWOZeroPNOs` — le job planifié s'interrompait entièrement

Un `return` non local dans le `forEach` sortait de `execute()` au lieu de passer au préavis suivant. Le premier préavis sans `reportId` bloquait donc l'invalidation de **tous** les suivants, à chaque exécution, puisque l'enregistrement fautif revenait à chaque fois.

*Rouge :* `WantedButNotInvoked` — le second préavis n'était jamais invalidé.

### 2. `GetVesselReportings` — 500 sur l'onglet signalements du navire

Un `checkNotNull` sur la date de validation d'une alerte, à l'intérieur du sélecteur de `maxByOrNull`, levait une `IllegalStateException`. Elle n'est pas mappée par le handler et retombait donc en 500, faisant échouer l'onglet entier pour le navire concerné.

Trois lignes plus bas, le même use-case triait déjà avec `validationDate ?: creationDate` : le `checkNotNull` était l'exception à la règle, pas la règle. La notion est extraite dans `Reporting.occurrenceDate` et remplace ses quatre duplications (le use-case perd 16 lignes au passage).

*Rouge :* `IllegalStateException: An alert must have a validation date`.

### 3. `GetMissionActionFacade` et `ComputeRiskFactor` — 500 sur un locode inconnu

`CodeNotFoundException` est une simple `RuntimeException` : non capturée, elle remontait en 500. Un port absent du référentiel faisait donc échouer l'enregistrement d'une action de contrôle ou la création d'un préavis manuel. Elle est désormais capturée, exactement comme le font déjà `EnrichMissionAction` et `GetActivityReports` sur le même appel.

Changement de comportement : l'action est enregistrée avec `facade = null`, et le préavis est calculé avec le niveau de risque d'infraction par défaut.

> À noter : le test existant `Should return null for a land control with unknown port` porte mal son nom — il passe `portLocode = null`. Le cas « locode absent du référentiel » n'était pas couvert.

*Rouge :* `CodeNotFoundException: Port UNKNOWN not found.` sur les deux use-cases.

### 4. `GetPendingAlerts` — une alerte utilisateur pouvait casser toute la liste

Les spécifications étaient résolues via `singleOrNull` sur le `name`, un champ librement saisi par les utilisateurs. Créer une spécification portant le nom d'une alerte native (ex. « FAR manquant en 48h ») donnait deux correspondances, donc `null`, donc une `BackendInternalException` — et une 500 sur l'ensemble des alertes, pas seulement celle en cause.

La résolution se fait désormais sur des clés stables : `id` pour les alertes de position, `type` pour les alertes natives. Sans risque de collision, puisque `PositionAlertSpecificationEntity` ne renseigne jamais `type` (défaut `POSITION_ALERT`) alors que `GetPositionAlertSpecifications` y inscrit le nom de l'`AlertType`.

*Rouge :* `BackendInternalException: Could not find alert specification of alertId: null`.

## Assainissement de `ControllersExceptionHandler`

| Problème | Correction |
|---|---|
| Le handler générique renvoyait `e.message` au client | Journalisé intégralement ; la réponse porte un message générique, corrélable via l'en-tête `x-correlation-id` |
| `ApiError` lisait `exception.cause?.message` | Lit l'exception qu'on lui passe ; l'enveloppe jetable `ApiError(IllegalArgumentException(e.message.toString(), e))` disparaît des deux appels, ainsi que le `"null"` littéral quand le message était absent |
| Cinq formes de sortie d'erreur | `MissingParameterApiError` fusionné dans `ApiError` (fichier supprimé) |
| Journalisation dans les constructeurs d'exceptions | Retirée de `BackendInternalException` et `BackendRequestException` ; chaque handler journalise désormais exactement une fois. `BackendInternalException` chaîne aussi sa cause au lieu de simplement la journaliser, ce qui préserve la stack trace |
| `IllegalStateException::class` en commentaire | Supprimé ; la KDoc explique pourquoi elle reste en 500 (`check()` vérifie un invariant backend, pas une requête malformée) |
| `@Priority(1)` + `@Order(1)` | `@Priority` retiré (seul `@Order` est pris en compte) |
| `handleIllegalArgumentException(e: Exception)` pour 4 types | Renommé `handleInvalidRequestException`, typé `RuntimeException` ; choix du statut extrait dans `statusOf()` |

Effet de bord corrigé au passage : l'ancienne ligne 47 instanciait un `BackendInternalException()` uniquement pour lire son message par défaut, ce qui déclenchait le logger de son constructeur. Chaque 500 inattendue produisait donc une ligne de log parasite. Le message est désormais une `const`.

## Impact frontend : aucun

**Aucun code HTTP n'a été modifié**, volontairement : `isUnauthorizedOrForbidden` et le prédicat de retry RTK se comportent à l'identique.

Côté corps de réponse, `BackendApi.ResponseBodyError` déclare `{ code, data, type }` — jamais `message` ni `error` :

- **`code` est le seul champ lu**, et uniquement pour `NOT_FOUND_BUT_OK`, dans `src/api/utils.ts:20` et `src/features/Logbook/api.ts:54,74`. Ce chemin répond toujours 200 avec son code — vérifié par un nouvel ITest **et** par le `VesselControllerITests:834` existant.
- **`type` est déclaré mais lu nulle part** : la recherche de tous les accès `.type` / `.error` dans `src/` ne remonte qu'un message de service worker dans `LoadOffline.tsx`.
- `FrontendApiError` affiche son propre `userMessage`, jamais celui du backend : le passage à un message générique est invisible pour l'utilisateur.

## Tests

- **9 tests unitaires** sur les use-cases (4 nouveaux cas de régression + les tests existants).
- **`ControllersExceptionHandlerUTests`** (8 tests) : contenu des corps de réponse et statuts des `ResponseEntity`.
- **`ControllersExceptionHandlerITests`** (9 tests) : un contrôleur de test qui lève chaque type d'échec, à travers la vraie pile Spring MVC. C'est ce niveau qui couvre les annotations `@ResponseStatus` et la sérialisation JSON, qu'un appel direct de méthode ne traverse pas.

La non-divulgation du message d'exception a été vérifiée rouge aux deux niveaux : réintroduire `e.message ?: DEFAULT_MESSAGE` fait échouer le test unitaire et l'ITest.

**La suite complète passe**, tests d'intégration Testcontainers inclus (`./gradlew test`, ~4 min). ktlint propre.
