### PR TITLE
Pass the current timestamp to get_active_trips

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaLogbookReportRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/JpaLogbookReportRepository.kt
@@ -218,9 +218,13 @@ class JpaLogbookReportRepository(
             return emptyMap()
         }
 
-        return dbLogbookReportRepository.getActiveTrips(cfrs.joinToString(",")).associate { row ->
-            (row[0] as String) to (row[1] as LocalDateTime).atZone(UTC)
-        }
+        return dbLogbookReportRepository
+            .getActiveTrips(
+                cfrsAsString = cfrs.joinToString(","),
+                nowUtc = LocalDateTime.now(UTC),
+            ).associate { row ->
+                (row[0] as String) to (row[1] as LocalDateTime).atZone(UTC)
+            }
     }
 
     override fun getCurrentTripDepAndPositionAtSeaDateTime(
@@ -228,8 +232,11 @@ class JpaLogbookReportRepository(
         hoursFromNow: Int,
     ): CurrentTripDepAndPositionAtSea? =
         dbLogbookReportRepository
-            .getCurrentTripDepAndPositionAtSeaDateTime(cfr, hoursFromNow)
-            .firstOrNull()
+            .getCurrentTripDepAndPositionAtSeaDateTime(
+                cfr = cfr,
+                hoursFromNow = hoursFromNow,
+                nowUtc = LocalDateTime.now(UTC),
+            ).firstOrNull()
             ?.let { row ->
                 CurrentTripDepAndPositionAtSea(
                     departureDateTime = (row[0] as LocalDateTime).atZone(UTC),

--- a/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/interfaces/DBLogbookReportRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/cnsp/monitorfish/infrastructure/database/repositories/interfaces/DBLogbookReportRepository.kt
@@ -193,11 +193,14 @@ interface DBLogbookReportRepository :
 
     @Query(
         value = """
-            SELECT * FROM get_active_trips(string_to_array(:cfrsAsString, ','))
+            SELECT * FROM get_active_trips(string_to_array(:cfrsAsString, ','), (:nowUtc)::TIMESTAMP)
         """,
         nativeQuery = true,
     )
-    fun getActiveTrips(cfrsAsString: String): List<Array<Any>>
+    fun getActiveTrips(
+        cfrsAsString: String,
+        nowUtc: LocalDateTime,
+    ): List<Array<Any>>
 
     @Query(
         value = """
@@ -210,8 +213,8 @@ interface DBLogbookReportRepository :
                     ROW_NUMBER() OVER (PARTITION BY p.internal_reference_number ORDER BY date_time DESC) AS dep_rank
                 FROM positions p
                 WHERE
-                    p.date_time >= CURRENT_TIMESTAMP AT TIME ZONE 'UTC' - make_interval(hours => :hoursFromNow)
-                    AND p.date_time < CURRENT_TIMESTAMP AT TIME ZONE 'UTC' - INTERVAL '2 hours'
+                    p.date_time >= (:nowUtc)::TIMESTAMP - make_interval(hours => :hoursFromNow)
+                    AND p.date_time < (:nowUtc)::TIMESTAMP - INTERVAL '2 hours'
                     AND p.is_at_port = false
                     AND time_emitting_at_sea = 0
                     AND p.flag_state IN ('FR', 'VE')
@@ -221,7 +224,7 @@ interface DBLogbookReportRepository :
             SELECT
                 gat.last_dep_datetime,
                 drd.date_time as trip_first_position_at_sea_datetime
-            FROM get_active_trips(string_to_array(:cfr, ',')) gat
+            FROM get_active_trips(string_to_array(:cfr, ','), (:nowUtc)::TIMESTAMP) gat
             LEFT JOIN detected_recent_deps drd ON
                 drd.cfr = gat.cfr AND
                 drd.dep_rank = 1
@@ -231,5 +234,6 @@ interface DBLogbookReportRepository :
     fun getCurrentTripDepAndPositionAtSeaDateTime(
         cfr: String,
         hoursFromNow: Int,
+        nowUtc: LocalDateTime,
     ): List<Array<Any>>
 }

--- a/backend/src/main/resources/db/migration/internal/V0.393__Update_get_active_trips_function.sql
+++ b/backend/src/main/resources/db/migration/internal/V0.393__Update_get_active_trips_function.sql
@@ -1,0 +1,65 @@
+-- `now_utc` is passed by the caller instead of being computed with `NOW()`: with `NOW()`, the planner cannot
+-- exclude the `logbook_reports` Timescale chunks at planning time, which makes the query take seconds instead
+-- of milliseconds.
+DROP FUNCTION IF EXISTS get_active_trips(text[]);
+
+CREATE OR REPLACE FUNCTION get_active_trips(cfrs text[], now_utc timestamp)
+RETURNS TABLE (
+    cfr text,
+    last_dep_datetime timestamp
+)
+LANGUAGE sql
+STABLE
+AS $$
+WITH last_snapshot_trips AS (
+    SELECT DISTINCT ON (cfr)
+        cfr,
+        trip_number,
+        start_datetime_utc
+    FROM trips_snapshot
+    WHERE cfr = ANY(cfrs)
+    ORDER BY cfr, start_datetime_utc DESC
+),
+
+recent_trips AS (
+    SELECT
+        cfr,
+        trip_number,
+        COALESCE(
+            MIN(
+                CASE WHEN ABS(EXTRACT(epoch FROM activity_datetime_utc - operation_datetime_utc)) / 3600 / 24 / 365 < 5
+                THEN activity_datetime_utc
+            END),
+            MIN(operation_datetime_utc)
+        ) AS start_datetime_utc
+    FROM logbook_reports
+    WHERE
+        operation_datetime_utc >= now_utc - INTERVAL '24 hours'
+        AND operation_datetime_utc < now_utc + INTERVAL '24 hours'
+        AND trip_number IS NOT NULL
+        AND cfr = ANY(cfrs)
+    GROUP BY cfr, trip_number
+),
+
+last_recent_trips AS (
+    SELECT DISTINCT ON (cfr) *
+    FROM recent_trips
+    ORDER BY cfr, start_datetime_utc DESC
+),
+
+merged_trips AS (
+    SELECT
+        COALESCE(lst.cfr, lrt.cfr) AS cfr,
+        COALESCE(lrt.trip_number, lst.trip_number) AS trip_number,
+        LEAST(lrt.start_datetime_utc, lst.start_datetime_utc) AS start_datetime_utc
+    FROM last_snapshot_trips lst
+    FULL OUTER JOIN last_recent_trips lrt
+    ON
+        lrt.cfr = lst.cfr
+        AND lrt.trip_number = lst.trip_number
+)
+
+SELECT DISTINCT ON (cfr) cfr, start_datetime_utc
+FROM merged_trips
+ORDER BY cfr, start_datetime_utc DESC
+$$;


### PR DESCRIPTION
Fixes #5423

## Problème

`get_active_trips` filtrait `logbook_reports` sur `operation_datetime_utc` — la colonne de chunking Timescale — avec des bornes calculées par `NOW()` :

```sql
WHERE
    operation_datetime_utc >= NOW() AT TIME ZONE 'UTC' - INTERVAL '24 hours'
    AND operation_datetime_utc < NOW() AT TIME ZONE 'UTC' + INTERVAL '24 hours'
```

Le planner ne pouvait donc pas exclure les chunks au moment du planning : la phase de planification prenait à elle seule 0,5 à 2s, ce qui faisait de cette requête la plus consommatrice de CPU sur la BDD. Elle est appelée par les use cases `GetActiveVessels` et `GetControlledVesselById`.

## Correction

- Nouvelle migration `V0.393__Update_get_active_trips_function.sql` : `get_active_trips(cfrs text[])` devient `get_active_trips(cfrs text[], now_utc timestamp)`. Le corps est inchangé à l'exception du filtre, qui utilise l'argument `now_utc`.
- Les deux requêtes natives de `DBLogbookReportRepository` passent le timestamp : `get_active_trips(…, (:nowUtc)::TIMESTAMP)`.
- `JpaLogbookReportRepository` calcule `LocalDateTime.now(UTC)` et le transmet. Volontairement fait dans le corps des méthodes plutôt qu'en ajoutant un paramètre à l'interface de domaine : `findLastDepDatetimeOfCurrentTripsPerCfr` est `@Cacheable` avec `cfrs` comme clé, et un paramètre `now` serait entré dans la clé de cache, supprimant de fait tout hit.

Un point en plus de l'issue : dans `getCurrentTripDepAndPositionAtSeaDateTime`, la CTE sur `positions` avait exactement le même motif `CURRENT_TIMESTAMP AT TIME ZONE 'UTC'`, et `positions` est également une hypertable (`V0.0__Create_positions_table.sql:27`). Elle utilise donc désormais le même `:nowUtc` bindé.

## Tests

`compileKotlin` et `ktlintMainSourceSetCheck` OK, et l'ensemble de `JpaLogbookReportRepositoryITests` passe. Testcontainers exécute Flyway, la nouvelle migration et le binding du paramètre sont donc tous les deux couverts — dont les 4 tests `findLastDepDatetimeOfCurrentTripsPerCfr` et les 3 tests `getCurrentTripDepAndPositionAtSeaDateTime`.
