### PR TITLE
[Tech] Bump GitHub Actions (checkout, cache, setup-java, codeql-action)

### DIFF
--- a/.github/workflows/cicd-data-processing-prefect-3.yml
+++ b/.github/workflows/cicd-data-processing-prefect-3.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/setup-buildx-action@master
 
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /tmp/.buildx-cache-pipeline-prefect3
           key: ${{ runner.os }}-single-buildx-data-pipeline-prefect3-${{ github.ref_name }}

--- a/.github/workflows/cicd-data-processing-prefect-3.yml
+++ b/.github/workflows/cicd-data-processing-prefect-3.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Get last release version
         id: lastrelease

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -145,7 +145,7 @@ jobs:
         uses: docker/setup-buildx-action@master
 
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /tmp/.buildx-cache-app
           key: ${{ runner.os }}-single-buildx-app-${{ github.ref_name }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -40,7 +40,7 @@ jobs:
       VERSION: ${{ env.VERSION }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set version and environment profile
         uses: ./.github/actions/set-version-and-environment-profile
@@ -63,7 +63,7 @@ jobs:
           java-version: 17
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Lint Backend
         run: ./gradlew ktlintCheck
@@ -82,7 +82,7 @@ jobs:
       NODE_OPTIONS: "--max_old_space_size=10240"
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -138,7 +138,7 @@ jobs:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         id: buildx
@@ -206,7 +206,7 @@ jobs:
       VERSION: ${{ needs.version.outputs.VERSION }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Download image
         uses: ishworkh/container-image-artifact-download@v2.1.0
@@ -265,7 +265,7 @@ jobs:
       VERSION: ${{ needs.version.outputs.VERSION }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Download image
         uses: ishworkh/container-image-artifact-download@v2.1.0
@@ -311,7 +311,7 @@ jobs:
       SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 100
 
@@ -354,7 +354,7 @@ jobs:
       VERSION: ${{needs.version.outputs.VERSION}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Download image
         uses: ishworkh/container-image-artifact-download@v2.1.0

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -56,7 +56,7 @@ jobs:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: Setup Java JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.6.0
         with:
           # https://github.com/actions/setup-java/blob/main/README.md#Supported-distributions
           distribution: zulu

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -24,7 +24,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set IMAGE_TAG
         run: echo "IMAGE_TAG=ghcr.io/mtes-mct/monitorfish/monitorfish-database:${{ matrix.image_version }}" >> $GITHUB_ENV
@@ -71,7 +71,7 @@ jobs:
   #     packages: write
   #   steps:
   #     - name: Checkout
-  #       uses: actions/checkout@v5
+  #       uses: actions/checkout@v7
 
   #     - name: Set IMAGE_TAG
   #       run: echo "IMAGE_TAG=ghcr.io/mtes-mct/monitorfish/monitorfish-database-upgrade:${{ matrix.image_version }}" >> $GITHUB_ENV

--- a/.github/workflows/database_healthcheck.yml
+++ b/.github/workflows/database_healthcheck.yml
@@ -36,7 +36,7 @@ jobs:
       POSTGRES_PASSWORD: postgres
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Get last release version
         id: get-last-release-version

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -59,6 +59,6 @@ jobs:
           severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@v4.37.3
         with:
           sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
Regroupe les 4 PRs Dependabot ouvertes de mise à jour des GitHub Actions :

- actions/cache 4 → 6 (#5252)
- actions/checkout 5 → 7 (#5253)
- actions/setup-java 5 → 5.6.0 (#5341)
- github/codeql-action 4 → 4.37.3 (#5342)

Les commits Dependabot sont repris tels quels (cherry-pick, sans conflit). Les 4 PRs d'origine sont fermées au profit de celle-ci.