### PR TITLE
CR de contrôle - Bug de saisie du poids des espèces

### DIFF
--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/speciesControlCheckRows.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/Species/speciesControlCheckRows.tsx
@@ -6,7 +6,6 @@ import type { SpeciesEISRApplicability } from './getSpeciesEISRApplicability'
 import type { ControlCheckRow } from '../ControlCheckTable'
 
 const BASE_SPECIES_CHECK_ROWS: ControlCheckRow[] = [
-  { isRequired: true, label: 'Poids des espèces vérifiés', name: 'speciesWeightControlled' },
   { isRequired: true, label: 'Taille des espèces vérifiées', name: 'speciesSizeControlled' },
   {
     isRequired: true,
@@ -58,6 +57,7 @@ const LAND_CONTROL_NOT_LANDED_CHECK_ROWS: ControlCheckRow[] = [
 ]
 
 const SEA_CONTROL_EISR_CHECK_ROWS: ControlCheckRow[] = [
+  { isRequired: true, label: 'Poids des espèces vérifiés', name: 'speciesWeightControlled' },
   {
     isRequired: true,
     label: "Arrimage séparé des poissons n'ayant pas la taille requise",


### PR DESCRIPTION
## Linked issues

- Resolve #5358

See historic commit: https://github.com/MTES-MCT/monitorfish/pull/5283/changes/a765470023b26d296a082357d3c01c20af74d93f

----

- [ ] Tests E2E (Cypress)
