### PR TITLE
Corrige les principales erreurs backend remontées par Kibana (timeouts JDBC, état de préavis impossible, encodage des paramètres d'URL)

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/prior_notification/PriorNotification.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/prior_notification/PriorNotification.kt
@@ -83,8 +83,7 @@ data class PriorNotification(
                         PriorNotificationState.VERIFIED_AND_SENT
                     else -> {
                         logger.error(
-                            "Impossible PriorNotification state: `reportId = $reportId`, isInVerificationScope = $isInVerificationScope`, `isVerified = $isVerified`, `isSent = $isSent`, `isBeingSent = $isBeingSent`.",
-                            BackendInternalErrorCode.UNPROCESSABLE_RESOURCE_DATA,
+                            "[${BackendInternalErrorCode.UNPROCESSABLE_RESOURCE_DATA}] Impossible PriorNotification state: `reportId = $reportId`, isInVerificationScope = $isInVerificationScope`, `isVerified = $isVerified`, `isSent = $isSent`, `isBeingSent = $isBeingSent`.",
                         )
 
                         null

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/repositories/LogbookReportRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/repositories/LogbookReportRepository.kt
@@ -39,6 +39,7 @@ interface LogbookReportRepository {
 
     fun findAllCfrWithVisioCaptures(): List<String>
 
+    /** [cfrs] is used as a cache key: pass it sorted so that identical sets of CFRs share the same entry. */
     fun findLastDepDatetimeOfCurrentTripsPerCfr(cfrs: List<String>): Map<String, ZonedDateTime>
 
     fun getCurrentTripDepAndPositionAtSeaDateTime(

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/vessel/GetActiveVessels.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/use_cases/vessel/GetActiveVessels.kt
@@ -33,7 +33,7 @@ class GetActiveVessels(
         val currentReportingsByCfr = currentReportings.groupBy { it.internalReferenceNumber }
         val currentReportingsByVesselIds = currentReportings.groupBy { it.vesselId }
 
-        val cfrsWithReportings = currentReportings.mapNotNull { it.internalReferenceNumber }.distinct()
+        val cfrsWithReportings = currentReportings.mapNotNull { it.internalReferenceNumber }.distinct().sorted()
         val lastDepDatetimePerCfr = logbookReportRepository.findLastDepDatetimeOfCurrentTripsPerCfr(cfrsWithReportings)
 
         val lastPositionsWithProfileAndVessel =

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaLastPositionRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaLastPositionRepository.kt
@@ -53,7 +53,15 @@ class JpaLastPositionRepository(
             null
         }
 
-    @Cacheable(value = ["active_vessels"])
+    /**
+     * Callers pass `now().minusMonths(1)`: without truncation the sub-second precision makes every call a distinct
+     * cache key, so the cache would never hit and each request would run this (heavy) query again.
+     */
+    @Cacheable(
+        value = ["active_vessels"],
+        key = "#dateTime.truncatedTo(T(java.time.temporal.ChronoUnit).HOURS)",
+        sync = true,
+    )
     override fun findActiveVesselWithReferentialData(dateTime: ZonedDateTime): List<EnrichedActiveVessel> =
         dbLastPositionRepository
             .findActiveVesselWithReferentialData(dateTime)

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaLogbookReportRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaLogbookReportRepository.kt
@@ -204,10 +204,15 @@ class JpaLogbookReportRepository(
     override fun findLastOperationNumber(internalReferenceNumber: String): String? =
         dbLogbookReportRepository.findLastOperationNumber(internalReferenceNumber)
 
-    @Cacheable(value = ["all_visiocaptures_vessels"])
+    @Cacheable(value = ["all_visiocaptures_vessels"], sync = true)
     override fun findAllCfrWithVisioCaptures(): List<String> = dbLogbookReportRepository.findAllCfrWithVisioCaptures()
 
-    @Cacheable(value = ["last_dep_current_trips_by_cfr"])
+    /**
+     * `/bff/v1/vessels` is polled by every connected user, so without `sync` all of them run this (heavy) query
+     * concurrently as soon as the cache entry expires, and the resulting contention makes them all hit the JDBC
+     * query timeout. `cfrs` is the cache key, so callers must pass it sorted to avoid spurious misses.
+     */
+    @Cacheable(value = ["last_dep_current_trips_by_cfr"], sync = true)
     override fun findLastDepDatetimeOfCurrentTripsPerCfr(cfrs: List<String>): Map<String, ZonedDateTime> {
         if (cfrs.isEmpty()) {
             return emptyMap()

--- a/frontend/src/utils/__tests__/getUrlOrPathWithQueryParams.test.ts
+++ b/frontend/src/utils/__tests__/getUrlOrPathWithQueryParams.test.ts
@@ -30,6 +30,15 @@ describe('getUrlOrPathWithQueryParams', () => {
     expect(result).toBe('/example?name=John')
   })
 
+  it('should percent-encode values so that reserved characters do not break the query string', () => {
+    const path = '/example'
+    const queryParams = { searched: '%ARIA CE', startedAfterDateTime: '2026-07-02T00:00:00+02:00' }
+
+    const result = getUrlOrPathWithQueryParams(path, queryParams)
+
+    expect(result).toBe('/example?searched=%25ARIA%20CE&startedAfterDateTime=2026-07-02T00%3A00%3A00%2B02%3A00')
+  })
+
   it('should return the original URL if queryParamsAsObject is empty', () => {
     const path = '/example'
     const queryParams = {}

--- a/frontend/src/utils/getUrlOrPathWithQueryParams.ts
+++ b/frontend/src/utils/getUrlOrPathWithQueryParams.ts
@@ -15,7 +15,12 @@ export function getUrlOrPathWithQueryParams(urlOrPath: string, queryParamsAsObje
         return queryParamsAsStringAcc
       }
 
-      const queryParamAsString = Array.isArray(value) ? `${key}=${[...value].sort().join(',')}` : `${key}=${value}`
+      const queryParamAsString = Array.isArray(value)
+        ? `${encodeURIComponent(key)}=${[...value]
+            .sort()
+            .map(item => encodeURIComponent(item))
+            .join(',')}`
+        : `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
 
       return `${queryParamsAsStringAcc}${queryParamsAsStringAcc ? '&' : ''}${queryParamAsString}`
     }, '')

--- a/pipeline/src/flows/distribute_pnos.py
+++ b/pipeline/src/flows/distribute_pnos.py
@@ -958,7 +958,12 @@ def make_update_logbook_reports_statement(
             "WHERE "
             "   operation_datetime_utc >= :start_datetime_utc "
             "   AND operation_datetime_utc < :end_datetime_utc "
-            "   AND report_id IN :logbook_pno_report_ids"
+            "   AND report_id IN :logbook_pno_report_ids "
+            # The backend resets `isBeingSent`, `isSent` and `isVerified` to false when the PNO
+            # is edited while this flow is running. Without this guard we would then write
+            # `isSent = true` back onto a PNO the backend just reset, producing a state that the
+            # backend considers impossible (see adrs/0006).
+            "   AND (value->>'isBeingSent')::BOOLEAN IS true"
         ).bindparams(
             *bind_params,
             start_datetime_utc=start_datetime_utc,
@@ -1045,7 +1050,9 @@ def make_manual_prior_notifications_statement(
             "       '{isSent}', "
             f"{is_sent_line}"
             "   ) "
-            "WHERE report_id IN :manual_pno_report_ids"
+            "WHERE report_id IN :manual_pno_report_ids "
+            # See `make_update_logbook_reports_statement`.
+            "   AND (value->>'isBeingSent')::BOOLEAN IS true"
         ).bindparams(*bind_params)
 
         return statement

--- a/pipeline/tests/test_flows/test_distribute_pnos.py
+++ b/pipeline/tests/test_flows/test_distribute_pnos.py
@@ -2502,6 +2502,7 @@ def test_make_update_logbook_reports_statement(
         "    operation_datetime_utc >= '2023-06-05 12:05:06'"
         "    AND operation_datetime_utc < '2023-07-05 15:02:38'"
         "    AND report_id IN ('Report-1')"
+        "    AND (value->>'isBeingSent')::BOOLEAN IS true"
     )
 
     # Test with sent messages
@@ -2530,6 +2531,7 @@ def test_make_update_logbook_reports_statement(
         "    operation_datetime_utc >= '2023-06-05 12:05:06'"
         "    AND operation_datetime_utc < '2023-07-05 15:02:38'"
         "    AND report_id IN ('Report-1')"
+        "    AND (value->>'isBeingSent')::BOOLEAN IS true"
     )
 
 
@@ -2555,6 +2557,7 @@ def test_make_update_manual_prior_notifications_statement(
         "        false::text::jsonb"
         "   ) "
         "WHERE report_id IN ('Report-2')"
+        "    AND (value->>'isBeingSent')::BOOLEAN IS true"
     )
 
     # Test with sent messages
@@ -2577,6 +2580,7 @@ def test_make_update_manual_prior_notifications_statement(
         "        (CASE WHEN report_id IN ('Manual-Report-1') THEN 'true' ELSE 'false' END)::jsonb"
         "   ) "
         "WHERE report_id IN ('Report-2')"
+        "    AND (value->>'isBeingSent')::BOOLEAN IS true"
     )
 
 

--- a/pipeline/tests/test_flows/test_distribute_pnos.py
+++ b/pipeline/tests/test_flows/test_distribute_pnos.py
@@ -2638,6 +2638,7 @@ def test_make_update_logbook_reports_statement(
         "    operation_datetime_utc >= '2023-06-05 12:05:06'"
         "    AND operation_datetime_utc < '2023-07-05 15:02:38'"
         "    AND report_id IN ('Report-1')"
+        "    AND (value->>'isBeingSent')::BOOLEAN IS true"
     )
 
     # Test with sent messages
@@ -2666,6 +2667,7 @@ def test_make_update_logbook_reports_statement(
         "    operation_datetime_utc >= '2023-06-05 12:05:06'"
         "    AND operation_datetime_utc < '2023-07-05 15:02:38'"
         "    AND report_id IN ('Report-1')"
+        "    AND (value->>'isBeingSent')::BOOLEAN IS true"
     )
 
 
@@ -2691,6 +2693,7 @@ def test_make_update_manual_prior_notifications_statement(
         "        false::text::jsonb"
         "   ) "
         "WHERE report_id IN ('Report-2')"
+        "    AND (value->>'isBeingSent')::BOOLEAN IS true"
     )
 
     # Test with sent messages
@@ -2713,6 +2716,7 @@ def test_make_update_manual_prior_notifications_statement(
         "        (CASE WHEN report_id IN ('Manual-Report-1') THEN 'true' ELSE 'false' END)::jsonb"
         "   ) "
         "WHERE report_id IN ('Report-2')"
+        "    AND (value->>'isBeingSent')::BOOLEAN IS true"
     )
 
 


### PR DESCRIPTION
## Contexte

Analyse de deux exports Kibana des logs backend de production (~4 900 hits, 1 000 échantillonnés). Répartition des erreurs de niveau `ERROR`, dédoublonnées :

| # | Erreur | Part |
|---|---|---|
| 1 | `QueryTimeoutException` — *canceling statement due to user request* | ~92 % |
| 2 | `Impossible PriorNotification state` (un seul préavis : `PRT20260206000001`) | 112 |
| 3 | `Unexpected error occurred in scheduled task` | 9 |
| 4 | `Could not fetch missions` (MonitorEnv 502) | 7 |
| 5 | `Character decoding failed. Parameter [searched]` | 8 |
| 6 | Échecs OIDC (`invalid_token_response`, JWKS injoignable, `authorization_request_not_found`) | 12 |

Les erreurs 1 et 3 ont la même origine : `MONITORFISH_DATABASE_QUERY_TIMEOUT=20000` alimente `jakarta.persistence.query.timeout` (`application.yml:83`), donc toute requête dépassant 20 s est annulée par le driver PostgreSQL.

Détail de l'erreur 1 par requête SQL :

- **2 208** — `SELECT * FROM get_active_trips(...)`
- **87** — la jointure `last_positions ⋈ vessel_profiles ⋈ vessels ⋈ beacons ⋈ risk_factors`
- **24 / 6** — liste des préavis manuels / `find_all_enriched_pno_references_and_related_operations`

Toutes ces requêtes sont exécutées par `GetActiveVessels`, c'est-à-dire `/bff/v1/vessels`, que `VesselLoader.tsx:27` sonde toutes les 5 minutes pour chaque utilisateur connecté.

## Corrections

### 1. Le cache `active_vessels` n'était jamais touché

`JpaLastPositionRepository.kt:56` — les deux appelants passent `ZonedDateTime.now().minusMonths(1)`, et le générateur de clé par défaut utilise cette valeur (précise à la nanoseconde) comme clé. Chaque appel produisait donc une clé unique et la grosse jointure était rejouée à chaque requête. La clé est désormais tronquée à l'heure, avec `sync = true`.

### 2. Effet « thundering herd » sur `get_active_trips`

`JpaLogbookReportRepository.kt:210` — aucun des 56 `@Cacheable` du projet n'utilisait `sync`. À l'expiration de l'entrée (TTL 5 min), tous les clients en cours de polling lançaient la même requête lourde simultanément ; la contention les faisait tous dépasser les 20 s, le cache n'était donc jamais peuplé et le cycle se répétait indéfiniment. Ajout de `sync = true` (également sur `all_visiocaptures_vessels`) et tri de la liste de CFR côté appelant, puisqu'elle sert de clé de cache.

### 3. État de préavis impossible (perte de mise à jour)

`distribute_pnos.py` sélectionne les préavis avec `isBeingSent = true`, puis réécrit `isSent = true` plusieurs minutes plus tard. Si un utilisateur téléverse un document ou modifie le commentaire dans cet intervalle, le backend remet `isVerified` / `isSent` / `isBeingSent` à false, et la pipeline ressuscite ensuite `isSent` par-dessus → `isInVerificationScope && !isVerified && isSent`, état que l'ADR 0006 déclare impossible. Les deux UPDATE de réécriture sont maintenant gardés par `AND (value->>'isBeingSent')::BOOLEAN IS true`.

Au passage, le code d'erreur de ce log était silencieusement perdu : SLF4J traite `BackendInternalErrorCode.UNPROCESSABLE_RESOURCE_DATA` comme argument de `{}`, et le message n'en contenait aucun. Il est désormais intégré au message.

### 4. `Character decoding failed`

`getUrlOrPathWithQueryParams` concaténait les valeurs sans aucun encodage. Un `%` saisi dans la recherche de navire arrivait donc à Tomcat comme un échappement invalide, et le paramètre était ignoré. Clés et valeurs sont maintenant passées par `encodeURIComponent`. Corrige également le `+` des décalages ISO qui devenait silencieusement une espace.

## Vérifications

- `compileKotlin` sans erreur
- `GetActiveVesselsUTests` + `PriorNotificationUTests` au vert
- Tests unitaires frontend au vert (5/5), prettier + oxlint sans remontée
- Les attentes des tests pipeline sont mises à jour. Je n'ai pas pu lancer pytest en local (`pipeline/.env` ne contient pas `MONITORFISH_URL` ni d'autres clés, l'import du conftest échoue) : le SQL compilé a été comparé octet à octet aux nouvelles chaînes attendues via un script SQLAlchemy autonome.

## Hors périmètre — à arbitrer

- **`get_active_trips` elle-même.** `sync = true` supprime l'empilement, mais si la requête dépasse réellement 20 s seule, les utilisateurs auront encore un échec toutes les 5 minutes. `trips_snapshot` n'a que `trips_cfr_idx` sur `(cfr)` alors que la fonction fait `DISTINCT ON (cfr) … ORDER BY cfr, start_datetime_utc DESC` : un index sur `(cfr, start_datetime_utc DESC)` est le candidat évident, mais je n'ai pas voulu livrer une migration spéculative sans `EXPLAIN` de prod.
- **TTL de `last_dep_current_trips_by_cfr` à 5 min**, exactement l'intervalle de polling : chaque cycle paie donc encore une exécution complète. L'augmenter (15 min ?) est un arbitrage de fraîcheur sur l'affichage signalement/marée.
- **Tâches planifiées** (`UpdateCache`, `InvalidateOutdatedBFTSWOZeroPNOs`, `ArchiveOutdatedReportings`) : elles héritent du plafond de 20 s, inadapté à des traitements batch. Un `@QueryHints` ciblé fonctionnerait, mais ces méthodes de repository sont partagées avec des chemins utilisateur — il faut les séparer d'abord.
- **502 MonitorEnv** — infra amont ; le client Ktor n'a aucun retry. Volume faible (7).
- **Erreurs OIDC** — majoritairement externes (401/500 du fournisseur, JWKS injoignable). `authorization_request_not_found` correspond au cas normal du callback périmé et relève plutôt du WARN que de l'ERROR.
- **`application.yml:59` passe le logger de déconnexion en DEBUG dans tous les environnements**, ce qui explique les 34 lignes contenant des e-mails utilisateurs et des identifiants de session présentes dans un export filtré sur ERROR. À retirer.
