### PR TITLE
Tech - Frontend - Nettoyage des effets React (timers et listeners non nettoyés)

### DIFF
--- a/frontend/src/features/ActivityVisualization/components/ActivityVisualizationMap.tsx
+++ b/frontend/src/features/ActivityVisualization/components/ActivityVisualizationMap.tsx
@@ -21,10 +21,10 @@ export function ActivityVisualizationMap() {
 
   useEffect(() => {
     if (!html) {
-      return
+      return undefined
     }
 
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       const map = (
         document.getElementById('kepler_iframe') as HTMLIFrameElement
       ).contentWindow?.document.getElementById('kepler-gl__map')
@@ -33,6 +33,8 @@ export function ActivityVisualizationMap() {
         map.style.height = '100%'
       }
     }, 3000)
+
+    return () => clearTimeout(timeoutId)
   }, [html])
 
   if (!html) {

--- a/frontend/src/features/Alert/components/SideWindowAlerts/AlertManagementForm/FormikValidityPeriod.tsx
+++ b/frontend/src/features/Alert/components/SideWindowAlerts/AlertManagementForm/FormikValidityPeriod.tsx
@@ -50,7 +50,9 @@ export function FormikValidityPeriod() {
       })
     }
 
-    setTimeout(addIconToLabel, 200)
+    const timeoutId = setTimeout(addIconToLabel, 200)
+
+    return () => clearTimeout(timeoutId)
   }, [])
 
   const handleDateRangePickerChange = (dateRange: DateAsStringRange | undefined) => {

--- a/frontend/src/features/BeaconMalfunction/components/BeaconMalfunctionBoard/BeaconMalfunctionDetailsFollowUp.tsx
+++ b/frontend/src/features/BeaconMalfunction/components/BeaconMalfunctionBoard/BeaconMalfunctionDetailsFollowUp.tsx
@@ -44,10 +44,14 @@ export function BeaconMalfunctionDetailsFollowUp({ beaconMalfunctionWithDetails,
     setYesterday(getDate(yesterdayDate.toISOString()))
 
     if (comments?.length && !isScrollBlocked.current) {
-      setTimeout(() => {
+      const timeoutId = setTimeout(() => {
         scrollToRef.current?.scrollIntoView({ block: 'nearest' })
       }, 500)
+
+      return () => clearTimeout(timeoutId)
     }
+
+    return undefined
   }, [comments])
 
   const getCommentOrActionDate = date => {

--- a/frontend/src/features/Map/components/BaseMap.tsx
+++ b/frontend/src/features/Map/components/BaseMap.tsx
@@ -46,13 +46,15 @@ export function BaseMap({
     if (!isMainApp) {
       isInitRenderDone.current = true
 
-      return
+      return undefined
     }
 
     // Wait 15 seconds to not apply any animate() before this init phase only in the homepage
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       isInitRenderDone.current = true
     }, 15000)
+
+    return () => clearTimeout(timeoutId)
   }, [isMainApp])
 
   const saveCoordinates = useCallback((event: MapBrowserEvent<any>) => {

--- a/frontend/src/features/Station/components/HoveredStationOverlay.tsx
+++ b/frontend/src/features/Station/components/HoveredStationOverlay.tsx
@@ -1,6 +1,6 @@
 import { MonitorFishMap } from '@features/Map/Map.types'
-import { useForceUpdate, type Coordinates } from '@mtes-mct/monitor-ui'
-import { useEffect, useMemo, useRef } from 'react'
+import { type Coordinates } from '@mtes-mct/monitor-ui'
+import { useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import { StationCard } from './StationCard'
@@ -15,7 +15,7 @@ type HoveredStationOverlayProps = {
   hoveredFeature: FeatureWithCodeAndEntityId | undefined
 }
 export function HoveredStationOverlay({ hoveredFeature }: HoveredStationOverlayProps) {
-  const hoverDialogElementRef = useRef<HTMLDivElement | null>(null)
+  const [hoverDialogElement, setHoverDialogElement] = useState<HTMLDivElement | null>(null)
 
   const selectedStationId = useMainAppSelector(state => state.station.selectedStationId)
   const hoveredStationId =
@@ -24,7 +24,6 @@ export function HoveredStationOverlay({ hoveredFeature }: HoveredStationOverlayP
       : undefined
 
   const { data: stations } = useGetStationsQuery()
-  const { forceUpdate } = useForceUpdate()
 
   const hoveredStation = useMemo(
     () => (hoveredStationId ? stations?.find(station => station.id === hoveredStationId) : undefined),
@@ -32,21 +31,15 @@ export function HoveredStationOverlay({ hoveredFeature }: HoveredStationOverlayP
   )
 
   const wrapperWindowPosition = useMemo(
-    () => getDialogWindowPositionFromFeature(hoveredFeature, hoverDialogElementRef.current, FEATURE_MARGINS),
+    () => getDialogWindowPositionFromFeature(hoveredFeature, hoverDialogElement, FEATURE_MARGINS),
     // Dependency optimization
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [hoverDialogElementRef.current, hoveredStationId]
+    [hoverDialogElement, hoveredStationId]
   )
 
-  useEffect(() => {
-    if (hoveredStationId !== undefined) {
-      forceUpdate()
-    }
-  }, [forceUpdate, hoveredStationId])
-
   return (
-    <Wrapper $isVisible={!!hoverDialogElementRef.current} $topLeftPosition={wrapperWindowPosition}>
-      {hoveredStation && <StationCard ref={hoverDialogElementRef} station={hoveredStation} />}
+    <Wrapper $isVisible={!!hoverDialogElement} $topLeftPosition={wrapperWindowPosition}>
+      {hoveredStation && <StationCard ref={setHoverDialogElement} station={hoveredStation} />}
     </Wrapper>
   )
 }

--- a/frontend/src/features/Vessel/layers/VesselsLabelsLayer/index.tsx
+++ b/frontend/src/features/Vessel/layers/VesselsLabelsLayer/index.tsx
@@ -58,9 +58,12 @@ export function VesselsLabelsLayer({ mapMovingAndZoomEvent }) {
   const [vesselToCoordinates, setVesselToCoordinates] = useState(new Map())
   const [vesselToRiskFactorDetailsShowed, setVesselToRiskFactorDetailsShowed] = useState(new Map())
   const isThrottled = useRef(false)
+  const throttleTimeoutIdRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const [currentLabels, setCurrentLabels] = useState<JSX.Element[]>([])
 
   useMapLayer(VESSELS_LABEL_VECTOR_LAYER)
+
+  useEffect(() => () => clearTimeout(throttleTimeoutIdRef.current), [])
 
   const moveVesselLabelLine = useCallback(
     (featureId, fromCoordinates, toCoordinates, offset) => {
@@ -195,7 +198,7 @@ export function VesselsLabelsLayer({ mapMovingAndZoomEvent }) {
     // End of functions definition
 
     isThrottled.current = true
-    setTimeout(() => {
+    throttleTimeoutIdRef.current = setTimeout(() => {
       addVesselLabelToAllFeaturesInExtent()
       isThrottled.current = false
     }, throttleDuration)

--- a/frontend/src/hooks/useClickOutsideWhenOpened.jsx
+++ b/frontend/src/hooks/useClickOutsideWhenOpened.jsx
@@ -16,16 +16,15 @@ export const useClickOutsideWhenOpened = (ref, isOpened) => {
     if (isOpened) {
       document.addEventListener('mousedown', handleClickOutside)
 
-      return
+      return () => {
+        // Unbind the event listener on clean up
+        document.removeEventListener('mousedown', handleClickOutside)
+      }
     }
 
-    document.removeEventListener('mousedown', handleClickOutside)
     setClicked(null)
 
-    return () => {
-      // Unbind the event listener on clean up
-      document.removeEventListener('mousedown', handleClickOutside)
-    }
+    return undefined
   }, [ref, isOpened])
 
   return clicked

--- a/frontend/src/hooks/useDisplayMapBox.ts
+++ b/frontend/src/hooks/useDisplayMapBox.ts
@@ -7,13 +7,15 @@ export function useDisplayMapBox(condition: boolean) {
   useEffect(() => {
     if (condition) {
       setIsRendered(true)
-      setTimeout(() => setIsOpened(true), 50)
+      const openingTimeoutId = setTimeout(() => setIsOpened(true), 50)
 
-      return
+      return () => clearTimeout(openingTimeoutId)
     }
 
     setIsOpened(false)
-    setTimeout(() => setIsRendered(false), 300)
+    const closingTimeoutId = setTimeout(() => setIsRendered(false), 300)
+
+    return () => clearTimeout(closingTimeoutId)
   }, [condition])
 
   return {


### PR DESCRIPTION
## Linked issues

Follow-up of #5176 — fixes the error-severity react-doctor findings (`effect-needs-cleanup`, `no-mutable-in-deps`). Each finding was triaged individually; only real leaks were fixed.

### Leaked timers (cleared in effect cleanup)

- `useDisplayMapBox.ts` — both open/close animation timers were never cleared: a quick close-then-reopen let the stale 300 ms `setIsRendered(false)` fire and hide the box that was just reopened.
- `ActivityVisualizationMap.tsx` — the 3 s Kepler iframe resize timer survived unmount and could throw a `TypeError` (`getElementById(...) as HTMLIFrameElement` is null once the iframe is gone).
- `FormikValidityPeriod.tsx` — 200 ms "add info icon" timer.
- `BeaconMalfunctionDetailsFollowUp.tsx` — 500 ms scroll-into-view timer, re-armed on every `comments` change without clearing the previous one.
- `BaseMap.tsx` — 15 s init-phase timer.
- `VesselsLabelsLayer/index.tsx` — the labels throttle timer kept running after unmount (setState + mutation of the global `VESSELS_LABEL_VECTOR_SOURCE`). Cleared by a dedicated unmount-only effect so the throttle semantics are untouched.

### Leaked listener

- `useClickOutsideWhenOpened.jsx` — the `isOpened` branch did `addEventListener` then `return` (early return, **no** cleanup); the cleanup only existed in the branch that never adds a listener. Unmounting while open leaked a document-level `mousedown` listener. The cleanup now lives in the right branch.

### Ref in deps (`no-mutable-in-deps`)

- `HoveredStationOverlay.tsx` — `hoverDialogElementRef.current` was in `useMemo` deps (never triggers re-render) and was papered over with a `forceUpdate()` effect. Replaced with the canonical callback-ref-in-state pattern (`ref={setHoverDialogElement}`), which also deletes the `forceUpdate` hack and fixes a stale-visibility edge (the wrapper stayed `$isVisible` after the card unmounted).

### Triaged as false positives (not changed)

- The remaining `effect-needs-cleanup` hits (`SilenceAlertMenu`, `Draw/layer`, `BaseMap` move-listeners, `useMoveOverlayWhenDragging`, `RightClickMapMenu`, `useMapClick`, `useMapPointerMove`, `useListenToAllMissionEventsUpdates`, `SelectedReportingOverlay`) all already return complete cleanups — the rule seems to trip on early-return guards and optional chaining.
- All 5 `no-ref-current-in-render` hits are the deliberate, idempotent latest-value-ref pattern (two are even commented as such); rewriting them would change render-timing semantics.

Verified: `tsc`, `test:lint` (OxLint), `test:lint:types` and Prettier all pass; react-doctor re-run confirms every real finding cleared (`effect-needs-cleanup` 18 → 13 false positives, `no-mutable-in-deps` 1 → 0).

----

- [ ] Tests E2E (Cypress)
