### PR TITLE
Le flow `enrich_lobook_flow` fail quand l'input est vide

### DIFF
--- a/pipeline/src/helpers/dates.py
+++ b/pipeline/src/helpers/dates.py
@@ -115,7 +115,13 @@ def get_datetime_intervals(
     )
 
     if unit:
-        intervals = intervals.map(lambda dt: dt.total_seconds())
+        # NB: `.dt.total_seconds()` is used instead of `.map(lambda dt: dt.total_seconds())`
+        # because `.map()` on an empty Series does not invoke the mapping function and
+        # returns the input unchanged, leaving the dtype as `timedelta64[ns]` (or `object`,
+        # if `s` was empty with no explicit dtype) instead of `float64`. This caused errors
+        # downstream when dividing by this Series. `.astype("timedelta64[ns]")` normalizes
+        # the dtype (a no-op when it is already timedelta64) so `.dt` can be used safely.
+        intervals = intervals.astype("timedelta64[ns]").dt.total_seconds()
         if unit == "h":
             intervals = intervals / 3600
         elif unit == "min":

--- a/pipeline/tests/test_helpers/test_dates.py
+++ b/pipeline/tests/test_helpers/test_dates.py
@@ -93,6 +93,18 @@ def test_get_datetime_intervals():
         get_datetime_intervals(s, how="incorrect")
 
 
+def test_get_datetime_intervals_with_empty_series():
+    # An empty input must still yield a float64 Series when `unit` is provided,
+    # not a timedelta64 one, otherwise dividing by the result raises a
+    # `UFuncTypeError` downstream.
+    s = pd.Series([], dtype="datetime64[ns]")
+
+    intervals = get_datetime_intervals(s, unit="h", how="backward")
+
+    assert intervals.dtype == np.float64
+    assert len(intervals) == 0
+
+
 def test_make_periods():
     with pytest.raises(ValueError):
         make_periods(


### PR DESCRIPTION
## Linked issues

- Resolve #5417
