### PR TITLE
CR de contrôle - Débloquer la complétion des contrôles et préserver les autres contrôles

### DIFF
--- a/frontend/cypress/e2e/side_window/mission_form/action_list.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/action_list.spec.ts
@@ -14,7 +14,8 @@ context('Side Window > Mission Form > Action List', () => {
     cy.clickButton('Ajouter un contrôle en mer')
     cy.get('*[data-cy="action-list-item"]').contains('Contrôle en mer')
     cy.get('*[data-cy="action-list-item"]').should('have.css', 'outline', 'rgb(86, 151, 210) solid 2px')
-    cy.getDataCy('action-completion-status').contains('13 champs nécessaires aux statistiques à compléter')
+    // 13 until the INN area query answers: it is not in one, so `isINNControl` stops being required
+    cy.getDataCy('action-completion-status').contains('12 champs nécessaires aux statistiques à compléter')
     cy.getDataCy('action-contains-missing-fields').eq(0).should('exist')
 
     cy.wait(250)

--- a/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
@@ -925,6 +925,23 @@ context('Side Window > Mission Form > Sea Control', () => {
     // otherwise the whole form is auto-saved as a single creation and never updated
     cy.wait(1200)
 
+    // Editing the unit contact does not change the attached unit, so the control keeps its answers
+    cy.fill('Contact de l’unité 1', 'Tel. 06 88 65 66 66')
+    cy.wait(1200)
+
+    cy.waitForLastRequest(
+      '@updateMissionAction',
+      {
+        body: {
+          isAdministrativeControl: true,
+          isComplianceWithWaterRegulationsControl: false,
+          isSafetyEquipmentAndStandardsComplianceControl: false,
+          isSeafarersControl: true
+        }
+      },
+      5
+    )
+
     // Remove the PAM control unit
     cy.fill('Administration 1', undefined)
     cy.fill('Unité 1', 'Cultures marines 56')

--- a/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
@@ -925,22 +925,15 @@ context('Side Window > Mission Form > Sea Control', () => {
     // otherwise the whole form is auto-saved as a single creation and never updated
     cy.wait(1200)
 
-    // Editing the unit contact does not change the attached unit, so the control keeps its answers
+    // Editing the unit contact does not change the attached unit, so the control keeps its answers.
+    // Only the action form auto-saves the action, hence the assertion on the checkboxes themselves.
     cy.fill('Contact de l’unité 1', 'Tel. 06 88 65 66 66')
     cy.wait(1200)
 
-    cy.waitForLastRequest(
-      '@updateMissionAction',
-      {
-        body: {
-          isAdministrativeControl: true,
-          isComplianceWithWaterRegulationsControl: false,
-          isSafetyEquipmentAndStandardsComplianceControl: false,
-          isSeafarersControl: true
-        }
-      },
-      5
-    )
+    cy.get('input[name="isAdministrativeControl"]').should('be.checked')
+    cy.get('input[name="isComplianceWithWaterRegulationsControl"]').should('not.be.checked')
+    cy.get('input[name="isSeafarersControl"]').should('be.checked')
+    cy.get('input[name="isSafetyEquipmentAndStandardsComplianceControl"]').should('not.be.checked')
 
     // Remove the PAM control unit
     cy.fill('Administration 1', undefined)

--- a/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
@@ -925,8 +925,7 @@ context('Side Window > Mission Form > Sea Control', () => {
     // otherwise the whole form is auto-saved as a single creation and never updated
     cy.wait(1200)
 
-    // Editing the unit contact does not change the attached unit, so the control keeps its answers.
-    // Only the action form auto-saves the action, hence the assertion on the checkboxes themselves.
+    // An action only auto-saves on its own form changes, so a unit edit sends no request to assert on
     cy.fill('Contact de l’unité 1', 'Tel. 06 88 65 66 66')
     cy.wait(1200)
 

--- a/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
+++ b/frontend/cypress/e2e/side_window/mission_form/sea_control.spec.ts
@@ -1023,6 +1023,8 @@ context('Side Window > Mission Form > Sea Control', () => {
     cy.clickButton('Ajouter un contrôle en mer')
 
     cy.intercept('POST', '/bff/v1/mission_actions').as('createMissionActionOne')
+    // MALOTRU is flagless: with the INN area left unresolved, the hidden INN field must still be answered
+    cy.intercept('GET', '/bff/v1/mission_actions/is-in-inn-area*', { statusCode: 500 })
 
     // -------------------------------------------------------------------------
     // Form
@@ -1057,7 +1059,7 @@ context('Side Window > Mission Form > Sea Control', () => {
 
       cy.fill('Saisi par', 'Marlin CROSS')
 
-      cy.wait('@updateMissionAction')
+      cy.waitForLastRequest('@updateMissionAction', { body: { isINNControl: false } }, 5)
     })
   })
 

--- a/frontend/node_modules
+++ b/frontend/node_modules
@@ -1,1 +1,0 @@
-/home/lth/workspace/monitorfish/frontend/node_modules

--- a/frontend/node_modules
+++ b/frontend/node_modules
@@ -1,0 +1,1 @@
+/home/lth/workspace/monitorfish/frontend/node_modules

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/FormikINNRadio.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/FormikINNRadio.tsx
@@ -20,7 +20,7 @@ export function FormikINNRadio() {
   const isEligibleVessel = isThirdCountryOrFlaglessVessel(values.flagState)
   const isLandControl = values.actionType === MissionAction.MissionActionType.LAND_CONTROL
 
-  const { data } = useGetIsInInnAreaQuery(
+  const { data, isFetching } = useGetIsInInnAreaQuery(
     !isLandControl && isEligibleVessel && values.latitude && values.longitude
       ? {
           latitude: values.latitude,
@@ -30,16 +30,16 @@ export function FormikINNRadio() {
   )
 
   const isInInnArea = isLandControl ? isPortInInnArea(values.portLocode) : data?.isInInnArea === true
-  // Not the negation of `isInInnArea`: for a sea or air control, the area is unknown until the query resolves
-  const isNotInInnArea = isLandControl ? !isPortInInnArea(values.portLocode) : data?.isInInnArea === false
+  const isApplicable = isEligibleVessel && isInInnArea
 
   useEffect(() => {
-    if (!isEligibleVessel || isNotInInnArea) {
+    // `isINNControl` is required to complete the control, and a hidden field can never be answered
+    if (!isApplicable && !isFetching) {
       setFieldValue('isINNControl', false)
     }
-  }, [isEligibleVessel, isNotInInnArea, setFieldValue])
+  }, [isApplicable, isFetching, setFieldValue])
 
-  if (!isEligibleVessel || !isInInnArea) {
+  if (!isApplicable) {
     return null
   }
 

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/FormikINNRadio.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/FormikINNRadio.tsx
@@ -20,7 +20,7 @@ export function FormikINNRadio() {
   const isEligibleVessel = isThirdCountryOrFlaglessVessel(values.flagState)
   const isLandControl = values.actionType === MissionAction.MissionActionType.LAND_CONTROL
 
-  const { data, isFetching } = useGetIsInInnAreaQuery(
+  const { data, isError } = useGetIsInInnAreaQuery(
     !isLandControl && isEligibleVessel && values.latitude && values.longitude
       ? {
           latitude: values.latitude,
@@ -30,16 +30,18 @@ export function FormikINNRadio() {
   )
 
   const isInInnArea = isLandControl ? isPortInInnArea(values.portLocode) : data?.isInInnArea === true
-  const isApplicable = isEligibleVessel && isInInnArea
+  // Not the negation of `isInInnArea`: for a sea or air control, the area is unknown until the query
+  // resolves, and a failed query never resolves — so an error counts as “not in an INN area”, otherwise
+  // `isINNControl` stays unanswerable and blocks the completion behind a field nobody can see
+  const isNotInInnArea = isLandControl ? !isPortInInnArea(values.portLocode) : data?.isInInnArea === false || isError
 
   useEffect(() => {
-    // `isINNControl` is required to complete the control, and a hidden field can never be answered
-    if (!isApplicable && !isFetching) {
+    if (!isEligibleVessel || isNotInInnArea) {
       setFieldValue('isINNControl', false)
     }
-  }, [isApplicable, isFetching, setFieldValue])
+  }, [isEligibleVessel, isNotInInnArea, setFieldValue])
 
-  if (!isApplicable) {
+  if (!isEligibleVessel || !isInInnArea) {
     return null
   }
 

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/FormikINNRadio.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/FormikINNRadio.tsx
@@ -29,17 +29,15 @@ export function FormikINNRadio() {
       : skipToken
   )
 
-  const isInInnArea = isLandControl ? isPortInInnArea(values.portLocode) : data?.isInInnArea === true
-  // Not the negation of `isInInnArea`: for a sea or air control, the area is unknown until the query
-  // resolves, and a failed query never resolves — so an error counts as “not in an INN area”, otherwise
-  // `isINNControl` stays unanswerable and blocks the completion behind a field nobody can see
-  const isNotInInnArea = isLandControl ? !isPortInInnArea(values.portLocode) : data?.isInInnArea === false || isError
+  // `undefined` until a sea or air control area query resolves, hence the explicit `=== false` below
+  const isInInnArea = isLandControl ? isPortInInnArea(values.portLocode) : data?.isInInnArea
 
   useEffect(() => {
-    if (!isEligibleVessel || isNotInInnArea) {
+    // A failed query never resolves, and an unanswered `isINNControl` blocks the completion for good
+    if (!isEligibleVessel || isInInnArea === false || isError) {
       setFieldValue('isINNControl', false)
     }
-  }, [isEligibleVessel, isNotInInnArea, setFieldValue])
+  }, [isEligibleVessel, isInInnArea, isError, setFieldValue])
 
   if (!isEligibleVessel || !isInInnArea) {
     return null

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/__tests__/FormikINNRadio.test.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/__tests__/FormikINNRadio.test.tsx
@@ -46,7 +46,7 @@ function getIsINNControl(): string {
 describe('<FormikINNRadio />', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockUseGetIsInInnAreaQuery.mockReturnValue({ data: undefined, isFetching: false })
+    mockUseGetIsInInnAreaQuery.mockReturnValue({ data: undefined, isError: false })
   })
 
   it('Should default `isINNControl` to false When the vessel flies an EU flag', () => {
@@ -61,7 +61,9 @@ describe('<FormikINNRadio />', () => {
     expect(getIsINNControl()).toEqual('false')
   })
 
-  it('Should default `isINNControl` to false When the area query gives no answer', () => {
+  it('Should default `isINNControl` to false When the area query fails', () => {
+    mockUseGetIsInInnAreaQuery.mockReturnValue({ data: undefined, isError: true })
+
     renderFormikINNRadio({
       actionType: MissionAction.MissionActionType.SEA_CONTROL,
       flagState: NON_EU_FLAG_STATE,
@@ -73,9 +75,7 @@ describe('<FormikINNRadio />', () => {
     expect(getIsINNControl()).toEqual('false')
   })
 
-  it('Should NOT answer for the operator While the area query is in flight', () => {
-    mockUseGetIsInInnAreaQuery.mockReturnValue({ data: undefined, isFetching: true })
-
+  it('Should NOT answer for the operator While the area query has yet to resolve', () => {
     renderFormikINNRadio({
       actionType: MissionAction.MissionActionType.SEA_CONTROL,
       flagState: NON_EU_FLAG_STATE,
@@ -87,8 +87,18 @@ describe('<FormikINNRadio />', () => {
     expect(getIsINNControl()).toEqual('undefined')
   })
 
+  it('Should NOT answer for the operator While the control location is unknown', () => {
+    renderFormikINNRadio({
+      actionType: MissionAction.MissionActionType.SEA_CONTROL,
+      flagState: NON_EU_FLAG_STATE
+    })
+
+    expect(screen.queryByText('Contrôle INN')).toBeNull()
+    expect(getIsINNControl()).toEqual('undefined')
+  })
+
   it('Should display the radio When a third country vessel is controlled in an INN area', () => {
-    mockUseGetIsInInnAreaQuery.mockReturnValue({ data: { isInInnArea: true }, isFetching: false })
+    mockUseGetIsInInnAreaQuery.mockReturnValue({ data: { isInInnArea: true }, isError: false })
 
     renderFormikINNRadio({
       actionType: MissionAction.MissionActionType.SEA_CONTROL,

--- a/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/__tests__/FormikINNRadio.test.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/ActionForm/shared/__tests__/FormikINNRadio.test.tsx
@@ -1,0 +1,125 @@
+import { MissionAction } from '@features/Mission/missionAction.types'
+import { beforeEach, describe, expect, it } from '@jest/globals'
+import { THEME, ThemeProvider } from '@mtes-mct/monitor-ui'
+import { render, screen } from '@testing-library/react'
+import { Formik, useFormikContext } from 'formik'
+
+import { FormikINNRadio } from '../FormikINNRadio'
+
+import type { MissionActionFormValues } from '../../../types'
+
+/**
+ * Warning: We could not add `jest` import as it makes the test to fail.
+ * @see: https://github.com/swc-project/jest/issues/14#issuecomment-2525330413
+ */
+
+const mockUseGetIsInInnAreaQuery = jest.fn()
+jest.mock('@features/Mission/missionActionApi', () => ({
+  useGetIsInInnAreaQuery: arg => mockUseGetIsInInnAreaQuery(arg)
+}))
+
+const NON_EU_FLAG_STATE = 'GB'
+
+function IsINNControlProbe() {
+  const { values } = useFormikContext<MissionActionFormValues>()
+
+  return <div data-testid="isINNControl">{String(values.isINNControl)}</div>
+}
+
+function renderFormikINNRadio(values: Partial<MissionActionFormValues>) {
+  render(
+    <ThemeProvider theme={THEME}>
+      <Formik initialValues={values} onSubmit={() => {}}>
+        <>
+          <FormikINNRadio />
+          <IsINNControlProbe />
+        </>
+      </Formik>
+    </ThemeProvider>
+  )
+}
+
+function getIsINNControl(): string {
+  return screen.getByTestId('isINNControl').textContent ?? ''
+}
+
+describe('<FormikINNRadio />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseGetIsInInnAreaQuery.mockReturnValue({ data: undefined, isFetching: false })
+  })
+
+  it('Should default `isINNControl` to false When the vessel flies an EU flag', () => {
+    renderFormikINNRadio({
+      actionType: MissionAction.MissionActionType.SEA_CONTROL,
+      flagState: 'FR',
+      latitude: 47.1,
+      longitude: -3.5
+    })
+
+    expect(screen.queryByText('Contrôle INN')).toBeNull()
+    expect(getIsINNControl()).toEqual('false')
+  })
+
+  it('Should default `isINNControl` to false When the area query gives no answer', () => {
+    renderFormikINNRadio({
+      actionType: MissionAction.MissionActionType.SEA_CONTROL,
+      flagState: NON_EU_FLAG_STATE,
+      latitude: 47.1,
+      longitude: -3.5
+    })
+
+    expect(screen.queryByText('Contrôle INN')).toBeNull()
+    expect(getIsINNControl()).toEqual('false')
+  })
+
+  it('Should NOT answer for the operator While the area query is in flight', () => {
+    mockUseGetIsInInnAreaQuery.mockReturnValue({ data: undefined, isFetching: true })
+
+    renderFormikINNRadio({
+      actionType: MissionAction.MissionActionType.SEA_CONTROL,
+      flagState: NON_EU_FLAG_STATE,
+      latitude: 47.1,
+      longitude: -3.5
+    })
+
+    expect(screen.queryByText('Contrôle INN')).toBeNull()
+    expect(getIsINNControl()).toEqual('undefined')
+  })
+
+  it('Should display the radio When a third country vessel is controlled in an INN area', () => {
+    mockUseGetIsInInnAreaQuery.mockReturnValue({ data: { isInInnArea: true }, isFetching: false })
+
+    renderFormikINNRadio({
+      actionType: MissionAction.MissionActionType.SEA_CONTROL,
+      flagState: NON_EU_FLAG_STATE,
+      latitude: -21.1,
+      longitude: 55.5
+    })
+
+    expect(screen.queryAllByText('Contrôle INN').length).toBeGreaterThan(0)
+    expect(getIsINNControl()).toEqual('undefined')
+  })
+
+  it('Should default `isINNControl` to false When a land control happens in a metropolitan French port', () => {
+    renderFormikINNRadio({
+      actionType: MissionAction.MissionActionType.LAND_CONTROL,
+      flagState: NON_EU_FLAG_STATE,
+      portLocode: 'FRZEG'
+    })
+
+    expect(screen.queryByText('Contrôle INN')).toBeNull()
+    expect(getIsINNControl()).toEqual('false')
+  })
+
+  it('Should display the radio When a land control happens in an overseas port', () => {
+    renderFormikINNRadio({
+      actionType: MissionAction.MissionActionType.LAND_CONTROL,
+      flagState: NON_EU_FLAG_STATE,
+      portLocode: 'REPDG'
+    })
+
+    expect(screen.queryAllByText('Contrôle INN').length).toBeGreaterThan(0)
+    expect(getIsINNControl()).toEqual('undefined')
+  })
+})

--- a/frontend/src/features/Mission/components/MissionForm/MainForm/FormikMultiControlUnitPicker/index.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/MainForm/FormikMultiControlUnitPicker/index.tsx
@@ -70,9 +70,14 @@ export function FormikMultiControlUnitPicker({
       index: number,
       nextControlUnit: LegacyControlUnit.LegacyControlUnit | LegacyControlUnit.LegacyControlUnitDraft
     ) => {
+      const previousControlUnit = values[name][index]
       const nextControlUnits = update(index, nextControlUnit, values[name])
 
-      updateMissionActionOtherControlsCheckboxes(values, isPreviousControlUnitPAMOrULAM)
+      // Resetting on any edit of the unit erases the checkboxes at each keystroke in its contact
+      if (previousControlUnit?.id !== nextControlUnit.id) {
+        updateMissionActionOtherControlsCheckboxes(values, isPreviousControlUnitPAMOrULAM)
+      }
+
       setFieldValue(name, nextControlUnits)
       forceUpdate()
     },

--- a/frontend/src/features/Mission/components/MissionForm/MainForm/FormikMultiControlUnitPicker/index.tsx
+++ b/frontend/src/features/Mission/components/MissionForm/MainForm/FormikMultiControlUnitPicker/index.tsx
@@ -70,11 +70,10 @@ export function FormikMultiControlUnitPicker({
       index: number,
       nextControlUnit: LegacyControlUnit.LegacyControlUnit | LegacyControlUnit.LegacyControlUnitDraft
     ) => {
-      const previousControlUnit = values[name][index]
       const nextControlUnits = update(index, nextControlUnit, values[name])
 
-      // Resetting on any edit of the unit erases the checkboxes at each keystroke in its contact
-      if (previousControlUnit?.id !== nextControlUnit.id) {
+      // Resetting on any edit would erase the checkboxes at each keystroke in the unit contact
+      if (values[name][index]?.id !== nextControlUnit.id) {
         updateMissionActionOtherControlsCheckboxes(values, isPreviousControlUnitPAMOrULAM)
       }
 


### PR DESCRIPTION
Deux régressions signalées par le CNSP lors de la saisie des contrôles.

**Le contrôle reste « À compléter » avec « 1 champ nécessaire aux statistiques à compléter »**

`isINNControl` est requis par les schémas de complétion, mais la condition d'affichage du radio INN et celle de sa valeur par défaut n'étaient pas complémentaires : pour un navire tiers ou sans pavillon dont la zone INN ne se résout jamais (requête sautée faute de coordonnées, ou en échec), le champ était masqué *et* laissé indéfini. Il manquait donc exactement un champ, invisible et impossible à renseigner.

La valeur retombe désormais à « Non » dans tous les cas où le champ n'est pas affiché, en attendant seulement la requête réellement en vol.

**Saisir le contact de l'unité efface les autres contrôles**

Chaque frappe dans « Contact de l'unité N » demandait la réinitialisation des cases « Autre(s) contrôle(s) effectué(s) par l'unité sur le navire » du contrôle ouvert. Pour une unité PAM ou ULAM, les quatre réponses étaient silencieusement effacées. La réinitialisation ne part plus qu'au changement d'unité.

Tests : 6 tests unitaires sur `<FormikINNRadio />`, et deux assertions ajoutées à des `it()` Cypress existants pour ne pas allonger la CI. Tous vérifiés en échec sans les correctifs.

Le troisième symptôme signalé — le téléphone de l'unité qui disparaît à la réouverture de la mission — vient de MonitorEnv : MTES-MCT/monitorenv#3085.
