### PR TITLE
Tech - Corrige trois erreurs Sentry (façade `Polynésie et Clipperton`, `single()` sur `threatHierarchy`)

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/facade/Seafront.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/facade/Seafront.kt
@@ -20,6 +20,10 @@ enum class Seafront(
     OI_HORS_ZEE("Océan Indien Hors ZEE"),
     LA_REUNION("La Réunion"),
     POLYNESIE_FRANCAISE("Polynésie Française"),
+
+    // Split into POLYNESIE_FRANCAISE and CLIPPERTON, but still stored by the CROSS referential and by rows
+    // predating the split, so reading it must keep working
+    POLYNESIE_ET_CLIPPERTON("Polynésie et Clipperton"),
     NOUVELLE_CALEDONIE("Nouvelle Calédonie"),
     CLIPPERTON("Clipperton"),
     WALLIS_FUTUNA("Wallis et Futuna"),

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/facade/SeafrontGroup.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/facade/SeafrontGroup.kt
@@ -40,6 +40,7 @@ enum class SeafrontGroup {
                 OUTREMEROP to
                     listOf(
                         Seafront.POLYNESIE_FRANCAISE,
+                        Seafront.POLYNESIE_ET_CLIPPERTON,
                         Seafront.NOUVELLE_CALEDONIE,
                         Seafront.CLIPPERTON,
                         Seafront.WALLIS_FUTUNA,

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/input/AddMissionActionDataInput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/input/AddMissionActionDataInput.kt
@@ -24,21 +24,13 @@ data class MissionActionInfractionDataInput(
             return Infraction(infractionType = infractionType, comments = comments)
         }
 
-        val threat = threats.single()
-        val threatName = threat.value
-        val threatCharacterization = threat.children.single().value
-        val natinf =
-            threat.children
-                .single()
-                .children
-                .single()
-                .value
+        val leaf = threats.toSingleLeaf()
 
         return Infraction(
             infractionType = this.infractionType,
-            natinf = natinf,
-            threat = threatName,
-            threatCharacterization = threatCharacterization,
+            natinf = leaf.natinfCode,
+            threat = leaf.threat,
+            threatCharacterization = leaf.threatCharacterization,
             comments = this.comments,
         )
     }

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/input/CreateReportingDataInput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/input/CreateReportingDataInput.kt
@@ -46,15 +46,12 @@ class CreateReportingDataInput(
     fun toReporting(createdBy: String): Reporting {
         val infractions =
             threatHierarchies.map { threatHierarchy ->
+                val leaf = threatHierarchy.toLeaf()
+
                 InfractionSuspicionThreat(
-                    natinfCode =
-                        threatHierarchy.children
-                            .single()
-                            .children
-                            .single()
-                            .value,
-                    threat = threatHierarchy.value,
-                    threatCharacterization = threatHierarchy.children.single().value,
+                    natinfCode = leaf.natinfCode,
+                    threat = leaf.threat,
+                    threatCharacterization = leaf.threatCharacterization,
                 )
             }
 

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/input/PositionAlertSpecificationDataInput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/input/PositionAlertSpecificationDataInput.kt
@@ -30,23 +30,16 @@ data class PositionAlertSpecificationDataInput(
     val producerOrganizations: List<String> = listOf(),
 ) {
     fun toPositionAlertSpecification(): PositionAlertSpecification {
-        val threat = threatHierarchy.value
-        val threatCharacterization = threatHierarchy.children.single().value
-        val natinf =
-            threatHierarchy.children
-                .single()
-                .children
-                .single()
-                .value
+        val leaf = threatHierarchy.toLeaf()
 
         return PositionAlertSpecification(
             name = this.name,
             type = this.type,
             description = this.description,
             isUserDefined = true,
-            natinf = natinf,
-            threat = threat,
-            threatCharacterization = threatCharacterization,
+            natinf = leaf.natinfCode,
+            threat = leaf.threat,
+            threatCharacterization = leaf.threatCharacterization,
             validityStartDatetimeUtc = this.validityStartDatetimeUtc,
             validityEndDatetimeUtc = this.validityEndDatetimeUtc,
             repeatEachYear = this.repeatEachYear,

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/input/ThreatHierarchyDataInput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/input/ThreatHierarchyDataInput.kt
@@ -1,5 +1,10 @@
 package fr.gouv.cnsp.monitorfish.infrastructure.api.input
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+private val logger: Logger = LoggerFactory.getLogger(ThreatHierarchyDataInput::class.java)
+
 data class NatinfDataInput(
     val label: String,
     val value: Int,
@@ -15,4 +20,56 @@ data class ThreatHierarchyDataInput(
     val children: List<ThreatCharacterizationDataInput>,
     val label: String,
     val value: String,
+) {
+    /**
+     * The Frontend threat picker selects a single leaf, so a hierarchy is expected to carry exactly one
+     * characterization and one NATINF.
+     *
+     * A wider hierarchy used to reach `single()` and answer a `400` naming neither the endpoint nor the payload
+     * (MONITORFISH-17J03). We keep the first leaf and log what was actually received instead, so the next
+     * occurrence names its own culprit.
+     */
+    fun toLeaf(): ThreatLeaf {
+        val characterization =
+            children.firstOrNull()
+                ?: throw IllegalArgumentException("Threat \"$value\" has no threat characterization.")
+        val natinf =
+            characterization.children.firstOrNull()
+                ?: throw IllegalArgumentException(
+                    "Threat characterization \"${characterization.value}\" of threat \"$value\" has no NATINF.",
+                )
+
+        if (children.size > 1 || characterization.children.size > 1) {
+            logger.warn(
+                "Threat \"$value\" carries ${children.size} threat characterizations and " +
+                    "${characterization.children.size} NATINFs for its first one: keeping " +
+                    "\"${characterization.value}\" / ${natinf.value}.",
+            )
+        }
+
+        return ThreatLeaf(
+            threat = value,
+            threatCharacterization = characterization.value,
+            natinfCode = natinf.value,
+        )
+    }
+}
+
+data class ThreatLeaf(
+    val threat: String,
+    val threatCharacterization: String,
+    val natinfCode: Int,
 )
+
+/**
+ * Same contract as [ThreatHierarchyDataInput.toLeaf] one level up: a single threat is expected.
+ */
+fun List<ThreatHierarchyDataInput>.toSingleLeaf(): ThreatLeaf {
+    val threat = firstOrNull() ?: throw IllegalArgumentException("No threat given.")
+
+    if (size > 1) {
+        logger.warn("$size threats given where a single one is expected: keeping \"${threat.value}\".")
+    }
+
+    return threat.toLeaf()
+}

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/input/UpdateReportingDataInput.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/input/UpdateReportingDataInput.kt
@@ -43,15 +43,12 @@ class UpdateReportingDataInput(
     fun toUpdatedReportingValues(): ReportingUpdateCommand {
         val infractions =
             threatHierarchies.map { threatHierarchy ->
+                val leaf = threatHierarchy.toLeaf()
+
                 InfractionSuspicionThreat(
-                    natinfCode =
-                        threatHierarchy.children
-                            .single()
-                            .children
-                            .single()
-                            .value,
-                    threat = threatHierarchy.value,
-                    threatCharacterization = threatHierarchy.children.single().value,
+                    natinfCode = leaf.natinfCode,
+                    threat = leaf.threat,
+                    threatCharacterization = leaf.threatCharacterization,
                 )
             }
 

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/facade/SeafrontGroupUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/domain/entities/facade/SeafrontGroupUTests.kt
@@ -17,6 +17,18 @@ class SeafrontGroupUTests {
     }
 
     @Test
+    fun `fromSeafront should return OUTREMEROP with the legacy Polynésie et Clipperton seafront`() {
+        // Given
+        val seafront = Seafront.POLYNESIE_ET_CLIPPERTON
+
+        // When
+        val result = SeafrontGroup.fromSeafront(seafront)
+
+        // Then
+        assertThat(result).isEqualTo(SeafrontGroup.OUTREMEROP)
+    }
+
+    @Test
     fun `fromSeafront should return NO_FACADE with a null seafront`() {
         // When
         val result = SeafrontGroup.fromSeafront(null)
@@ -118,6 +130,7 @@ class SeafrontGroupUTests {
         // Then
         assertThat(result).containsExactlyInAnyOrder(
             Seafront.POLYNESIE_FRANCAISE,
+            Seafront.POLYNESIE_ET_CLIPPERTON,
             Seafront.NOUVELLE_CALEDONIE,
             Seafront.CLIPPERTON,
             Seafront.WALLIS_FUTUNA,

--- a/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/input/ThreatHierarchyDataInputUTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/api/input/ThreatHierarchyDataInputUTests.kt
@@ -1,0 +1,114 @@
+package fr.gouv.cnsp.monitorfish.infrastructure.api.input
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class ThreatHierarchyDataInputUTests {
+    private fun natinf(code: Int) = NatinfDataInput(value = code, label = code.toString())
+
+    private fun characterization(
+        name: String,
+        vararg natinfCodes: Int,
+    ) = ThreatCharacterizationDataInput(
+        value = name,
+        label = name,
+        children = natinfCodes.map { natinf(it) },
+    )
+
+    private fun threat(
+        name: String,
+        vararg characterizations: ThreatCharacterizationDataInput,
+    ) = ThreatHierarchyDataInput(value = name, label = name, children = characterizations.toList())
+
+    @Test
+    fun `toLeaf Should return the single leaf`() {
+        // Given
+        val hierarchy =
+            threat("Activités INN", characterization("Pêche sans autorisation par navire tiers", 2608))
+
+        // When
+        val result = hierarchy.toLeaf()
+
+        // Then
+        assertThat(result.threat).isEqualTo("Activités INN")
+        assertThat(result.threatCharacterization).isEqualTo("Pêche sans autorisation par navire tiers")
+        assertThat(result.natinfCode).isEqualTo(2608)
+    }
+
+    @Test
+    fun `toLeaf Should keep the first threat characterization When several are given`() {
+        // Given
+        val hierarchy =
+            threat(
+                "Mesures techniques et de conservation",
+                characterization("Engin", 2593),
+                characterization("Transbordement", 27714),
+            )
+
+        // When
+        val result = hierarchy.toLeaf()
+
+        // Then
+        assertThat(result.threatCharacterization).isEqualTo("Engin")
+        assertThat(result.natinfCode).isEqualTo(2593)
+    }
+
+    @Test
+    fun `toLeaf Should keep the first NATINF When several are given`() {
+        // Given
+        val hierarchy = threat("Mesures techniques et de conservation", characterization("Engin", 2593, 7057, 7059))
+
+        // When
+        val result = hierarchy.toLeaf()
+
+        // Then
+        assertThat(result.natinfCode).isEqualTo(2593)
+    }
+
+    @Test
+    fun `toLeaf Should throw When the threat has no threat characterization`() {
+        // Given
+        val hierarchy = threat("Activités INN")
+
+        // When / Then
+        assertThatThrownBy { hierarchy.toLeaf() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Activités INN")
+    }
+
+    @Test
+    fun `toLeaf Should throw When the threat characterization has no NATINF`() {
+        // Given
+        val hierarchy = threat("Activités INN", characterization("Pêche sans autorisation par navire tiers"))
+
+        // When / Then
+        assertThatThrownBy { hierarchy.toLeaf() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Pêche sans autorisation par navire tiers")
+    }
+
+    @Test
+    fun `toSingleLeaf Should keep the first threat When several are given`() {
+        // Given
+        val hierarchies =
+            listOf(
+                threat("Activités INN", characterization("Pêche sans autorisation par navire tiers", 2608)),
+                threat("Entrave au contrôle", characterization("Dissimulation", 12922)),
+            )
+
+        // When
+        val result = hierarchies.toSingleLeaf()
+
+        // Then
+        assertThat(result.threat).isEqualTo("Activités INN")
+        assertThat(result.natinfCode).isEqualTo(2608)
+    }
+
+    @Test
+    fun `toSingleLeaf Should throw When no threat is given`() {
+        // When / Then
+        assertThatThrownBy { emptyList<ThreatHierarchyDataInput>().toSingleLeaf() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+}

--- a/frontend/src/constants/seafront.ts
+++ b/frontend/src/constants/seafront.ts
@@ -25,6 +25,9 @@ export enum Seafront {
   MEMN = 'MEMN',
   NAMO = 'NAMO',
   POLYNESIE_FRANCAISE = 'Polynésie Française',
+  // Split into POLYNESIE_FRANCAISE and CLIPPERTON, but still stored by the CROSS referential and by rows
+  // predating the split, so reading it must keep working
+  POLYNESIE_ET_CLIPPERTON = 'Polynésie et Clipperton',
   NOUVELLE_CALEDONIE = 'Nouvelle Calédonie',
   CLIPPERTON = 'Clipperton',
   WALLIS_FUTUNA = 'Wallis et Futuna',
@@ -50,7 +53,13 @@ export const SEAFRONT_GROUP_SEAFRONTS: Record<SeafrontGroup, Seafront[]> = {
     Seafront.MARTINIQUE
   ],
   OUTREMEROI: [Seafront.OI_HORS_ZEE, Seafront.LA_REUNION, Seafront.MAYOTTE, Seafront.SUD_OCEAN_INDIEN, Seafront.TAAF],
-  OUTREMEROP: [Seafront.POLYNESIE_FRANCAISE, Seafront.NOUVELLE_CALEDONIE, Seafront.CLIPPERTON, Seafront.WALLIS_FUTUNA],
+  OUTREMEROP: [
+    Seafront.POLYNESIE_FRANCAISE,
+    Seafront.POLYNESIE_ET_CLIPPERTON,
+    Seafront.NOUVELLE_CALEDONIE,
+    Seafront.CLIPPERTON,
+    Seafront.WALLIS_FUTUNA
+  ],
   SA: [Seafront.SA]
 }
 

--- a/frontend/src/features/Alert/schemas/__tests__/PendingAlertValueSchema.test.ts
+++ b/frontend/src/features/Alert/schemas/__tests__/PendingAlertValueSchema.test.ts
@@ -1,0 +1,31 @@
+import { Seafront } from '@constants/seafront'
+import { PendingAlertValueType } from '@features/Alert/constants'
+import { PendingAlertValueSchema } from '@features/Alert/schemas/PendingAlertValueSchema'
+import { expect } from '@jest/globals'
+
+describe('features/Alert/schemas/PendingAlertValueSchema', () => {
+  const anAlertValue = {
+    name: 'Pêche en zone interdite',
+    natinfCode: 2608,
+    threat: 'Activités INN',
+    threatCharacterization: 'Pêche sans autorisation par navire tiers',
+    type: PendingAlertValueType.POSITION_ALERT
+  }
+
+  /**
+   * `Polynésie et Clipperton` was split into `Polynésie Française` and `Clipperton`, but the pipeline writes
+   * `facade_areas_subdivided.facade` into `value.seaFront` untranslated, so the legacy label still reaches us.
+   */
+  it('should accept the legacy `Polynésie et Clipperton` seafront', () => {
+    const result = PendingAlertValueSchema.safeParse({ ...anAlertValue, seaFront: 'Polynésie et Clipperton' })
+
+    expect(result.success).toBe(true)
+    expect(result.data?.seaFront).toBe(Seafront.POLYNESIE_ET_CLIPPERTON)
+  })
+
+  it('should reject an unknown seafront', () => {
+    const result = PendingAlertValueSchema.safeParse({ ...anAlertValue, seaFront: 'Atlantide' })
+
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Contexte

Quatre tickets Sentry ont été analysés. Trois sont corrigés ici, ils se ramènent à deux causes racines. Le quatrième est laissé de côté volontairement (voir plus bas).

## 1. La façade `Polynésie et Clipperton` a été supprimée du code mais pas des données

MONITORFISH-17HZY et MONITORFISH-17HXA n'ont qu'une seule cause.

Le commit `be5ac3ac1` (« Add pacific ocean seafront ») a remplacé `Seafront.POLYNESIE_CLIPPERTON = 'Polynésie et Clipperton'` par quatre valeurs (`Polynésie Française`, `Nouvelle Calédonie`, `Clipperton`, `Wallis et Futuna`) dans les deux énumérations `Seafront`, et a ajouté ces quatre valeurs au type Postgres `facade` (`V0.374`). Il n'a jamais retiré l'ancienne valeur du type Postgres (ajoutée en `V0.360`), ni migré les lignes qui la portent encore.

L'arithmétique des ensembles désigne la valeur fautive avec certitude : toutes les colonnes `facade` sont typées `facade`, donc seule une valeur de ce type peut être stockée, et **type Postgres `facade` moins énumération Kotlin `Seafront` = exactement `{'Polynésie et Clipperton'}`**.

| Ticket | Symptôme |
|---|---|
| MONITORFISH-17HZY | `NoSuchElementException` dans `Seafront.from` (`Seafront.kt:45`) ← `FacadeAreaEntity.toFacadeArea` ← `IsPointInInnArea.execute` : `GET /mission_actions/is-in-inn-area` répond `400`, donc le contrôle INN du formulaire de CR échoue. |
| MONITORFISH-17HXA | `ZodError` `invalid_value` sur l'énumération `Seafront`, levée dans `parseOrReturn` depuis un `transformResponse` sur un tableau — la liste des signalements. Les signalements de type alerte portent un `value.seaFront` écrit par le pipeline directement depuis `facade_areas_subdivided.facade`, et `GetReportingWithDMLAndSeaFront` sort tôt pour `Reporting.Alert` : la chaîne héritée atteint donc `PendingAlertValueSchema` sans traduction. |

`facade_areas_subdivided` est vidée puis rechargée par `facade_areas_flow` depuis la base externe `monitorfish_local` (`prod.facade_areas.facade_cnsp`) : une migration de données serait annulée au prochain passage du pipeline. **La valeur est donc réintroduite dans les deux énumérations**, sous le groupe `OUTREMEROP` existant, avec un commentaire qui la marque comme héritée pour qu'elle ne soit pas « nettoyée » à nouveau. Pas de migration Flyway : elle fait partie du type Postgres depuis `V0.360`.

Aucun autre fichier n'est concerné, et cela a été vérifié plutôt que supposé : les `SUB_MENU_LABEL` (alertes, missions, préavis) sont indexés par `SeafrontGroup` et non par `Seafront`, aucun groupe n'est ajouté ; le backend n'a aucun `when` exhaustif sur `Seafront` ; le frontend n'a aucun `Record<Seafront, …>` ; les schémas Zod lisent l'énumération via `z.enum(Seafront)` et prennent le nouveau membre automatiquement.

## 2. `single()` sur une hiérarchie de menaces répond une `400` opaque

MONITORFISH-17J03 : `List has more than one element.`, soit `List.single()`, sur un `PUT`. Les seuls `single()` atteignables depuis un `PUT` sont les trois DTO d'entrée de hiérarchie de menaces ; les deux `single()` côté sortie construisent depuis `listOf(unSeulÉlément)` et ne peuvent pas lever cette erreur.

**Aucun scénario de reproduction dans l'IHM actuelle**, et c'est vérifié : dans monitor-ui `24.56.1` (épinglé depuis le 28/07, donc antérieur à l'événement du 25/08), `uncheckableItemValues` rend non cochable tout nœud ayant des enfants — seules les feuilles NATINF sont sélectionnables ; le `onChange` filtre la nouvelle sélection contre la valeur courante quand `isSelect` est passé, donc une deuxième feuille *remplace* la première ; et `generateUniqueIds` suffixe chaque valeur de feuille par un hash de la valeur de son parent, donc un NATINF présent sous plusieurs qualifications se résout quand même en un seul chemin.

Deux angles morts subsistent et ne sont **pas** fermés par cette PR : la collision d'identifiants de feuille si deux qualifications partagent un même `name` sous des menaces différentes (zéro occurrence dans le référentiel de test, production non vérifiée), et le doute sur la version réellement déployée du bundle. La PR durcit donc l'échec au lieu de deviner la cause.

Le contrat vit désormais sur `ThreatHierarchyDataInput` (`toLeaf()` / `List<…>.toSingleLeaf()`) : on garde la première feuille, on journalise les décomptes réellement reçus, et on échoue avec un message nommant la menace quand un niveau est vide. Les cinq `single()` disparaissent de `AddMissionActionDataInput`, `CreateReportingDataInput`, `UpdateReportingDataInput` et `PositionAlertSpecificationDataInput`.

À noter : le handler alors déployé journalisait `e.cause` — `null` pour `single()` — d'où l'absence totale de stack d'origine dans Sentry. Le handler actuel journalise déjà `e`.

## Hors périmètre

**MONITORFISH-DJ** (`` `createOrUpdate()` failed. ``) n'est pas traité ici, par choix. Pour mémoire : le message est dupliqué à l'identique dans `saveMission.ts:67` et `saveMissionAndMissionActionsByDiff.ts:91`, et `logSoftError` envoie un `captureMessage` avec l'erreur réelle enfouie dans `extra` — Sentry fusionne donc cinq échecs distincts (`createMission`, `updateMission`, `getMission`, `createMissionAction`, `deleteMissionAction`) dans un seul ticket inexploitable.

## Vérifications

- Backend : 708 tests unitaires, 0 échec ; `ktlintCheck` vert.
  - Nouveau `ThreatHierarchyDataInputUTests` : feuille unique, plusieurs qualifications, plusieurs NATINF, plusieurs menaces, et les deux cas de niveau vide.
  - `SeafrontGroupUTests` : `fromSeafront(POLYNESIE_ET_CLIPPERTON)` vaut `OUTREMEROP`. L'assertion qui figeait `OUTREMEROP` à quatre façades passe à cinq — conséquence assumée du choix ci-dessus.
- Frontend : `tsc`, `oxlint` et `prettier` propres, Jest vert.
  - Nouveau `PendingAlertValueSchema.test.ts` : la charge utile exacte à l'origine de MONITORFISH-17HXA est acceptée, et une façade inconnue reste rejetée.

----

- [ ] Tests E2E (Cypress)
