### PR TITLE
CR de contrôle - Masquer les champs de maillage pour les engins qui n'ont pas de maillage

### DIFF
--- a/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
@@ -1096,9 +1096,11 @@ context('Side Window > Mission Form > Sea Control', () => {
 
     cy.wait(500)
 
-    // OTB (Chaluts category) is prefilled at index 0 — wire fields should be shown.
+    // OTB (Chaluts category) is prefilled at index 0 — wire and mesh fields should be shown.
     cy.get('[id="gearOnboard[0].averageWireThickness"]').should('exist')
     cy.get('[name="gearOnboard[0].wireType"]').should('exist')
+    cy.get('[id="gearOnboard[0].declaredMesh"]').should('exist')
+    cy.get('[id="gearOnboard[0].controlledMesh"]').should('exist')
 
     cy.fill('Engin contrôlé', 'Oui', { index: 0 })
     cy.fill("Marquage de l'engin conforme", 'Non', { index: 0 })
@@ -1121,11 +1123,13 @@ context('Side Window > Mission Form > Sea Control', () => {
     cy.fill('Epaisseur moy. de fil  ', 1.5)
     cy.fill('Type de fil', 'Simple')
 
-    // Add an LLS gear (Lignes et hameçons category) — wire fields should NOT appear
+    // Add an LLS gear (Lignes et hameçons category) — wire and mesh fields should NOT appear
     cy.fill('Ajouter un engin', 'LLS')
     cy.wait(250)
     cy.get('[id="gearOnboard[1].averageWireThickness"]').should('not.exist')
     cy.get('[name="gearOnboard[1].wireType"]').should('not.exist')
+    cy.get('[id="gearOnboard[1].declaredMesh"]').should('not.exist')
+    cy.get('[id="gearOnboard[1].controlledMesh"]').should('not.exist')
 
     // LLS (Lignes et hameçons) is a marking-not-applicable category, so it shows no marking field
     // and defaults gearMarkingIsCompliant to NOT_APPLICABLE.

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/schemas.ts
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/schemas.ts
@@ -1,6 +1,7 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 
 import { HIDDEN_ERROR } from '@features/Mission/components/MissionForm/constants'
+import { hasGearMesh } from '@features/Mission/components/MissionForm/utils'
 import { MissionAction } from '@features/Mission/missionAction.types'
 import { customDayjs } from '@mtes-mct/monitor-ui'
 import { mainStore } from '@store'
@@ -132,10 +133,10 @@ export function makeGearOnboardSchema(isEISR: boolean) {
     declaredMesh: number().when(['gearCode', 'controlledMesh'], {
       is: (gearCode, controlledMesh, context) => {
         const { gears } = mainStore.getState().gear
-        const isMeshRequiredForSegment = gears.find(gear => gear.code === gearCode)?.isMeshRequiredForSegment
+        const gear = gears.find(({ code }) => code === gearCode)
         const declaredMesh = context?.parent?.declaredMesh
 
-        if (isMeshRequiredForSegment) {
+        if (gear?.isMeshRequiredForSegment && hasGearMesh(gearCode, gear.category)) {
           return controlledMesh === undefined && declaredMesh === undefined
         }
 

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/GearsField.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/GearsField.tsx
@@ -27,6 +27,7 @@ import { useGetMissionActionFormikUsecases } from '../../hooks/useGetMissionActi
 import { FieldGroup } from '../../shared/FieldGroup'
 import { FieldsetGroup, FieldsetGroupSpinner } from '../../shared/FieldsetGroup'
 import { FieldsetGroupSeparator } from '../../shared/FieldsetGroupSeparator'
+import { hasGearMesh } from '../../utils'
 
 import type { MissionActionFormValues } from '../../types'
 import type { Option } from '@mtes-mct/monitor-ui'
@@ -167,6 +168,8 @@ export function GearsField() {
         <>
           {input.value.map((gearOnboard, index) => {
             const gearCategory = gearsAsOptions.find(o => o.value.code === gearOnboard.gearCode)?.value.category ?? ''
+            const hasMeshFields = hasGearMesh(gearOnboard.gearCode, gearCategory)
+            const hasWireFields = isEISREnabled && WIRE_FIELDS_GEAR_CATEGORIES.has(gearCategory)
 
             return (
               <Row
@@ -203,44 +206,50 @@ export function GearsField() {
                     />
                   )}
 
-                  <StyledFieldGroup isInline>
-                    <FormikNumberInput
-                      isErrorMessageHidden
-                      isRequired
-                      label="Maillage déclaré"
-                      name={`gearOnboard[${index}].declaredMesh`}
-                    />
-                    <FormikNumberInput
-                      disabled={!gearOnboard.gearWasControlled || gearOnboard.hasUncontrolledMesh}
-                      isErrorMessageHidden
-                      isUndefinedWhenDisabled
-                      label="Maillage mesuré"
-                      name={`gearOnboard[${index}].controlledMesh`}
-                    />
-                    {isEISREnabled && WIRE_FIELDS_GEAR_CATEGORIES.has(gearCategory) && (
-                      <>
-                        <FormikNumberInput
-                          disabled={gearOnboard.gearWasControlled === false}
-                          isErrorMessageHidden
-                          isUndefinedWhenDisabled
-                          label="Epaisseur moy. de fil"
-                          name={`gearOnboard[${index}].averageWireThickness`}
-                        />
-                        <FormikSelect
-                          disabled={gearOnboard.gearWasControlled === false}
-                          isErrorMessageHidden
-                          isUndefinedWhenDisabled
-                          label="Type de fil"
-                          name={`gearOnboard[${index}].wireType`}
-                          options={WIRE_TYPE_OPTIONS}
-                        />
-                      </>
-                    )}
-                  </StyledFieldGroup>
-                  {typedError && typedError[index]?.declaredMesh && (
+                  {(hasMeshFields || hasWireFields) && (
+                    <StyledFieldGroup isInline>
+                      {hasMeshFields && (
+                        <>
+                          <FormikNumberInput
+                            isErrorMessageHidden
+                            isRequired
+                            label="Maillage déclaré"
+                            name={`gearOnboard[${index}].declaredMesh`}
+                          />
+                          <FormikNumberInput
+                            disabled={!gearOnboard.gearWasControlled || gearOnboard.hasUncontrolledMesh}
+                            isErrorMessageHidden
+                            isUndefinedWhenDisabled
+                            label="Maillage mesuré"
+                            name={`gearOnboard[${index}].controlledMesh`}
+                          />
+                        </>
+                      )}
+                      {hasWireFields && (
+                        <>
+                          <FormikNumberInput
+                            disabled={gearOnboard.gearWasControlled === false}
+                            isErrorMessageHidden
+                            isUndefinedWhenDisabled
+                            label="Epaisseur moy. de fil"
+                            name={`gearOnboard[${index}].averageWireThickness`}
+                          />
+                          <FormikSelect
+                            disabled={gearOnboard.gearWasControlled === false}
+                            isErrorMessageHidden
+                            isUndefinedWhenDisabled
+                            label="Type de fil"
+                            name={`gearOnboard[${index}].wireType`}
+                            options={WIRE_TYPE_OPTIONS}
+                          />
+                        </>
+                      )}
+                    </StyledFieldGroup>
+                  )}
+                  {hasMeshFields && typedError && typedError[index]?.declaredMesh && (
                     <FieldError>{typedError[index]?.declaredMesh}</FieldError>
                   )}
-                  {typedError && typedError[index]?.controlledMesh && (
+                  {hasMeshFields && typedError && typedError[index]?.controlledMesh && (
                     <FieldError>{typedError[index]?.controlledMesh}</FieldError>
                   )}
 

--- a/frontend/src/features/Mission/components/MissionForm/__tests__/utils.test.ts
+++ b/frontend/src/features/Mission/components/MissionForm/__tests__/utils.test.ts
@@ -2,7 +2,7 @@ import { Mission } from '@features/Mission/mission.types'
 import { expect } from '@jest/globals'
 
 import { MissionAction } from '../../../missionAction.types'
-import { getMissionActionsToCreateUpdateOrDelete, getMissionDataFromMissionFormValues } from '../utils'
+import { getMissionActionsToCreateUpdateOrDelete, getMissionDataFromMissionFormValues, hasGearMesh } from '../utils'
 
 import MissionActionType = MissionAction.MissionActionType
 import CompletionStatus = MissionAction.CompletionStatus
@@ -491,5 +491,16 @@ describe('features/Mission/components/MissionForm/utils', () => {
 
     // Then
     expect(result).toStrictEqual(missionFormWithoutIsValid)
+  })
+
+  it('hasGearMesh() should return whether the mesh fields apply to a gear', () => {
+    expect(hasGearMesh('OTB', 'Chaluts')).toBe(true)
+    expect(hasGearMesh('DRB', 'Dragues')).toBe(true)
+    expect(hasGearMesh('LLS', 'Lignes et hameçons')).toBe(false)
+    expect(hasGearMesh('FPO', 'Pièges et casiers')).toBe(false)
+    expect(hasGearMesh('NO', "Pas d'engin")).toBe(false)
+    expect(hasGearMesh('HAR', 'Engins divers')).toBe(false)
+    expect(hasGearMesh('FCN', 'Engins divers')).toBe(true)
+    expect(hasGearMesh('MDR', 'Engins divers')).toBe(true)
   })
 })

--- a/frontend/src/features/Mission/components/MissionForm/constants.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/constants.tsx
@@ -141,3 +141,21 @@ export const HIDDEN_ERROR = 'HIDDEN_ERROR'
  * the field is hidden and the value is recorded as N/A (ControlCheck.NOT_APPLICABLE).
  */
 export const GEAR_MARKING_NOT_APPLICABLE_CATEGORIES = ['Lignes et hameçons', 'Engins de récolte', 'Engins divers']
+
+/**
+ * Gear categories without any mesh: the "Maillage déclaré" and "Maillage mesuré" fields are hidden for them.
+ *
+ * "Dragues" are deliberately kept out of this list: their mesh fields are used to record the ring or blade measurement.
+ */
+export const GEAR_CATEGORIES_WITHOUT_MESH = [
+  'Engins de pêche récréative',
+  'Engins de récolte',
+  'Engins divers',
+  'Lignes et hameçons',
+  'Palangres',
+  "Pas d'engin",
+  'Pièges et casiers'
+]
+
+/** Gears having a mesh although their category is listed in `GEAR_CATEGORIES_WITHOUT_MESH`. */
+export const GEAR_CODES_WITH_MESH = ['FCN', 'MDR']

--- a/frontend/src/features/Mission/components/MissionForm/useCases/updateActionGearsOnboard.ts
+++ b/frontend/src/features/Mission/components/MissionForm/useCases/updateActionGearsOnboard.ts
@@ -1,4 +1,5 @@
 import { GEAR_MARKING_NOT_APPLICABLE_CATEGORIES } from '@features/Mission/components/MissionForm/constants'
+import { hasGearMesh } from '@features/Mission/components/MissionForm/utils'
 import { MissionAction } from '@features/Mission/missionAction.types'
 import { riskFactorApi } from '@features/RiskFactor/apis'
 import { FrontendError } from '@libs/FrontendError'
@@ -46,7 +47,7 @@ export const updateActionGearsOnboard =
         averageWireThickness: undefined,
         comments: undefined,
         controlledMesh: undefined,
-        declaredMesh: gear.declaredMesh,
+        declaredMesh: hasGearMesh(gear.code, gear.category) ? gear.declaredMesh : undefined,
         gearCode: gear.code,
         gearMarkingIsCompliant: GEAR_MARKING_NOT_APPLICABLE_CATEGORIES.includes(gear.category)
           ? MissionAction.ControlCheck.NOT_APPLICABLE

--- a/frontend/src/features/Mission/components/MissionForm/utils.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/utils.tsx
@@ -2,7 +2,7 @@ import { FormError, FormErrorCode } from '@libs/FormError'
 import { validateRequiredFormValues } from '@utils/validateRequiredFormValues'
 import { difference, omit } from 'lodash-es'
 
-import { MISSION_ACTION_FORM_VALUES_SKELETON } from './constants'
+import { GEAR_CATEGORIES_WITHOUT_MESH, GEAR_CODES_WITH_MESH, MISSION_ACTION_FORM_VALUES_SKELETON } from './constants'
 import { Mission } from '../../mission.types'
 import { MissionAction } from '../../missionAction.types'
 
@@ -147,4 +147,11 @@ export function getValidMissionDataControlUnit(
   }
 
   return validMissionDataControlUnit
+}
+
+/**
+ * Whether the "Maillage déclaré" and "Maillage mesuré" fields apply to this gear.
+ */
+export function hasGearMesh(gearCode: string, gearCategory: string | undefined): boolean {
+  return !GEAR_CATEGORIES_WITHOUT_MESH.includes(gearCategory ?? '') || GEAR_CODES_WITH_MESH.includes(gearCode)
 }


### PR DESCRIPTION
## Linked issues

- Resolve #4866

----

The "Maillage déclaré" and "Maillage mesuré" fields are now hidden in the control action form for gear categories that have no mesh:

- Engins de pêche récréative
- Engins de récolte
- Engins divers (except `FCN` and `MDR`)
- Lignes et hameçons
- Palangres
- Pas d'engin
- Pièges et casiers

**Dragues** are deliberately left out of the list: their mesh fields are used to record the ring or blade measurement.

Two side effects, both needed so a hidden value can never be silently recorded (and to unblock #4867, which will make the declared mesh required):

- the declared mesh is no longer required by the form validation for these gears;
- the declared mesh is no longer prefilled from the logbook for these gears.

Existing controls keep the mesh values they already have — they are hidden, not erased. The vessel sidebar control history is unchanged.

----

- [x] Tests E2E (Cypress)